### PR TITLE
Polish table UI and responsive interactions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -510,10 +510,9 @@ button {
   box-shadow: 0 0.8rem 2.8rem rgba(0, 0, 0, 0.26);
   backdrop-filter: blur(18px);
   transform: translateX(-50%);
-  animation: tarot-toolbar-enter 220ms ease-out backwards;
-  transition: opacity 180ms ease,
-    translate 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
-  will-change: opacity, translate;
+  animation: tarot-toolbar-enter 260ms ease-out backwards;
+  transition: opacity 260ms ease;
+  will-change: opacity;
 }
 
 .tarot-mode-cancel {
@@ -623,7 +622,6 @@ button {
 @media (min-width: 768px) and (hover: hover) and (pointer: fine) {
   .tarot-toolbar[data-dock-state="hidden"] {
     opacity: 0;
-    translate: 0 calc(100% + 2rem);
     pointer-events: none;
   }
 }
@@ -765,12 +763,10 @@ select:focus-visible {
 @keyframes tarot-toolbar-enter {
   from {
     opacity: 0;
-    transform: translate3d(-50%, 0.35rem, 0);
   }
 
   to {
     opacity: 1;
-    transform: translate3d(-50%, 0, 0);
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1029,6 +1029,51 @@ select:focus-visible {
     max-height: calc(100dvh - 6.5rem);
   }
 
+  .tarot-inspector .tarot-eyebrow {
+    margin-bottom: 0.35rem;
+  }
+
+  .tarot-inspector-heading {
+    min-height: 0;
+    padding-right: 2.75rem;
+  }
+
+  .tarot-inspector-collapse {
+    position: absolute;
+    top: 0.58rem;
+    right: 0.58rem;
+    margin: 0;
+  }
+
+  .tarot-inspector h2 {
+    font-size: 1.15rem;
+  }
+
+  .tarot-inspector > p:not(.tarot-eyebrow) {
+    margin-top: 0.2rem;
+    font-size: 0.84rem;
+  }
+
+  .tarot-card-browser {
+    margin-top: 0.42rem;
+  }
+
+  .tarot-inspector-actions {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.3rem;
+    margin-top: 0.5rem;
+  }
+
+  .tarot-inspector-actions button {
+    min-height: 2.6rem;
+    padding: 0.25rem 0.38rem;
+    font-size: 0.58rem;
+  }
+
+  .tarot-shortcut {
+    display: none;
+  }
+
   .tarot-inspector-toggle {
     right: auto;
     bottom: 5.6rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -510,7 +510,10 @@ button {
   box-shadow: 0 0.8rem 2.8rem rgba(0, 0, 0, 0.26);
   backdrop-filter: blur(18px);
   transform: translateX(-50%);
-  animation: tarot-toolbar-enter 220ms ease-out both;
+  animation: tarot-toolbar-enter 220ms ease-out backwards;
+  transition: opacity 180ms ease,
+    translate 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  will-change: opacity, translate;
 }
 
 .tarot-mode-cancel {
@@ -611,6 +614,18 @@ button {
 
 .tarot-toolbar-trigger[aria-expanded="true"] .tarot-menu-chevron {
   transform: rotate(180deg);
+}
+
+.tarot-sound-toggle[aria-pressed="false"] {
+  color: var(--faint-ink);
+}
+
+@media (min-width: 768px) and (hover: hover) and (pointer: fine) {
+  .tarot-toolbar[data-dock-state="hidden"] {
+    opacity: 0;
+    translate: 0 calc(100% + 2rem);
+    pointer-events: none;
+  }
 }
 
 .tarot-arrange-popover,
@@ -816,7 +831,7 @@ select:focus-visible {
   }
 
   .tarot-inspector {
-    right: -3.05rem;
+    right: -2.95rem;
     bottom: calc(100% + 0.42rem);
     left: auto;
     width: min(20rem, calc(100vw - 1.25rem));
@@ -876,7 +891,7 @@ select:focus-visible {
   }
 
   .tarot-spread-actions {
-    right: -9.25rem;
+    right: -10.4rem;
     bottom: calc(100% + 0.42rem);
     left: auto;
     width: min(20rem, calc(100vw - 1.25rem));
@@ -973,10 +988,19 @@ select:focus-visible {
   }
 }
 
+@media (max-width: 399px) {
+  .tarot-toolbar-trigger,
+  .tarot-mode-cancel {
+    width: 2.5rem;
+    min-height: 2.5rem;
+  }
+}
+
 @media (max-width: 349px) {
   .tarot-toolbar {
-    gap: 0.18rem;
-    padding: 0.28rem;
+    gap: 0.16rem;
+    max-width: calc(100vw - 0.5rem);
+    padding: 0.2rem;
   }
 
   .tarot-zoom-controls {
@@ -984,18 +1008,12 @@ select:focus-visible {
     gap: 0.1rem;
   }
 
-  .tarot-toolbar-trigger,
-  .tarot-mode-cancel {
-    width: 2.5rem;
-    min-height: 2.5rem;
-  }
-
   .tarot-spread-actions {
-    right: -9rem;
+    right: -10.2rem;
   }
 
   .tarot-inspector {
-    right: -2.8rem;
+    right: -2.08rem;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,8 +7,8 @@
     "Book Antiqua", Georgia, serif;
   --font-mono: "SFMono-Regular", "Cascadia Mono", "Liberation Mono", monospace;
   --ink: #f6efdf;
-  --muted-ink: rgba(246, 239, 223, 0.72);
-  --faint-ink: rgba(246, 239, 223, 0.48);
+  --muted-ink: rgba(246, 239, 223, 0.78);
+  --faint-ink: rgba(246, 239, 223, 0.62);
   --primary: #281832;
   --primary-deep: #100918;
   --primary-raised: #3d254a;
@@ -18,6 +18,10 @@
   --panel-edge: rgba(224, 197, 145, 0.28);
   --control: rgba(45, 26, 56, 0.68);
   --control-hover: rgba(75, 45, 88, 0.9);
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
 }
 
 * {
@@ -29,8 +33,15 @@ body {
   min-height: 100%;
 }
 
+html {
+  color-scheme: dark;
+  background: var(--primary-deep);
+}
+
 body {
   margin: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
   color: var(--ink);
   background: var(--primary-deep);
   font-family: var(--font-display);
@@ -50,7 +61,7 @@ button {
   position: relative;
   width: 100%;
   height: 100dvh;
-  min-height: 620px;
+  min-height: 0;
   overflow: hidden;
   background:
     radial-gradient(circle at 15% 78%, rgba(190, 143, 78, 0.12), transparent 28rem),
@@ -187,23 +198,24 @@ button {
 
 .tarot-set-picker {
   top: clamp(1rem, 2.5vw, 1.75rem);
-  right: clamp(1rem, 2.5vw, 1.75rem);
+  right: max(clamp(1rem, 2.5vw, 1.75rem), var(--safe-right));
   display: grid;
-  gap: 0.2rem;
-  min-width: 10.4rem;
-  padding: 0.54rem 0.68rem;
+  gap: 0.38rem;
+  width: min(18.5rem, calc(100vw - 2rem));
+  padding: 0.62rem 0.68rem 0.68rem;
   border: 1px solid var(--panel-edge);
-  border-radius: 0.62rem;
-  background: rgba(20, 11, 29, 0.62);
-  box-shadow: 0 0.7rem 2rem rgba(0, 0, 0, 0.14);
-  backdrop-filter: blur(14px);
+  border-radius: 0.82rem;
+  background: rgba(20, 11, 29, 0.76);
+  box-shadow: 0 0.8rem 2.4rem rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(18px);
+  animation: tarot-panel-enter 180ms ease-out both;
 }
 
 .tarot-set-picker label,
 .tarot-set-picker span {
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.5rem;
+  font-size: 0.625rem;
   letter-spacing: 0.12em;
   line-height: 1.2;
   text-transform: uppercase;
@@ -211,33 +223,43 @@ button {
 
 .tarot-set-picker select {
   width: 100%;
-  padding: 0.04rem 0.08rem 0.12rem 0;
-  border: 0;
-  border-bottom: 1px solid rgba(247, 239, 217, 0.28);
-  border-radius: 0;
-  outline: none;
+  min-height: 2.75rem;
+  padding: 0.55rem 2.2rem 0.55rem 0.65rem;
+  border: 1px solid rgba(247, 239, 217, 0.2);
+  border-radius: 0.55rem;
   color: var(--ink);
   appearance: none;
-  background: transparent;
-  font-size: 0.9rem;
-  line-height: 1.15;
+  background-color: rgba(48, 28, 59, 0.72);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23ead49b' stroke-width='1.7' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+  background-position: right 0.62rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  font-size: 0.96rem;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
 }
 
 .tarot-set-picker option {
-  color: var(--primary-deep);
+  color: var(--ink);
+  background: #201229;
 }
 
 .tarot-inspector {
-  right: clamp(1rem, 2.5vw, 1.75rem);
-  bottom: 6.8rem;
-  width: min(20rem, calc(100vw - 2rem));
-  padding: 0.76rem 0.82rem 0.8rem;
+  right: max(clamp(1rem, 2.5vw, 1.75rem), var(--safe-right));
+  bottom: 6.35rem;
+  width: min(18.5rem, calc(100vw - 2rem));
+  max-height: calc(100dvh - 8.5rem);
+  padding: 0.84rem 0.88rem 0.9rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid var(--panel-edge);
-  border-radius: 0.72rem;
-  background: rgba(20, 11, 29, 0.7);
-  box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(14px);
+  border-radius: 0.88rem;
+  background: rgba(20, 11, 29, 0.82);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.26);
+  backdrop-filter: blur(18px);
+  animation: tarot-panel-enter 180ms ease-out both;
 }
 
 .tarot-inspector-heading {
@@ -265,8 +287,8 @@ button {
 
 .tarot-inspector-collapse {
   flex: 0 0 auto;
-  width: 1.85rem;
-  height: 1.85rem;
+  width: 2.5rem;
+  height: 2.5rem;
   margin: -0.15rem -0.2rem 0 0;
   border-radius: 999px;
 }
@@ -293,10 +315,10 @@ button {
 .tarot-inspector-toggle {
   position: absolute;
   z-index: 3;
-  right: clamp(1rem, 2.5vw, 1.75rem);
-  bottom: 6.8rem;
-  width: 2.45rem;
-  min-height: 2.45rem;
+  right: max(clamp(1rem, 2.5vw, 1.75rem), var(--safe-right));
+  bottom: 6.35rem;
+  width: 2.75rem;
+  min-height: 2.75rem;
   padding: 0;
   border-color: var(--panel-edge);
   border-radius: 999px;
@@ -306,6 +328,7 @@ button {
   font-size: 0.56rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  animation: tarot-panel-enter 160ms ease-out both;
 }
 
 .tarot-inspector-toggle svg {
@@ -316,10 +339,10 @@ button {
 .tarot-inspector h2 {
   margin: 0;
   color: #fff9e8;
-  font-size: 1.3rem;
+  font-size: 1.35rem;
   font-weight: 500;
   letter-spacing: -0.035em;
-  line-height: 0.95;
+  line-height: 1.05;
 }
 
 .tarot-inspector > p:not(.tarot-eyebrow) {
@@ -327,7 +350,7 @@ button {
   margin: 0.38rem 0 0;
   color: var(--muted-ink);
   font-size: 0.96rem;
-  line-height: 1.1;
+  line-height: 1.3;
 }
 
 .tarot-card-browser {
@@ -339,21 +362,24 @@ button {
 .tarot-card-browser label {
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.5rem;
+  font-size: 0.625rem;
   letter-spacing: 0.11em;
   text-transform: uppercase;
 }
 
 .tarot-card-browser select {
   width: 100%;
-  padding: 0.32rem 0.15rem;
-  border: 0;
-  border-bottom: 1px solid rgba(247, 239, 217, 0.25);
-  border-radius: 0;
-  outline: none;
+  min-height: 2.75rem;
+  padding: 0.52rem 2rem 0.52rem 0.62rem;
+  border: 1px solid rgba(247, 239, 217, 0.18);
+  border-radius: 0.5rem;
   color: var(--ink);
   appearance: none;
-  background: transparent;
+  background-color: rgba(48, 28, 59, 0.62);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23ead49b' stroke-width='1.7' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+  background-position: right 0.58rem center;
+  background-repeat: no-repeat;
+  background-size: 0.95rem;
   font-size: 0.88rem;
   cursor: pointer;
 }
@@ -364,12 +390,13 @@ button {
 }
 
 .tarot-card-browser option {
-  color: var(--primary-deep);
+  color: var(--ink);
+  background: #201229;
 }
 
 .tarot-inspector-actions {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.45rem;
   margin-top: 0.68rem;
 }
@@ -378,14 +405,14 @@ button {
 .tarot-zoom-controls button,
 .tarot-arrange-trigger,
 .tarot-shuffle-trigger {
-  min-height: 2.25rem;
+  min-height: 2.75rem;
   padding: 0.42rem 0.7rem;
   border: 1px solid rgba(247, 239, 217, 0.22);
   border-radius: 999px;
   background: var(--control);
   color: var(--ink);
   font-family: var(--font-mono);
-  font-size: 0.62rem;
+  font-size: 0.65rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   cursor: pointer;
@@ -415,7 +442,7 @@ button {
 .tarot-shortcut {
   margin-left: 0.26rem;
   color: var(--accent-bright);
-  font-size: 0.56rem;
+  font-size: 0.62rem;
 }
 
 .tarot-spread-actions {
@@ -483,27 +510,29 @@ button {
   left: 50%;
   display: flex;
   align-items: center;
-  gap: 0.7rem;
-  width: min(31rem, calc(100vw - 2.5rem));
-  padding: 0.55rem;
+  gap: 0.45rem;
+  width: max-content;
+  max-width: calc(100vw - 2rem);
+  padding: 0.45rem;
   border: 1px solid var(--panel-edge);
-  border-radius: 999px;
-  background: rgba(16, 9, 24, 0.78);
+  border-radius: 0.88rem;
+  background: rgba(16, 9, 24, 0.84);
   box-shadow: 0 0.8rem 2.8rem rgba(0, 0, 0, 0.26);
   backdrop-filter: blur(18px);
   transform: translateX(-50%);
+  animation: tarot-toolbar-enter 220ms ease-out both;
 }
 
 .tarot-zoom-controls {
   display: grid;
-  grid-template-columns: 2.25rem minmax(3.55rem, auto) 2.25rem;
+  grid-template-columns: 2.75rem minmax(4rem, auto) 2.75rem;
   gap: 0.22rem;
   flex: 0 0 auto;
 }
 
 .tarot-zoom-controls button {
   min-width: 0;
-  min-height: 2.25rem;
+  min-height: 2.75rem;
   padding: 0.38rem 0.35rem;
   border: 1px solid rgba(247, 239, 217, 0.2);
   border-radius: 999px;
@@ -570,12 +599,16 @@ button {
   bottom: calc(100% + 0.58rem);
   z-index: 4;
   width: 13.5rem;
-  padding: 0.42rem;
+  max-height: min(24rem, calc(100dvh - 7rem));
+  padding: 0.52rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid var(--panel-edge);
-  border-radius: 0.68rem;
+  border-radius: 0.82rem;
   background: rgba(20, 11, 29, 0.93);
   box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
   backdrop-filter: blur(18px);
+  animation: tarot-popover-enter 150ms ease-out both;
 }
 
 .tarot-arrange-popover {
@@ -589,7 +622,7 @@ button {
   margin: 0.14rem 0.38rem 0.38rem;
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.48rem;
+  font-size: 0.625rem;
   letter-spacing: 0.13em;
   text-transform: uppercase;
 }
@@ -603,7 +636,7 @@ button {
 .tarot-arrange-popover button {
   display: grid;
   gap: 0.1rem;
-  min-height: 3rem;
+  min-height: 3.25rem;
   padding: 0.48rem 0.56rem;
   border: 1px solid rgba(247, 239, 217, 0.12);
   border-radius: 0.42rem;
@@ -633,7 +666,7 @@ button {
 .tarot-arrange-popover button small {
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.45rem;
+  font-size: 0.625rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -642,7 +675,8 @@ button {
   display: grid;
   width: 100%;
   gap: 0.12rem;
-  padding: 0.58rem 0.65rem;
+  min-height: 3.25rem;
+  padding: 0.68rem 0.72rem;
   border: 1px solid transparent;
   border-radius: 0.18rem;
   background: transparent;
@@ -665,7 +699,7 @@ button {
 .tarot-shuffle-popover button small {
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.46rem;
+  font-size: 0.625rem;
   letter-spacing: 0.03em;
 }
 
@@ -686,40 +720,95 @@ select:focus-visible {
   outline-offset: 3px;
 }
 
-@media (max-width: 719px) {
-  .tarot-app {
-    min-height: 560px;
+@keyframes tarot-panel-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 0.35rem, 0);
   }
 
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes tarot-toolbar-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(-50%, 0.35rem, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0);
+  }
+}
+
+@keyframes tarot-popover-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 0.25rem, 0);
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.tarot-arrange-popover {
+  animation-name: tarot-arrange-popover-enter;
+}
+
+@keyframes tarot-arrange-popover-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(-50%, 0.25rem, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0);
+  }
+}
+
+@media (max-width: 719px) {
   .tarot-set-picker {
-    top: max(1.05rem, env(safe-area-inset-top));
-    right: 1rem;
-    min-width: 8.25rem;
-    padding: 0.48rem 0.58rem;
+    top: max(0.75rem, var(--safe-top));
+    right: max(0.75rem, var(--safe-right));
+    width: min(14.5rem, calc(100vw - 1.5rem));
+    padding: 0.52rem 0.58rem 0.58rem;
   }
 
   .tarot-set-picker label,
   .tarot-set-picker span {
-    font-size: 0.48rem;
+    font-size: 0.6rem;
   }
 
   .tarot-set-picker select {
-    font-size: 0.84rem;
+    min-height: 2.75rem;
+    font-size: 0.86rem;
   }
 
   .tarot-inspector {
-    left: 1rem;
-    right: 1rem;
-    bottom: 5.7rem;
+    left: max(0.75rem, var(--safe-left));
+    right: max(0.75rem, var(--safe-right));
+    bottom: calc(max(0.65rem, var(--safe-bottom)) + 4.25rem);
     width: auto;
+    max-height: calc(100dvh - 6rem);
     min-height: 0;
-    padding: 0.58rem 0.7rem;
+    padding: 0.68rem 0.72rem 0.74rem;
   }
 
   .tarot-inspector-toggle {
-    right: 1rem;
-    bottom: 5.7rem;
-    min-height: 2.4rem;
+    right: max(0.75rem, var(--safe-right));
+    bottom: calc(max(0.65rem, var(--safe-bottom)) + 4.25rem);
+    width: 2.75rem;
+    min-height: 2.75rem;
+  }
+
+  .tarot-inspector-collapse {
+    width: 2.75rem;
+    height: 2.75rem;
   }
 
   .tarot-inspector .tarot-eyebrow {
@@ -750,13 +839,15 @@ select:focus-visible {
   }
 
   .tarot-inspector-actions {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.36rem;
     margin-top: 0.55rem;
   }
 
   .tarot-inspector-actions button {
     min-height: 2.75rem;
     padding: 0.28rem 0.55rem;
-    font-size: 0.54rem;
+    font-size: 0.64rem;
   }
 
   .tarot-shortcut {
@@ -792,16 +883,17 @@ select:focus-visible {
   }
 
   .tarot-toolbar {
-    bottom: max(0.65rem, env(safe-area-inset-bottom));
+    bottom: max(0.65rem, var(--safe-bottom));
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-columns: auto 2.75rem 2.75rem;
     gap: 0.42rem;
-    width: calc(100vw - 1.25rem);
+    width: max-content;
+    max-width: calc(100vw - 1.25rem);
     padding: 0.42rem;
   }
 
   .tarot-zoom-controls {
-    grid-template-columns: 2rem 3rem 2rem;
+    grid-template-columns: 2.75rem 3.6rem 2.75rem;
     gap: 0.16rem;
   }
 
@@ -813,9 +905,10 @@ select:focus-visible {
 
   .tarot-arrange-trigger,
   .tarot-shuffle-trigger {
+    width: 2.75rem;
     min-height: 2.75rem;
-    padding: 0.24rem 0.18rem;
-    font-size: 0.5rem;
+    padding: 0.24rem;
+    font-size: 0.625rem;
     letter-spacing: 0.02em;
   }
 
@@ -833,7 +926,7 @@ select:focus-visible {
 
   .tarot-arrange-trigger,
   .tarot-shuffle-trigger {
-    width: 100%;
+    width: 2.75rem;
     min-height: 2.75rem;
   }
 
@@ -855,6 +948,7 @@ select:focus-visible {
     bottom: calc(100% + 0.42rem);
     width: min(17rem, calc(100vw - 1.25rem));
     transform: none;
+    animation-name: tarot-popover-enter;
   }
 
   .tarot-shuffle-popover {
@@ -869,7 +963,25 @@ select:focus-visible {
 
 @media (max-height: 660px) and (min-width: 720px) {
   .tarot-inspector {
-    bottom: 6.1rem;
+    bottom: 5.6rem;
+    left: max(0.75rem, var(--safe-left));
+    right: auto;
+    width: min(18rem, calc(100vw - 1.5rem));
+    max-height: calc(100dvh - 6.5rem);
+  }
+
+  .tarot-inspector-toggle {
+    right: auto;
+    bottom: 5.6rem;
+    left: max(0.75rem, var(--safe-left));
+  }
+
+  .tarot-set-picker {
+    top: max(0.75rem, var(--safe-top));
+  }
+
+  .tarot-toolbar {
+    bottom: max(0.6rem, var(--safe-bottom));
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -249,8 +249,9 @@ button {
 
 .tarot-inspector {
   position: absolute;
+  right: 0;
   bottom: calc(100% + 0.58rem);
-  left: 50%;
+  left: auto;
   z-index: 4;
   width: min(18.5rem, calc(100vw - 2rem));
   max-height: min(34rem, calc(100dvh - 7rem));
@@ -262,8 +263,8 @@ button {
   background: rgba(20, 11, 29, 0.98);
   box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.26);
   backdrop-filter: blur(18px);
-  transform: translateX(-50%);
-  animation: tarot-panel-enter 180ms ease-out both;
+  transform: none;
+  animation: tarot-popover-enter 180ms ease-out both;
 }
 
 .tarot-inspector-heading {
@@ -563,6 +564,7 @@ button {
 }
 
 .tarot-deck-menu,
+.tarot-zoom-menu,
 .tarot-card-menu,
 .tarot-spread-menu,
 .tarot-arrange-menu,
@@ -579,6 +581,10 @@ button {
   padding-inline: 0.62rem;
   border-color: rgba(247, 239, 217, 0.18);
   color: var(--muted-ink);
+}
+
+.tarot-zoom-trigger {
+  display: none;
 }
 
 .tarot-toolbar-trigger svg {
@@ -792,7 +798,7 @@ select:focus-visible {
   }
 }
 
-@media (max-width: 719px) {
+@media (max-width: 767px) {
   .tarot-set-picker {
     bottom: calc(100% + 0.42rem);
     width: min(18rem, calc(100vw - 1.25rem));
@@ -810,7 +816,7 @@ select:focus-visible {
   }
 
   .tarot-inspector {
-    right: -6.35rem;
+    right: -3.05rem;
     bottom: calc(100% + 0.42rem);
     left: auto;
     width: min(20rem, calc(100vw - 1.25rem));
@@ -870,7 +876,7 @@ select:focus-visible {
   }
 
   .tarot-spread-actions {
-    right: -6.35rem;
+    right: -9.25rem;
     bottom: calc(100% + 0.42rem);
     left: auto;
     width: min(20rem, calc(100vw - 1.25rem));
@@ -895,9 +901,30 @@ select:focus-visible {
     padding: 0.35rem;
   }
 
+  .tarot-zoom-trigger {
+    display: inline-flex;
+  }
+
   .tarot-zoom-controls {
+    position: absolute;
+    bottom: calc(100% + 0.42rem);
+    left: 0;
+    z-index: 4;
+    display: none;
     grid-template-columns: repeat(3, 2.75rem);
     gap: 0.16rem;
+    width: max-content;
+    padding: 0.42rem;
+    border: 1px solid var(--panel-edge);
+    border-radius: 999px;
+    background: rgba(20, 11, 29, 0.98);
+    box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
+    backdrop-filter: blur(18px);
+    animation: tarot-popover-enter 150ms ease-out both;
+  }
+
+  .tarot-zoom-controls--open {
+    display: grid;
   }
 
   .tarot-zoom-controls button {
@@ -928,7 +955,7 @@ select:focus-visible {
   }
 
   .tarot-arrange-popover {
-    right: 0;
+    right: -6.3rem;
     left: auto;
     bottom: calc(100% + 0.42rem);
     width: min(17rem, calc(100vw - 1.25rem));
@@ -963,9 +990,12 @@ select:focus-visible {
     min-height: 2.5rem;
   }
 
-  .tarot-inspector,
   .tarot-spread-actions {
-    right: -5.9rem;
+    right: -9rem;
+  }
+
+  .tarot-inspector {
+    right: -2.8rem;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -178,11 +178,7 @@ button {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 160 160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.54'/%3E%3C/svg%3E");
 }
 
-.tarot-set-picker,
-.tarot-inspector,
-.tarot-spread-actions,
 .tarot-toolbar,
-.tarot-mode-hint,
 .tarot-live-status {
   position: absolute;
   z-index: 3;
@@ -200,17 +196,20 @@ button {
 }
 
 .tarot-set-picker {
-  top: clamp(1rem, 2.5vw, 1.75rem);
-  right: max(clamp(1rem, 2.5vw, 1.75rem), var(--safe-right));
+  position: absolute;
+  bottom: calc(100% + 0.58rem);
+  left: 0;
+  z-index: 4;
   display: grid;
   gap: 0.38rem;
   width: min(18.5rem, calc(100vw - 2rem));
   padding: 0.62rem 0.68rem 0.68rem;
   border: 1px solid var(--panel-edge);
   border-radius: 0.82rem;
-  background: rgba(20, 11, 29, 0.76);
-  box-shadow: 0 0.8rem 2.4rem rgba(0, 0, 0, 0.2);
+  background: rgba(20, 11, 29, 0.98);
+  box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
   backdrop-filter: blur(18px);
+  animation: tarot-popover-enter 150ms ease-out both;
 }
 
 .tarot-set-picker label,
@@ -249,18 +248,21 @@ button {
 }
 
 .tarot-inspector {
-  right: max(clamp(1rem, 2.5vw, 1.75rem), var(--safe-right));
-  bottom: 6.35rem;
+  position: absolute;
+  bottom: calc(100% + 0.58rem);
+  left: 50%;
+  z-index: 4;
   width: min(18.5rem, calc(100vw - 2rem));
-  max-height: calc(100dvh - 8.5rem);
+  max-height: min(34rem, calc(100dvh - 7rem));
   padding: 0.84rem 0.88rem 0.9rem;
   overflow-y: auto;
   overscroll-behavior: contain;
   border: 1px solid var(--panel-edge);
   border-radius: 0.88rem;
-  background: rgba(20, 11, 29, 0.82);
+  background: rgba(20, 11, 29, 0.98);
   box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.26);
   backdrop-filter: blur(18px);
+  transform: translateX(-50%);
   animation: tarot-panel-enter 180ms ease-out both;
 }
 
@@ -275,8 +277,7 @@ button {
   margin-bottom: 0.55rem;
 }
 
-.tarot-inspector-collapse,
-.tarot-inspector-toggle {
+.tarot-inspector-collapse {
   display: inline-grid;
   place-items: center;
   border: 1px solid rgba(247, 239, 217, 0.2);
@@ -295,16 +296,14 @@ button {
   border-radius: 999px;
 }
 
-.tarot-inspector-collapse:hover,
-.tarot-inspector-toggle:hover {
+.tarot-inspector-collapse:hover {
   border-color: var(--accent-bright);
   background: var(--control-hover);
   color: #fff9e8;
   transform: translateY(-1px);
 }
 
-.tarot-inspector-collapse svg,
-.tarot-inspector-toggle svg {
+.tarot-inspector-collapse svg {
   width: 1rem;
   height: 1rem;
   fill: none;
@@ -312,30 +311,6 @@ button {
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 1.65;
-}
-
-.tarot-inspector-toggle {
-  position: absolute;
-  z-index: 3;
-  right: max(clamp(1rem, 2.5vw, 1.75rem), var(--safe-right));
-  bottom: 6.35rem;
-  width: 2.75rem;
-  min-height: 2.75rem;
-  padding: 0;
-  border-color: var(--panel-edge);
-  border-radius: 999px;
-  box-shadow: 0 0.7rem 2rem rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(14px);
-  font-family: var(--font-mono);
-  font-size: 0.56rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  animation: tarot-panel-enter 160ms ease-out both;
-}
-
-.tarot-inspector-toggle svg {
-  width: 1.08rem;
-  height: 1.08rem;
 }
 
 .tarot-inspector h2 {
@@ -405,8 +380,8 @@ button {
 
 .tarot-inspector-actions button,
 .tarot-zoom-controls button,
-.tarot-arrange-trigger,
-.tarot-shuffle-trigger {
+.tarot-toolbar-trigger,
+.tarot-mode-cancel {
   min-height: 2.75rem;
   padding: 0.42rem 0.7rem;
   border: 1px solid rgba(247, 239, 217, 0.22);
@@ -424,8 +399,8 @@ button {
 
 .tarot-inspector-actions button:hover:not(:disabled),
 .tarot-zoom-controls button:hover:not(:disabled),
-.tarot-arrange-trigger:hover:not(:disabled),
-.tarot-shuffle-trigger:hover:not(:disabled) {
+.tarot-toolbar-trigger:hover:not(:disabled),
+.tarot-mode-cancel:hover:not(:disabled) {
   border-color: var(--accent-bright);
   background: var(--control-hover);
   color: #fff9e8;
@@ -435,7 +410,7 @@ button {
 
 .tarot-inspector-actions button:disabled,
 .tarot-zoom-controls button:disabled,
-.tarot-arrange-trigger:disabled,
+.tarot-toolbar-trigger:disabled,
 .tarot-arrange-popover button:disabled {
   cursor: not-allowed;
   opacity: 0.42;
@@ -448,23 +423,28 @@ button {
 }
 
 .tarot-spread-actions {
-  bottom: clamp(6.25rem, 9vw, 7.1rem);
-  left: calc(50% + 4rem);
-  display: flex;
-  align-items: center;
-  gap: 0.34rem;
-  max-width: calc(100vw - 2rem);
-  padding: 0.36rem;
+  position: absolute;
+  bottom: calc(100% + 0.58rem);
+  left: 50%;
+  z-index: 4;
+  display: grid;
+  gap: 0.42rem;
+  width: min(22rem, calc(100vw - 2rem));
+  max-height: min(24rem, calc(100dvh - 7rem));
+  padding: 0.62rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid var(--panel-edge);
-  border-radius: 999px;
-  background: rgba(16, 9, 24, 0.72);
-  box-shadow: 0 0.65rem 2rem rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(16px);
+  border-radius: 0.82rem;
+  background: rgba(20, 11, 29, 0.98);
+  box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
   transform: translateX(-50%);
+  animation: tarot-centered-popover-enter 150ms ease-out both;
 }
 
 .tarot-spread-actions > span {
-  padding: 0 0.55rem;
+  padding: 0.06rem 0.2rem 0.12rem;
   color: var(--faint-ink);
   font-family: var(--font-mono);
   font-size: 0.625rem;
@@ -472,17 +452,24 @@ button {
   text-transform: uppercase;
 }
 
+.tarot-spread-actions > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.3rem;
+}
+
 .tarot-spread-actions button {
   display: grid;
   gap: 0.08rem;
-  min-height: 2.75rem;
-  padding: 0.38rem 0.78rem;
+  min-height: 3.3rem;
+  padding: 0.52rem 0.66rem;
   border: 1px solid rgba(247, 239, 217, 0.2);
-  border-radius: 999px;
+  border-radius: 0.48rem;
   background: var(--control);
   color: var(--ink);
   font-size: 0.82rem;
   line-height: 1.05;
+  text-align: left;
   cursor: pointer;
   transition: border-color 160ms ease, background 160ms ease,
     transform 160ms ease;
@@ -525,45 +512,32 @@ button {
   animation: tarot-toolbar-enter 220ms ease-out both;
 }
 
-.tarot-mode-hint {
-  bottom: 6.35rem;
-  left: 50%;
-  display: flex;
+.tarot-mode-cancel {
+  display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  max-width: calc(100vw - 2rem);
-  padding: 0.42rem 0.45rem 0.42rem 0.8rem;
+  justify-content: center;
+  gap: 0.34rem;
+  flex: 0 0 auto;
+  padding-inline: 0.68rem;
   border: 1px solid rgba(234, 212, 155, 0.48);
   border-radius: 999px;
-  background: rgba(20, 11, 29, 0.9);
-  box-shadow: 0 0.8rem 2.4rem rgba(0, 0, 0, 0.24);
-  color: var(--ink);
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.03em;
+  background: rgba(67, 38, 77, 0.88);
+  color: #fff9e8;
   white-space: nowrap;
-  backdrop-filter: blur(18px);
-  transform: translateX(-50%);
-  animation: tarot-mode-hint-enter 160ms ease-out both;
 }
 
-.tarot-mode-hint button {
-  min-height: 2.25rem;
-  padding: 0.36rem 0.7rem;
-  border: 1px solid rgba(247, 239, 217, 0.2);
-  border-radius: 999px;
-  background: var(--control);
-  color: var(--ink);
-  font-family: var(--font-mono);
-  font-size: 0.64rem;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: border-color 160ms ease, background 160ms ease;
+.tarot-mode-cancel svg {
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.55;
 }
 
-.tarot-mode-hint button:hover {
-  border-color: var(--accent-bright);
-  background: var(--control-hover);
+.tarot-mode-cancel-label {
+  color: var(--faint-ink);
 }
 
 .tarot-zoom-controls {
@@ -588,14 +562,16 @@ button {
     transform 160ms ease;
 }
 
+.tarot-deck-menu,
+.tarot-card-menu,
+.tarot-spread-menu,
 .tarot-arrange-menu,
 .tarot-shuffle-menu {
   position: relative;
   flex: 0 0 auto;
 }
 
-.tarot-arrange-trigger,
-.tarot-shuffle-trigger {
+.tarot-toolbar-trigger {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -605,8 +581,7 @@ button {
   color: var(--muted-ink);
 }
 
-.tarot-arrange-trigger svg,
-.tarot-shuffle-trigger svg {
+.tarot-toolbar-trigger svg {
   width: 0.9rem;
   height: 0.9rem;
   fill: none;
@@ -616,22 +591,19 @@ button {
   stroke-width: 1.7;
 }
 
-.tarot-arrange-trigger .tarot-menu-chevron,
-.tarot-shuffle-trigger .tarot-menu-chevron {
+.tarot-toolbar-trigger .tarot-menu-chevron {
   width: 0.72rem;
   height: 0.72rem;
   transition: transform 160ms ease;
 }
 
-.tarot-arrange-trigger[aria-expanded="true"],
-.tarot-shuffle-trigger[aria-expanded="true"] {
+.tarot-toolbar-trigger[aria-expanded="true"] {
   border-color: var(--accent-bright);
   background: var(--control-hover);
   color: #fff9e8;
 }
 
-.tarot-arrange-trigger[aria-expanded="true"] .tarot-menu-chevron,
-.tarot-shuffle-trigger[aria-expanded="true"] .tarot-menu-chevron {
+.tarot-toolbar-trigger[aria-expanded="true"] .tarot-menu-chevron {
   transform: rotate(180deg);
 }
 
@@ -781,18 +753,6 @@ select:focus-visible {
   }
 }
 
-@keyframes tarot-mode-hint-enter {
-  from {
-    opacity: 0;
-    transform: translate3d(-50%, 0.3rem, 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate3d(-50%, 0, 0);
-  }
-}
-
 @keyframes tarot-popover-enter {
   from {
     opacity: 0;
@@ -801,6 +761,18 @@ select:focus-visible {
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes tarot-centered-popover-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(-50%, 0.25rem, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0);
   }
 }
 
@@ -822,9 +794,8 @@ select:focus-visible {
 
 @media (max-width: 719px) {
   .tarot-set-picker {
-    top: max(0.75rem, var(--safe-top));
-    right: max(0.75rem, var(--safe-right));
-    width: min(14.5rem, calc(100vw - 1.5rem));
+    bottom: calc(100% + 0.42rem);
+    width: min(18rem, calc(100vw - 1.25rem));
     padding: 0.52rem 0.58rem 0.58rem;
   }
 
@@ -839,20 +810,15 @@ select:focus-visible {
   }
 
   .tarot-inspector {
-    left: max(0.75rem, var(--safe-left));
-    right: max(0.75rem, var(--safe-right));
-    bottom: calc(max(0.65rem, var(--safe-bottom)) + 4.25rem);
-    width: auto;
-    max-height: calc(100dvh - 6rem);
+    right: -6.35rem;
+    bottom: calc(100% + 0.42rem);
+    left: auto;
+    width: min(20rem, calc(100vw - 1.25rem));
+    max-height: calc(100dvh - 6.2rem);
     min-height: 0;
     padding: 0.68rem 0.72rem 0.74rem;
-  }
-
-  .tarot-inspector-toggle {
-    right: max(0.75rem, var(--safe-right));
-    bottom: calc(max(0.65rem, var(--safe-bottom)) + 4.25rem);
-    width: 2.75rem;
-    min-height: 2.75rem;
+    transform: none;
+    animation-name: tarot-popover-enter;
   }
 
   .tarot-inspector-collapse {
@@ -904,55 +870,33 @@ select:focus-visible {
   }
 
   .tarot-spread-actions {
-    right: 0.62rem;
-    bottom: 5.25rem;
-    left: 0.62rem;
-    justify-content: flex-start;
-    max-width: none;
-    overflow-x: auto;
-    padding: 0.3rem;
-    border-radius: 0.35rem;
-    scrollbar-width: none;
+    right: -6.35rem;
+    bottom: calc(100% + 0.42rem);
+    left: auto;
+    width: min(20rem, calc(100vw - 1.25rem));
+    max-height: calc(100dvh - 6.2rem);
+    padding: 0.52rem;
     transform: none;
-  }
-
-  .tarot-spread-actions::-webkit-scrollbar {
-    display: none;
-  }
-
-  .tarot-spread-actions > span {
-    display: none;
+    animation-name: tarot-popover-enter;
   }
 
   .tarot-spread-actions button {
-    flex: 0 0 auto;
-    min-height: 2.45rem;
-    padding: 0.34rem 0.66rem;
+    min-height: 3rem;
+    padding: 0.42rem 0.54rem;
     font-size: 0.74rem;
   }
 
   .tarot-toolbar {
     bottom: max(0.65rem, var(--safe-bottom));
-    display: grid;
-    grid-template-columns: auto 2.75rem 2.75rem;
-    gap: 0.42rem;
+    display: flex;
+    gap: 0.22rem;
     width: max-content;
     max-width: calc(100vw - 1.25rem);
-    padding: 0.42rem;
-  }
-
-  .tarot-mode-hint {
-    bottom: calc(max(0.65rem, var(--safe-bottom)) + 4.35rem);
-    max-width: calc(100vw - 1.5rem);
-    font-size: 0.66rem;
-  }
-
-  .tarot-mode-hint button {
-    min-height: 2.75rem;
+    padding: 0.35rem;
   }
 
   .tarot-zoom-controls {
-    grid-template-columns: 2.75rem 3.6rem 2.75rem;
+    grid-template-columns: repeat(3, 2.75rem);
     gap: 0.16rem;
   }
 
@@ -962,8 +906,8 @@ select:focus-visible {
     font-size: 0.65rem;
   }
 
-  .tarot-arrange-trigger,
-  .tarot-shuffle-trigger {
+  .tarot-toolbar-trigger,
+  .tarot-mode-cancel {
     width: 2.75rem;
     min-height: 2.75rem;
     padding: 0.24rem;
@@ -971,32 +915,14 @@ select:focus-visible {
     letter-spacing: 0.02em;
   }
 
-  .tarot-arrange-menu {
-    align-self: stretch;
-    grid-column: 2;
-    grid-row: 1;
-  }
-
-  .tarot-shuffle-menu {
-    align-self: stretch;
-    grid-column: 3;
-    grid-row: 1;
-  }
-
-  .tarot-arrange-trigger,
-  .tarot-shuffle-trigger {
-    width: 2.75rem;
-    min-height: 2.75rem;
-  }
-
-  .tarot-arrange-trigger > span,
-  .tarot-shuffle-trigger > span,
+  .tarot-toolbar-trigger > span,
+  .tarot-mode-cancel > span,
   .tarot-menu-chevron {
     display: none;
   }
 
-  .tarot-arrange-trigger svg,
-  .tarot-shuffle-trigger svg {
+  .tarot-toolbar-trigger svg,
+  .tarot-mode-cancel svg {
     width: 1.05rem;
     height: 1.05rem;
   }
@@ -1020,11 +946,31 @@ select:focus-visible {
   }
 }
 
+@media (max-width: 349px) {
+  .tarot-toolbar {
+    gap: 0.18rem;
+    padding: 0.28rem;
+  }
+
+  .tarot-zoom-controls {
+    grid-template-columns: 2.5rem 2.75rem 2.5rem;
+    gap: 0.1rem;
+  }
+
+  .tarot-toolbar-trigger,
+  .tarot-mode-cancel {
+    width: 2.5rem;
+    min-height: 2.5rem;
+  }
+
+  .tarot-inspector,
+  .tarot-spread-actions {
+    right: -5.9rem;
+  }
+}
+
 @media (max-height: 660px) and (min-width: 720px) {
   .tarot-inspector {
-    bottom: 5.6rem;
-    left: max(0.75rem, var(--safe-left));
-    right: auto;
     width: min(18rem, calc(100vw - 1.5rem));
     max-height: calc(100dvh - 6.5rem);
   }
@@ -1074,22 +1020,8 @@ select:focus-visible {
     display: none;
   }
 
-  .tarot-inspector-toggle {
-    right: auto;
-    bottom: 5.6rem;
-    left: max(0.75rem, var(--safe-left));
-  }
-
-  .tarot-set-picker {
-    top: max(0.75rem, var(--safe-top));
-  }
-
   .tarot-toolbar {
     bottom: max(0.6rem, var(--safe-bottom));
-  }
-
-  .tarot-mode-hint {
-    bottom: 5.2rem;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,6 +50,8 @@ body {
 button,
 select {
   font: inherit;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: rgba(234, 212, 155, 0.14);
 }
 
 button {
@@ -180,6 +182,7 @@ button {
 .tarot-inspector,
 .tarot-spread-actions,
 .tarot-toolbar,
+.tarot-mode-hint,
 .tarot-live-status {
   position: absolute;
   z-index: 3;
@@ -208,7 +211,6 @@ button {
   background: rgba(20, 11, 29, 0.76);
   box-shadow: 0 0.8rem 2.4rem rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(18px);
-  animation: tarot-panel-enter 180ms ease-out both;
 }
 
 .tarot-set-picker label,
@@ -396,7 +398,7 @@ button {
 
 .tarot-inspector-actions {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.45rem;
   margin-top: 0.68rem;
 }
@@ -412,7 +414,7 @@ button {
   background: var(--control);
   color: var(--ink);
   font-family: var(--font-mono);
-  font-size: 0.65rem;
+  font-size: 0.68rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   cursor: pointer;
@@ -465,7 +467,7 @@ button {
   padding: 0 0.55rem;
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.54rem;
+  font-size: 0.625rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -473,7 +475,7 @@ button {
 .tarot-spread-actions button {
   display: grid;
   gap: 0.08rem;
-  min-height: 2.65rem;
+  min-height: 2.75rem;
   padding: 0.38rem 0.78rem;
   border: 1px solid rgba(247, 239, 217, 0.2);
   border-radius: 999px;
@@ -500,7 +502,7 @@ button {
 .tarot-spread-actions small {
   color: var(--faint-ink);
   font-family: var(--font-mono);
-  font-size: 0.45rem;
+  font-size: 0.625rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -523,6 +525,47 @@ button {
   animation: tarot-toolbar-enter 220ms ease-out both;
 }
 
+.tarot-mode-hint {
+  bottom: 6.35rem;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  max-width: calc(100vw - 2rem);
+  padding: 0.42rem 0.45rem 0.42rem 0.8rem;
+  border: 1px solid rgba(234, 212, 155, 0.48);
+  border-radius: 999px;
+  background: rgba(20, 11, 29, 0.9);
+  box-shadow: 0 0.8rem 2.4rem rgba(0, 0, 0, 0.24);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  backdrop-filter: blur(18px);
+  transform: translateX(-50%);
+  animation: tarot-mode-hint-enter 160ms ease-out both;
+}
+
+.tarot-mode-hint button {
+  min-height: 2.25rem;
+  padding: 0.36rem 0.7rem;
+  border: 1px solid rgba(247, 239, 217, 0.2);
+  border-radius: 999px;
+  background: var(--control);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.tarot-mode-hint button:hover {
+  border-color: var(--accent-bright);
+  background: var(--control-hover);
+}
+
 .tarot-zoom-controls {
   display: grid;
   grid-template-columns: 2.75rem minmax(4rem, auto) 2.75rem;
@@ -539,7 +582,7 @@ button {
   background: var(--control);
   color: var(--ink);
   font-family: var(--font-mono);
-  font-size: 0.62rem;
+  font-size: 0.68rem;
   cursor: pointer;
   transition: border-color 160ms ease, background 160ms ease,
     transform 160ms ease;
@@ -605,7 +648,7 @@ button {
   overscroll-behavior: contain;
   border: 1px solid var(--panel-edge);
   border-radius: 0.82rem;
-  background: rgba(20, 11, 29, 0.93);
+  background: rgba(20, 11, 29, 0.98);
   box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
   backdrop-filter: blur(18px);
   animation: tarot-popover-enter 150ms ease-out both;
@@ -652,10 +695,6 @@ button {
   border-color: rgba(234, 212, 155, 0.45);
   background: var(--control-hover);
   transform: translateY(-1px);
-}
-
-.tarot-arrange-popover button:last-child {
-  grid-column: 1 / -1;
 }
 
 .tarot-arrange-popover button span {
@@ -723,12 +762,10 @@ select:focus-visible {
 @keyframes tarot-panel-enter {
   from {
     opacity: 0;
-    transform: translate3d(0, 0.35rem, 0);
   }
 
   to {
     opacity: 1;
-    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -736,6 +773,18 @@ select:focus-visible {
   from {
     opacity: 0;
     transform: translate3d(-50%, 0.35rem, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0);
+  }
+}
+
+@keyframes tarot-mode-hint-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(-50%, 0.3rem, 0);
   }
 
   to {
@@ -830,7 +879,7 @@ select:focus-visible {
   }
 
   .tarot-card-browser label {
-    font-size: 0.44rem;
+    font-size: 0.6rem;
   }
 
   .tarot-card-browser select {
@@ -892,6 +941,16 @@ select:focus-visible {
     padding: 0.42rem;
   }
 
+  .tarot-mode-hint {
+    bottom: calc(max(0.65rem, var(--safe-bottom)) + 4.35rem);
+    max-width: calc(100vw - 1.5rem);
+    font-size: 0.66rem;
+  }
+
+  .tarot-mode-hint button {
+    min-height: 2.75rem;
+  }
+
   .tarot-zoom-controls {
     grid-template-columns: 2.75rem 3.6rem 2.75rem;
     gap: 0.16rem;
@@ -900,7 +959,7 @@ select:focus-visible {
   .tarot-zoom-controls button {
     min-height: 2.75rem;
     padding: 0.25rem;
-    font-size: 0.56rem;
+    font-size: 0.65rem;
   }
 
   .tarot-arrange-trigger,
@@ -982,6 +1041,10 @@ select:focus-visible {
 
   .tarot-toolbar {
     bottom: max(0.6rem, var(--safe-bottom));
+  }
+
+  .tarot-mode-hint {
+    bottom: 5.2rem;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,13 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Tarot Table · v2",
   description: "A tactile, three-dimensional tarot table for personal readings.",
+};
+
+export const viewport: Viewport = {
+  themeColor: "#100918",
 };
 
 export default function RootLayout({

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -17,8 +17,10 @@ import {
   MathUtils,
   Mesh,
   Plane,
+  Raycaster,
   SRGBColorSpace,
   Texture,
+  Vector2,
   Vector3,
 } from "three";
 import type {
@@ -27,6 +29,7 @@ import type {
   TableCard,
   TablePoint,
 } from "@/types";
+import type { CardSoundEvent } from "@/lib/card-sounds";
 import type { SceneTableLayout } from "./table-layout";
 import { TAROT_SCENE_PALETTE } from "./theme";
 
@@ -60,6 +63,7 @@ type DragState = {
   target: Vector3;
   velocity: Vector3;
   lastMoveAt: number;
+  lastInputAt: number;
   moved: boolean;
   tiltX: number;
   tiltY: number;
@@ -77,6 +81,14 @@ type FlipAnimation = {
 type LostPointerCaptureBinding = {
   target: HTMLElement;
   handler: (event: PointerEvent) => void;
+};
+
+type PointerEndFallbackBinding = {
+  target: Document;
+  pointerId: number;
+  pointerMoveHandler: (event: PointerEvent) => void;
+  pointerUpHandler: (event: PointerEvent) => void;
+  pointerCancelHandler: (event: PointerEvent) => void;
 };
 
 function sampleDragVelocity(
@@ -149,6 +161,7 @@ type CardMeshProps = {
   onFlip: (cardId: string) => void;
   onRotate: (cardId: string, degrees: number) => void;
   onHover: (cardId: string | null) => void;
+  onSound: (event: CardSoundEvent) => void;
 };
 
 function useTextureForCard(url: string): Texture {
@@ -363,6 +376,7 @@ export const CardMesh = memo(function CardMesh({
   onFlip,
   onRotate,
   onHover,
+  onSound,
 }: CardMeshProps) {
   const groupRef = useRef<Group>(null);
   const flipRef = useRef<Group>(null);
@@ -376,12 +390,17 @@ export const CardMesh = memo(function CardMesh({
     useRef<ReturnType<typeof setTimeout> | null>(null);
   const lostPointerCaptureRef =
     useRef<LostPointerCaptureBinding | null>(null);
+  const pointerEndFallbackRef =
+    useRef<PointerEndFallbackBinding | null>(null);
   const deckPreviewRef = useRef<TablePoint | null>(null);
   const [hasRevealed, setHasRevealed] = useState(card.faceUp);
   const hasPositionedRef = useRef(false);
   const cardIdentityRef = useRef(card.id);
   const invalidate = useThree((state) => state.invalidate);
   const canvas = useThree((state) => state.gl.domElement);
+  const camera = useThree((state) => state.camera);
+  const pointerRaycasterRef = useRef(new Raycaster());
+  const pointerNdcRef = useRef(new Vector2());
   const targetPosition =
     card.zone === "deck" ? deckPosition : layout.toWorld(card.position);
   const targetPositionX = targetPosition[0];
@@ -432,6 +451,46 @@ export const CardMesh = memo(function CardMesh({
     lostPointerCaptureRef.current = null;
   }, []);
 
+  const clearPointerEndFallback = useCallback(() => {
+    const binding = pointerEndFallbackRef.current;
+
+    if (!binding) {
+      return;
+    }
+
+    binding.target.removeEventListener(
+      "pointermove",
+      binding.pointerMoveHandler
+    );
+    binding.target.removeEventListener("pointerup", binding.pointerUpHandler);
+    binding.target.removeEventListener(
+      "pointercancel",
+      binding.pointerCancelHandler
+    );
+    pointerEndFallbackRef.current = null;
+  }, []);
+
+  const getCanvasPointerPoint = useCallback(
+    (event: PointerEvent) => {
+      const bounds = canvas.getBoundingClientRect();
+      const pointer = pointerNdcRef.current;
+
+      pointer.set(
+        ((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+        -((event.clientY - bounds.top) / bounds.height) * 2 + 1
+      );
+      pointerRaycasterRef.current.setFromCamera(pointer, camera);
+
+      return (
+        pointerRaycasterRef.current.ray.intersectPlane(
+          DRAG_PLANE,
+          new Vector3()
+        ) ?? dragRef.current?.lastPoint.clone() ?? new Vector3()
+      );
+    },
+    [camera, canvas]
+  );
+
   const setDeckPreview = useCallback(
     (position: TablePoint | null) => {
       const current = deckPreviewRef.current;
@@ -476,12 +535,14 @@ export const CardMesh = memo(function CardMesh({
       pendingTopLayerRef.current = false;
       clearPendingReconciliationTimeout();
       clearLostPointerCapture();
+      clearPointerEndFallback();
       setDeckPreview(null);
       canvas.style.cursor = "grab";
     },
     [
       canvas,
       clearLostPointerCapture,
+      clearPointerEndFallback,
       clearPendingReconciliationTimeout,
       setDeckPreview,
     ]
@@ -578,6 +639,209 @@ export const CardMesh = memo(function CardMesh({
     targetPositionY,
   ]);
 
+  const updateDrag = useCallback(
+    ({
+      pointerId,
+      point,
+      timestamp,
+      shiftKey = false,
+    }: {
+      pointerId: number;
+      point: Vector3;
+      timestamp: number;
+      shiftKey?: boolean;
+    }) => {
+      const drag = dragRef.current;
+      const group = groupRef.current;
+
+      if (!drag || drag.pointerId !== pointerId || !group) {
+        return false;
+      }
+
+      // Both React Three Fiber and the canvas fallback see the same DOM event.
+      // Process it once while still accepting movement that no longer raycasts
+      // against the card after a very fast pointer motion.
+      if (
+        drag.lastInputAt === timestamp &&
+        point.distanceToSquared(drag.lastPoint) <= 0.00000001
+      ) {
+        return true;
+      }
+
+      drag.lastInputAt = timestamp;
+
+      if (drag.mode === "rotate") {
+        const pointerAngle = Math.atan2(
+          point.y - group.position.y,
+          point.x - group.position.x
+        );
+        let angleDelta = pointerAngle - drag.startAngle;
+
+        if (angleDelta > Math.PI) {
+          angleDelta -= Math.PI * 2;
+        } else if (angleDelta < -Math.PI) {
+          angleDelta += Math.PI * 2;
+        }
+
+        const rawRotation =
+          drag.startRotation + MathUtils.radToDeg(angleDelta);
+        const previewRotation = shiftKey
+          ? Math.round(rawRotation / 15) * 15
+          : rawRotation;
+
+        drag.previewRotation = previewRotation;
+        drag.moved =
+          Math.abs(previewRotation - drag.startRotation) > 0.8;
+        drag.lastPoint.copy(point);
+        invalidate();
+        return true;
+      }
+
+      const nextX = point.x - drag.offset.x;
+      const nextY = point.y - drag.offset.y;
+      const [deltaX, deltaY] = sampleDragVelocity(drag, point, timestamp);
+
+      const hadMoved = drag.moved;
+
+      if (point.distanceTo(drag.origin) > DRAG_THRESHOLD) {
+        drag.moved = true;
+      }
+
+      if (!hadMoved && drag.moved) {
+        onSound("move");
+      }
+
+      drag.tiltX = MathUtils.clamp(-deltaY * 0.48, -0.13, 0.13);
+      drag.tiltY = MathUtils.clamp(deltaX * 0.48, -0.13, 0.13);
+      drag.target.set(nextX, nextY, group.position.z);
+      invalidate();
+      return true;
+    },
+    [invalidate, onSound]
+  );
+
+  const finishDragAt = useCallback(
+    ({
+      pointerId,
+      point,
+      timestamp,
+      cancelled = false,
+    }: {
+      pointerId: number;
+      point: Vector3;
+      timestamp: number;
+      cancelled?: boolean;
+    }) => {
+      const drag = dragRef.current;
+      const group = groupRef.current;
+
+      if (!drag || drag.pointerId !== pointerId || !group) {
+        return false;
+      }
+
+      if (!cancelled) {
+        updateDrag({ pointerId, point, timestamp });
+      }
+
+      if (!cancelled) {
+        if (drag.mode === "rotate" && drag.moved) {
+          pendingRotationRef.current = drag.previewRotation;
+          schedulePendingReconciliation();
+          onRotate(card.id, drag.previewRotation - drag.startRotation);
+        } else if (drag.mode !== "rotate" && drag.moved) {
+          const releaseX = point.x - drag.offset.x;
+          const releaseY = point.y - drag.offset.y;
+          drag.target.set(releaseX, releaseY, group.position.z);
+          const idleSeconds = Math.max(
+            0,
+            (timestamp - drag.lastMoveAt) / 1000
+          );
+          const velocityDecay = reducedMotion
+            ? 0
+            : Math.exp(-idleSeconds * 10);
+          const releaseVelocityX = drag.velocity.x * velocityDecay;
+          const releaseVelocityY = drag.velocity.y * velocityDecay;
+          let glideX = releaseVelocityX * RELEASE_GLIDE_SECONDS;
+          let glideY = releaseVelocityY * RELEASE_GLIDE_SECONDS;
+          const glideDistance = Math.hypot(glideX, glideY);
+
+          if (glideDistance > MAX_RELEASE_GLIDE) {
+            const glideScale = MAX_RELEASE_GLIDE / glideDistance;
+            glideX *= glideScale;
+            glideY *= glideScale;
+          }
+
+          const nextPoint = layout.toPoint(
+            releaseX + glideX,
+            releaseY + glideY
+          );
+          const nextWorldPosition = layout.toWorld(nextPoint);
+
+          if (drag.mode === "move-deck") {
+            pendingPositionRef.current = nextWorldPosition;
+            schedulePendingReconciliation();
+            onMoveDeck(nextPoint);
+          } else {
+            const landingRotation = getThrownRotation({
+              rotation: card.rotation,
+              offset: drag.offset,
+              velocityX: releaseVelocityX,
+              velocityY: releaseVelocityY,
+              cardWidth,
+              cardHeight,
+              reducedMotion,
+            });
+
+            pendingPositionRef.current = nextWorldPosition;
+            pendingRotationRef.current = landingRotation;
+            pendingTopLayerRef.current = true;
+            schedulePendingReconciliation();
+
+            if (card.zone === "deck") {
+              onDraw(card.id, nextPoint, landingRotation);
+            } else {
+              onMove(card.id, nextPoint, landingRotation);
+            }
+          }
+        }
+      }
+
+      if (cancelled) {
+        clearPendingRelease();
+        onHover(null);
+      }
+
+      dragRef.current = null;
+
+      if (drag.mode === "move-deck") {
+        setDeckPreview(null);
+      }
+      canvas.style.cursor = "grab";
+      invalidate();
+      return true;
+    },
+    [
+      canvas,
+      card.id,
+      card.rotation,
+      card.zone,
+      cardHeight,
+      cardWidth,
+      clearPendingRelease,
+      invalidate,
+      layout,
+      onDraw,
+      onHover,
+      onMove,
+      onMoveDeck,
+      onRotate,
+      reducedMotion,
+      schedulePendingReconciliation,
+      setDeckPreview,
+      updateDrag,
+    ]
+  );
+
   useFrame((_, delta) => {
     const group = groupRef.current;
     const flippingCard = flipRef.current;
@@ -650,7 +914,7 @@ export const CardMesh = memo(function CardMesh({
         ? 0
         : Math.abs(Math.sin(flippingCard.rotation.y)) * FLIP_LIFT;
     const zTarget =
-      drag && drag.mode !== "move-deck"
+      drag?.moved && drag.mode !== "move-deck"
         ? draggingZ + flipLift
         : restingZ + (drag?.mode === "move-deck" ? 0.006 : 0) + flipLift;
     const positionXTarget = moving
@@ -768,12 +1032,12 @@ export const CardMesh = memo(function CardMesh({
       point.x - group.position.x
     );
 
-    const canCapture = typeof target.setPointerCapture === "function";
     target.setPointerCapture?.(event.pointerId);
-    const pointerTarget = event.nativeEvent.target;
+    canvas.setPointerCapture?.(event.pointerId);
 
     clearLostPointerCapture();
-    if (canCapture && pointerTarget instanceof HTMLElement) {
+    clearPointerEndFallback();
+    if (typeof canvas.setPointerCapture === "function") {
       const handleLostPointerCapture = (lostEvent: PointerEvent) => {
         lostPointerCaptureRef.current = null;
         const activeDrag = dragRef.current;
@@ -782,23 +1046,21 @@ export const CardMesh = memo(function CardMesh({
           return;
         }
 
-        dragRef.current = null;
-        clearPendingRelease();
-        if (activeDrag.mode === "move-deck") {
-          setDeckPreview(null);
-        }
-        onHover(null);
-        canvas.style.cursor = "grab";
-        invalidate();
+        clearPointerEndFallback();
+        finishDragAt({
+          pointerId: lostEvent.pointerId,
+          point: activeDrag.lastPoint.clone(),
+          timestamp: lostEvent.timeStamp,
+        });
       };
 
-      pointerTarget.addEventListener(
+      canvas.addEventListener(
         "lostpointercapture",
         handleLostPointerCapture,
         { once: true }
       );
       lostPointerCaptureRef.current = {
-        target: pointerTarget,
+        target: canvas,
         handler: handleLostPointerCapture,
       };
     }
@@ -816,6 +1078,7 @@ export const CardMesh = memo(function CardMesh({
       target: group.position.clone(),
       velocity: new Vector3(),
       lastMoveAt: event.timeStamp,
+      lastInputAt: event.timeStamp,
       moved: false,
       tiltX: 0,
       tiltY: 0,
@@ -823,9 +1086,67 @@ export const CardMesh = memo(function CardMesh({
       startRotation: card.rotation,
       previewRotation: card.rotation,
     };
+    onSound("pickup");
     if (mode === "move-deck") {
       setDeckPreview([group.position.x, group.position.y]);
     }
+
+    const handlePointerMoveFallback = (nativeEvent: PointerEvent) => {
+      if (nativeEvent.pointerId !== event.pointerId) {
+        return;
+      }
+
+      updateDrag({
+        pointerId: nativeEvent.pointerId,
+        point: getCanvasPointerPoint(nativeEvent),
+        timestamp: nativeEvent.timeStamp,
+        shiftKey: nativeEvent.shiftKey,
+      });
+    };
+    const handlePointerUpFallback = (nativeEvent: PointerEvent) => {
+      if (nativeEvent.pointerId !== event.pointerId) {
+        return;
+      }
+
+      clearLostPointerCapture();
+      clearPointerEndFallback();
+      if (canvas.hasPointerCapture(nativeEvent.pointerId)) {
+        canvas.releasePointerCapture(nativeEvent.pointerId);
+      }
+      finishDragAt({
+        pointerId: nativeEvent.pointerId,
+        point: getCanvasPointerPoint(nativeEvent),
+        timestamp: nativeEvent.timeStamp,
+      });
+    };
+    const handlePointerCancelFallback = (nativeEvent: PointerEvent) => {
+      if (nativeEvent.pointerId !== event.pointerId) {
+        return;
+      }
+
+      clearLostPointerCapture();
+      clearPointerEndFallback();
+      if (canvas.hasPointerCapture(nativeEvent.pointerId)) {
+        canvas.releasePointerCapture(nativeEvent.pointerId);
+      }
+      finishDragAt({
+        pointerId: nativeEvent.pointerId,
+        point: getCanvasPointerPoint(nativeEvent),
+        timestamp: nativeEvent.timeStamp,
+        cancelled: true,
+      });
+    };
+
+    document.addEventListener("pointermove", handlePointerMoveFallback);
+    document.addEventListener("pointerup", handlePointerUpFallback);
+    document.addEventListener("pointercancel", handlePointerCancelFallback);
+    pointerEndFallbackRef.current = {
+      target: document,
+      pointerId: event.pointerId,
+      pointerMoveHandler: handlePointerMoveFallback,
+      pointerUpHandler: handlePointerUpFallback,
+      pointerCancelHandler: handlePointerCancelFallback,
+    };
     canvas.style.cursor = mode === "rotate" ? "crosshair" : "grabbing";
     onSelect(
       mode !== "move-deck" && card.zone === "table" ? card.id : null
@@ -835,11 +1156,6 @@ export const CardMesh = memo(function CardMesh({
 
   const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
     const drag = dragRef.current;
-    const group = groupRef.current;
-
-    if (!group) {
-      return;
-    }
 
     if (!drag) {
       if (event.nativeEvent.pointerType !== "touch") {
@@ -865,146 +1181,29 @@ export const CardMesh = memo(function CardMesh({
     }
 
     event.stopPropagation();
-    const point = getPointerPoint(event);
-
-    if (drag.mode === "rotate") {
-      const pointerAngle = Math.atan2(
-        point.y - group.position.y,
-        point.x - group.position.x
-      );
-      let angleDelta = pointerAngle - drag.startAngle;
-
-      if (angleDelta > Math.PI) {
-        angleDelta -= Math.PI * 2;
-      } else if (angleDelta < -Math.PI) {
-        angleDelta += Math.PI * 2;
-      }
-
-      const rawRotation =
-        drag.startRotation + MathUtils.radToDeg(angleDelta);
-      const previewRotation = event.nativeEvent.shiftKey
-        ? Math.round(rawRotation / 15) * 15
-        : rawRotation;
-
-      drag.previewRotation = previewRotation;
-      drag.moved =
-        Math.abs(previewRotation - drag.startRotation) > 0.8;
-      drag.lastPoint.copy(point);
-      invalidate();
-      return;
-    }
-
-    const nextX = point.x - drag.offset.x;
-    const nextY = point.y - drag.offset.y;
-    const [deltaX, deltaY] = sampleDragVelocity(
-      drag,
-      point,
-      event.timeStamp
-    );
-
-    if (point.distanceTo(drag.origin) > DRAG_THRESHOLD) {
-      drag.moved = true;
-    }
-
-    drag.tiltX = MathUtils.clamp(-deltaY * 0.48, -0.13, 0.13);
-    drag.tiltY = MathUtils.clamp(deltaX * 0.48, -0.13, 0.13);
-    drag.target.set(nextX, nextY, group.position.z);
-    invalidate();
+    updateDrag({
+      pointerId: event.pointerId,
+      point: getPointerPoint(event),
+      timestamp: event.timeStamp,
+      shiftKey: event.nativeEvent.shiftKey,
+    });
   };
 
   const finishDrag = (event: ThreeEvent<PointerEvent>, cancelled = false) => {
-    const drag = dragRef.current;
-    const group = groupRef.current;
-
-    if (!drag || drag.pointerId !== event.pointerId || !group) {
-      return;
-    }
-
     event.stopPropagation();
     const target = event.target as unknown as PointerCaptureTarget;
     clearLostPointerCapture();
+    clearPointerEndFallback();
     target.releasePointerCapture?.(event.pointerId);
-
-    if (!cancelled) {
-      if (drag.mode === "rotate" && drag.moved) {
-        pendingRotationRef.current = drag.previewRotation;
-        schedulePendingReconciliation();
-        onRotate(
-          card.id,
-          drag.previewRotation - drag.startRotation
-        );
-      } else if (drag.mode !== "rotate" && drag.moved) {
-        const point = getPointerPoint(event);
-        const releaseX = point.x - drag.offset.x;
-        const releaseY = point.y - drag.offset.y;
-        sampleDragVelocity(drag, point, event.timeStamp);
-        drag.target.set(releaseX, releaseY, group.position.z);
-        const idleSeconds = Math.max(
-          0,
-          (event.timeStamp - drag.lastMoveAt) / 1000
-        );
-        const velocityDecay = reducedMotion
-          ? 0
-          : Math.exp(-idleSeconds * 10);
-        const releaseVelocityX = drag.velocity.x * velocityDecay;
-        const releaseVelocityY = drag.velocity.y * velocityDecay;
-        let glideX = releaseVelocityX * RELEASE_GLIDE_SECONDS;
-        let glideY = releaseVelocityY * RELEASE_GLIDE_SECONDS;
-        const glideDistance = Math.hypot(glideX, glideY);
-
-        if (glideDistance > MAX_RELEASE_GLIDE) {
-          const glideScale = MAX_RELEASE_GLIDE / glideDistance;
-          glideX *= glideScale;
-          glideY *= glideScale;
-        }
-
-        const nextPoint = layout.toPoint(
-          releaseX + glideX,
-          releaseY + glideY
-        );
-        const nextWorldPosition = layout.toWorld(nextPoint);
-
-        if (drag.mode === "move-deck") {
-          pendingPositionRef.current = nextWorldPosition;
-          schedulePendingReconciliation();
-          onMoveDeck(nextPoint);
-        } else {
-          const landingRotation = getThrownRotation({
-            rotation: card.rotation,
-            offset: drag.offset,
-            velocityX: releaseVelocityX,
-            velocityY: releaseVelocityY,
-            cardWidth,
-            cardHeight,
-            reducedMotion,
-          });
-
-          pendingPositionRef.current = nextWorldPosition;
-          pendingRotationRef.current = landingRotation;
-          pendingTopLayerRef.current = true;
-          schedulePendingReconciliation();
-
-          if (card.zone === "deck") {
-            onDraw(card.id, nextPoint, landingRotation);
-          } else {
-            onMove(card.id, nextPoint, landingRotation);
-          }
-        }
-      }
+    if (canvas.hasPointerCapture(event.pointerId)) {
+      canvas.releasePointerCapture(event.pointerId);
     }
-
-    if (cancelled) {
-      clearPendingRelease();
-      onHover(null);
-    }
-
-    dragRef.current = null;
-
-    if (drag.mode === "move-deck") {
-      setDeckPreview(null);
-    }
-    canvas.style.cursor = "grab";
-    invalidate();
+    finishDragAt({
+      pointerId: event.pointerId,
+      point: getPointerPoint(event),
+      timestamp: event.timeStamp,
+      cancelled,
+    });
   };
 
   const handleDoubleClick = (event: ThreeEvent<MouseEvent>) => {

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -3,6 +3,7 @@
 import { RoundedBox, useTexture } from "@react-three/drei";
 import { ThreeEvent, useFrame, useThree } from "@react-three/fiber";
 import {
+  memo,
   Suspense,
   useCallback,
   useEffect,
@@ -131,6 +132,7 @@ type CardMeshProps = {
   dragRenderOrder: number;
   selected: boolean;
   reducedMotion: boolean;
+  deckMoveMode: boolean;
   onSelect: (cardId: string | null) => void;
   onDraw: (
     cardId: string,
@@ -339,7 +341,7 @@ function getThrownRotation({
   return rotation + rotationDelta;
 }
 
-export function CardMesh({
+export const CardMesh = memo(function CardMesh({
   card,
   definition,
   cardSet,
@@ -352,6 +354,7 @@ export function CardMesh({
   dragRenderOrder,
   selected,
   reducedMotion,
+  deckMoveMode,
   onSelect,
   onDraw,
   onMoveDeck,
@@ -745,8 +748,9 @@ export function CardMesh({
 
     const movesDeck =
       card.zone === "deck" &&
-      event.nativeEvent.pointerType !== "touch" &&
-      (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey);
+      (deckMoveMode ||
+        (event.nativeEvent.pointerType !== "touch" &&
+          (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey)));
     const mode: DragState["mode"] = movesDeck
       ? "move-deck"
       : card.zone === "table" &&
@@ -841,7 +845,9 @@ export function CardMesh({
       if (event.nativeEvent.pointerType !== "touch") {
         const deckMoveReady =
           card.zone === "deck" &&
-          (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey);
+          (deckMoveMode ||
+            event.nativeEvent.ctrlKey ||
+            event.nativeEvent.metaKey);
         const ready =
           card.zone === "table" && selected && isNearCardEdge(event);
         canvas.style.cursor = deckMoveReady
@@ -1056,7 +1062,9 @@ export function CardMesh({
             onHover(card.zone === "table" ? card.id : null);
             const deckMoveReady =
               card.zone === "deck" &&
-              (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey);
+              (deckMoveMode ||
+                event.nativeEvent.ctrlKey ||
+                event.nativeEvent.metaKey);
             const ready =
               card.zone === "table" && selected && isNearCardEdge(event);
             canvas.style.cursor = deckMoveReady
@@ -1095,4 +1103,4 @@ export function CardMesh({
       </mesh>
     </group>
   );
-}
+});

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -29,7 +29,7 @@ import type {
   TableCard,
   TablePoint,
 } from "@/types";
-import type { CardSoundEvent } from "@/lib/card-sounds";
+import type { CardSoundPlayer } from "@/lib/card-sounds";
 import type { SceneTableLayout } from "./table-layout";
 import { TAROT_SCENE_PALETTE } from "./theme";
 
@@ -161,7 +161,7 @@ type CardMeshProps = {
   onFlip: (cardId: string) => void;
   onRotate: (cardId: string, degrees: number) => void;
   onHover: (cardId: string | null) => void;
-  onSound: (event: CardSoundEvent) => void;
+  onSound: CardSoundPlayer;
 };
 
 function useTextureForCard(url: string): Texture {
@@ -692,6 +692,18 @@ export const CardMesh = memo(function CardMesh({
         drag.previewRotation = previewRotation;
         drag.moved =
           Math.abs(previewRotation - drag.startRotation) > 0.8;
+
+        if (drag.moved) {
+          onSound("rotate", {
+            intensity: MathUtils.clamp(
+              0.32 +
+                Math.abs(previewRotation - drag.startRotation) / 120,
+              0.32,
+              0.75
+            ),
+          });
+        }
+
         drag.lastPoint.copy(point);
         invalidate();
         return true;
@@ -701,14 +713,20 @@ export const CardMesh = memo(function CardMesh({
       const nextY = point.y - drag.offset.y;
       const [deltaX, deltaY] = sampleDragVelocity(drag, point, timestamp);
 
-      const hadMoved = drag.moved;
-
       if (point.distanceTo(drag.origin) > DRAG_THRESHOLD) {
         drag.moved = true;
       }
 
-      if (!hadMoved && drag.moved) {
-        onSound("move");
+      if (drag.moved) {
+        const dragSpeed = Math.hypot(drag.velocity.x, drag.velocity.y);
+
+        onSound("move", {
+          intensity: MathUtils.clamp(
+            0.35 + (dragSpeed / MAX_POINTER_SPEED) * 0.55,
+            0.35,
+            0.9
+          ),
+        });
       }
 
       drag.tiltX = MathUtils.clamp(-deltaY * 0.48, -0.13, 0.13);

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -717,14 +717,14 @@ export const CardMesh = memo(function CardMesh({
         drag.moved = true;
       }
 
-      if (drag.moved) {
+      if (drag.moved && Math.hypot(deltaX, deltaY) > 0.003) {
         const dragSpeed = Math.hypot(drag.velocity.x, drag.velocity.y);
 
         onSound("move", {
           intensity: MathUtils.clamp(
-            0.35 + (dragSpeed / MAX_POINTER_SPEED) * 0.55,
-            0.35,
-            0.9
+            0.25 + (dragSpeed / MAX_POINTER_SPEED) * 0.28,
+            0.25,
+            0.53
           ),
         });
       }

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -28,7 +28,7 @@ import {
   getTableCards,
   getTopDeckCard,
 } from "@/lib/tarot-session";
-import type { CardSoundEvent } from "@/lib/card-sounds";
+import type { CardSoundPlayer } from "@/lib/card-sounds";
 import { CardArtwork, CARD_THICKNESS, CardMesh } from "./CardMesh";
 import {
   createSceneTableLayout,
@@ -82,7 +82,7 @@ type TarotSceneProps = {
   onFlip: (cardId: string) => void;
   onRotate: (cardId: string, degrees: number) => void;
   onHover: (cardId: string | null) => void;
-  onSound: (event: CardSoundEvent) => void;
+  onSound: CardSoundPlayer;
 };
 
 function AnimatedCameraZoom({

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -4,6 +4,7 @@ import { RoundedBox, useTexture } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import {
   type MutableRefObject,
+  memo,
   Suspense,
   useCallback,
   useEffect,
@@ -63,6 +64,7 @@ type TarotSceneProps = {
   session: TarotSession;
   reducedMotion: boolean;
   viewZoom: number;
+  deckMoveMode: boolean;
   onLayoutChange: (layout: SceneTableLayout) => void;
   onSelect: (cardId: string | null) => void;
   onDraw: (
@@ -391,6 +393,7 @@ function TarotTable({
   cardSet,
   session,
   reducedMotion,
+  deckMoveMode,
   onSelect,
   onDraw,
   onMoveDeck,
@@ -558,6 +561,7 @@ function TarotTable({
             dragRenderOrder={DRAG_RENDER_ORDER}
             selected={session.selectedCardId === card.id}
             reducedMotion={reducedMotion}
+            deckMoveMode={deckMoveMode}
             onSelect={onSelect}
             onDraw={onDraw}
             onMoveDeck={onMoveDeck}
@@ -573,7 +577,7 @@ function TarotTable({
   );
 }
 
-export function TarotScene(props: TarotSceneProps) {
+export const TarotScene = memo(function TarotScene(props: TarotSceneProps) {
   return (
     <Canvas
       className="tarot-canvas"
@@ -600,4 +604,4 @@ export function TarotScene(props: TarotSceneProps) {
       <TarotTable {...props} />
     </Canvas>
   );
-}
+});

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -28,6 +28,7 @@ import {
   getTableCards,
   getTopDeckCard,
 } from "@/lib/tarot-session";
+import type { CardSoundEvent } from "@/lib/card-sounds";
 import { CardArtwork, CARD_THICKNESS, CardMesh } from "./CardMesh";
 import {
   createSceneTableLayout,
@@ -81,6 +82,7 @@ type TarotSceneProps = {
   onFlip: (cardId: string) => void;
   onRotate: (cardId: string, degrees: number) => void;
   onHover: (cardId: string | null) => void;
+  onSound: (event: CardSoundEvent) => void;
 };
 
 function AnimatedCameraZoom({
@@ -401,6 +403,7 @@ function TarotTable({
   onFlip,
   onRotate,
   onHover,
+  onSound,
   onLayoutChange,
 }: TarotSceneProps) {
   const size = useThree((state) => state.size);
@@ -570,6 +573,7 @@ function TarotTable({
             onFlip={onFlip}
             onRotate={onRotate}
             onHover={onHover}
+            onSound={onSound}
           />
         );
       })}

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -2,8 +2,11 @@
 
 import dynamic from "next/dynamic";
 import {
+  type Dispatch,
   type KeyboardEvent,
   type ReactNode,
+  type RefObject,
+  type SetStateAction,
   type WheelEvent as ReactWheelEvent,
   useCallback,
   useEffect,
@@ -68,11 +71,63 @@ function Shortcut({ children }: { children: ReactNode }) {
   return <kbd className="tarot-shortcut">{children}</kbd>;
 }
 
+type DockPopoverOptions = {
+  containerRef: RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+};
+
+function useDockPopover({
+  containerRef,
+  isOpen,
+  setIsOpen,
+  triggerRef,
+}: DockPopoverOptions) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const focusTimer = window.requestAnimationFrame(() => {
+      containerRef.current
+        ?.querySelector<HTMLElement>(
+          "[role='dialog'] button:not(:disabled), [role='dialog'] select:not(:disabled)"
+        )
+        ?.focus();
+    });
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const closeOnEscape = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsidePress);
+    document.addEventListener("keydown", closeOnEscape);
+
+    return () => {
+      window.cancelAnimationFrame(focusTimer);
+      document.removeEventListener("pointerdown", closeOnOutsidePress);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [containerRef, isOpen, setIsOpen, triggerRef]);
+}
+
 export function TarotStudio() {
   const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
   const activeSpreadRef = useRef<TarotSpread | null>(null);
+  const deckMenuRef = useRef<HTMLDivElement>(null);
+  const deckMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const spreadMenuRef = useRef<HTMLDivElement>(null);
+  const spreadMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const arrangeMenuRef = useRef<HTMLDivElement>(null);
   const arrangeMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const shuffleMenuRef = useRef<HTMLDivElement>(null);
@@ -86,6 +141,8 @@ export function TarotStudio() {
   });
   const [activeCardSetId, setActiveCardSetId] = useState(cardSets[0].id);
   const [viewZoom, setViewZoom] = useState(1);
+  const [isDeckMenuOpen, setIsDeckMenuOpen] = useState(false);
+  const [isSpreadMenuOpen, setIsSpreadMenuOpen] = useState(false);
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
   const [isShuffleMenuOpen, setIsShuffleMenuOpen] = useState(false);
   const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(false);
@@ -158,75 +215,30 @@ export function TarotStudio() {
     viewZoom,
   ]);
 
-  useEffect(() => {
-    if (!isArrangeMenuOpen) {
-      return;
-    }
-
-    const focusTimer = window.requestAnimationFrame(() => {
-      arrangeMenuRef.current
-        ?.querySelector<HTMLButtonElement>(
-          "[role='dialog'] button:not(:disabled)"
-        )
-        ?.focus();
-    });
-
-    const closeOnOutsidePress = (event: PointerEvent) => {
-      if (!arrangeMenuRef.current?.contains(event.target as Node)) {
-        setIsArrangeMenuOpen(false);
-      }
-    };
-    const closeOnEscape = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsArrangeMenuOpen(false);
-        arrangeMenuTriggerRef.current?.focus();
-      }
-    };
-
-    document.addEventListener("pointerdown", closeOnOutsidePress);
-    document.addEventListener("keydown", closeOnEscape);
-
-    return () => {
-      window.cancelAnimationFrame(focusTimer);
-      document.removeEventListener("pointerdown", closeOnOutsidePress);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [isArrangeMenuOpen]);
-
-  useEffect(() => {
-    if (!isShuffleMenuOpen) {
-      return;
-    }
-
-    const focusTimer = window.requestAnimationFrame(() => {
-      shuffleMenuRef.current
-        ?.querySelector<HTMLButtonElement>(
-          "[role='dialog'] button:not(:disabled)"
-        )
-        ?.focus();
-    });
-
-    const closeOnOutsidePress = (event: PointerEvent) => {
-      if (!shuffleMenuRef.current?.contains(event.target as Node)) {
-        setIsShuffleMenuOpen(false);
-      }
-    };
-    const closeOnEscape = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsShuffleMenuOpen(false);
-        shuffleMenuTriggerRef.current?.focus();
-      }
-    };
-
-    document.addEventListener("pointerdown", closeOnOutsidePress);
-    document.addEventListener("keydown", closeOnEscape);
-
-    return () => {
-      window.cancelAnimationFrame(focusTimer);
-      document.removeEventListener("pointerdown", closeOnOutsidePress);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [isShuffleMenuOpen]);
+  useDockPopover({
+    containerRef: deckMenuRef,
+    isOpen: isDeckMenuOpen,
+    setIsOpen: setIsDeckMenuOpen,
+    triggerRef: deckMenuTriggerRef,
+  });
+  useDockPopover({
+    containerRef: spreadMenuRef,
+    isOpen: isSpreadMenuOpen,
+    setIsOpen: setIsSpreadMenuOpen,
+    triggerRef: spreadMenuTriggerRef,
+  });
+  useDockPopover({
+    containerRef: arrangeMenuRef,
+    isOpen: isArrangeMenuOpen,
+    setIsOpen: setIsArrangeMenuOpen,
+    triggerRef: arrangeMenuTriggerRef,
+  });
+  useDockPopover({
+    containerRef: shuffleMenuRef,
+    isOpen: isShuffleMenuOpen,
+    setIsOpen: setIsShuffleMenuOpen,
+    triggerRef: shuffleMenuTriggerRef,
+  });
 
   useEffect(() => {
     if (selectedCard?.zone !== "table") {
@@ -593,168 +605,76 @@ export function TarotStudio() {
         />
       </div>
 
-      {activeCardSet.kind === "tarot" &&
-        tableCards.length === 0 &&
-        !isDeckMoveMode && (
-        <section className="tarot-spread-actions" aria-label="Popular tarot spreads">
-          <span>Spreads</span>
-          {popularTarotSpreads.map((spread) => (
-            <button
-              key={spread.id}
-              type="button"
-              onClick={() => dealSpread(spread)}
-              disabled={
-                !isSceneLayoutReady || deckCount < spread.slots.length
-              }
-            >
-              {spread.label}
-              <small>{spread.shortLabel}</small>
-            </button>
-          ))}
-        </section>
-      )}
-
-      <div className="tarot-set-picker">
-        <label htmlFor="card-set">Deck</label>
-        <select
-          id="card-set"
-          name="card-set"
-          autoComplete="off"
-          value={activeCardSetId}
-          onChange={(event) => {
-            const nextCardSet = getCardSet(event.target.value);
-            activeSpreadRef.current = null;
-            setIsDeckMoveMode(false);
-            setIsSceneLayoutReady(false);
-            setActiveCardSetId(nextCardSet.id);
-            dispatch({ type: "new-shuffle", cardSet: nextCardSet });
-            setViewZoom(1);
-          }}
-        >
-          {cardSets.map((cardSet) => (
-            <option key={cardSet.id} value={cardSet.id}>
-              {cardSet.label}
-            </option>
-          ))}
-        </select>
-        <span>
-          {deckCount} {deckCardNoun} in the deck
-        </span>
-      </div>
-
-      {isDeckMoveMode && (
-        <div className="tarot-mode-hint" role="status">
-          <span>Drag the deck to reposition it</span>
+      <nav className="tarot-toolbar" aria-label="Table actions">
+        <div className="tarot-deck-menu" ref={deckMenuRef}>
           <button
+            ref={deckMenuTriggerRef}
             type="button"
+            className="tarot-toolbar-trigger tarot-deck-trigger"
+            aria-label={`Choose deck. ${activeCardSet.label}, ${deckCount} ${deckCardNoun} remaining`}
+            aria-controls="deck-actions"
+            aria-expanded={isDeckMenuOpen}
+            aria-haspopup="dialog"
             onClick={() => {
-              setIsDeckMoveMode(false);
-              canvasShellRef.current?.focus();
+              const willOpen = !isDeckMenuOpen;
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsShuffleMenuOpen(false);
+              if (selectedCard?.zone === "table") {
+                setIsInspectorCollapsed(true);
+              }
+              setIsDeckMenuOpen(willOpen);
             }}
           >
-            Cancel
-          </button>
-        </div>
-      )}
-
-      {selectedCard?.zone === "table" &&
-        (isInspectorCollapsed ? (
-          <button
-            ref={inspectorToggleRef}
-            type="button"
-            className="tarot-inspector-toggle"
-            aria-label={`Expand selected card controls for ${selectedTitle}`}
-            aria-expanded="false"
-            onClick={expandInspector}
-          >
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="5" y="3.5" width="14" height="17" rx="1.5" />
-              <path d="m12 7 .8 2.1 2.2.1-1.7 1.4.6 2.2-1.9-1.2-1.9 1.2.6-2.2-1.7-1.4 2.2-.1L12 7Z" />
+              <rect x="5" y="6" width="12" height="14" rx="1.5" />
+              <path d="M8 3.8h10.2a1.8 1.8 0 0 1 1.8 1.8V17" />
+              <path d="m11 10 .7 1.7 1.8.1-1.4 1.2.5 1.8-1.6-1-1.6 1 .5-1.8-1.4-1.2 1.8-.1L11 10Z" />
+            </svg>
+            <span>Deck</span>
+            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m8 10 4 4 4-4" />
             </svg>
           </button>
-        ) : (
-          <aside
-            id="selected-card-inspector"
-            className="tarot-inspector"
-            aria-live="polite"
-          >
-            <div className="tarot-inspector-heading">
-              <p className="tarot-eyebrow">Selected card</p>
-              <button
-                ref={inspectorCollapseRef}
-                type="button"
-                className="tarot-inspector-collapse"
-                aria-label="Collapse selected card controls"
-                aria-expanded="true"
-                onClick={collapseInspector}
-              >
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="m7 10 5 5 5-5" />
-                </svg>
-              </button>
-            </div>
-            <h2>{selectedTitle}</h2>
-            <p>{selectedHint}</p>
-            <div className="tarot-card-browser">
-              <label htmlFor="drawn-card">Browse cards on the table</label>
+          {isDeckMenuOpen && (
+            <div
+              id="deck-actions"
+              className="tarot-set-picker"
+              role="dialog"
+              aria-label="Choose deck"
+            >
+              <label htmlFor="card-set">Deck</label>
               <select
-                id="drawn-card"
-                name="drawn-card"
+                id="card-set"
+                name="card-set"
                 autoComplete="off"
-                value={session.selectedCardId ?? ""}
-                disabled={tableCards.length === 0}
-                onChange={(event) =>
-                  dispatch({ type: "select", cardId: event.target.value || null })
-                }
+                value={activeCardSetId}
+                onChange={(event) => {
+                  const nextCardSet = getCardSet(event.target.value);
+                  activeSpreadRef.current = null;
+                  setIsDeckMoveMode(false);
+                  setIsSceneLayoutReady(false);
+                  setActiveCardSetId(nextCardSet.id);
+                  dispatch({ type: "new-shuffle", cardSet: nextCardSet });
+                  setViewZoom(1);
+                  setIsDeckMenuOpen(false);
+                  window.requestAnimationFrame(() =>
+                    deckMenuTriggerRef.current?.focus()
+                  );
+                }}
               >
-                <option value="">Select a drawn card</option>
-                {tableCards.map((card, index) => {
-                  const definition = activeCardSet.cards.find(
-                    (candidate) => candidate.id === card.cardId
-                  );
-
-                  return (
-                    <option key={card.id} value={card.id}>
-                      {card.faceUp
-                        ? definition?.name ?? `Card ${index + 1}`
-                        : `Face-down card ${index + 1}`}
-                    </option>
-                  );
-                })}
+                {cardSets.map((cardSet) => (
+                  <option key={cardSet.id} value={cardSet.id}>
+                    {cardSet.label}
+                  </option>
+                ))}
               </select>
+              <span>
+                {deckCount} {deckCardNoun} in the deck
+              </span>
             </div>
-            <div className="tarot-inspector-actions">
-              <button type="button" onClick={flipSelected}>
-                Flip <Shortcut>F</Shortcut>
-              </button>
-              <button type="button" onClick={() => turnSelected(-15)}>
-                Turn −15° <Shortcut>[</Shortcut>
-              </button>
-              <button type="button" onClick={() => turnSelected(15)}>
-                Turn +15° <Shortcut>]</Shortcut>
-              </button>
-              <button type="button" onClick={() => turnSelected(180)}>
-                Reverse <Shortcut>R</Shortcut>
-              </button>
-              <button
-                type="button"
-                onClick={() => reorderSelected("backward")}
-                disabled={!canSendBackward}
-              >
-                Send back <Shortcut>Pg↓</Shortcut>
-              </button>
-              <button
-                type="button"
-                onClick={() => reorderSelected("forward")}
-                disabled={!canBringForward}
-              >
-                Bring forward <Shortcut>Pg↑</Shortcut>
-              </button>
-            </div>
-          </aside>
-        ))}
-
-      <nav className="tarot-toolbar" aria-label="Table actions">
+          )}
+        </div>
         <div className="tarot-zoom-controls" aria-label="Table zoom">
           <button
             type="button"
@@ -781,18 +701,220 @@ export function TarotStudio() {
             +
           </button>
         </div>
+        {isDeckMoveMode && (
+          <button
+            type="button"
+            className="tarot-mode-cancel"
+            aria-label="Cancel deck move mode"
+            onClick={() => {
+              setIsDeckMoveMode(false);
+              canvasShellRef.current?.focus();
+            }}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6.5 12.5V8.8a1.4 1.4 0 0 1 2.8 0v2.4-5a1.4 1.4 0 0 1 2.8 0v4.5-3a1.4 1.4 0 0 1 2.8 0v3.6-2a1.4 1.4 0 0 1 2.8 0v5.2c0 3.6-2.2 5.5-5.7 5.5h-.7c-2.4 0-3.7-1.2-5.2-3.2L4.5 14a1.35 1.35 0 0 1 2-1.8l1.7 1.6" />
+            </svg>
+            <span className="tarot-mode-cancel-label">Moving deck</span>
+            <span>Cancel</span>
+          </button>
+        )}
+        {selectedCard?.zone === "table" && !isDeckMoveMode && (
+          <div className="tarot-card-menu">
+            <button
+              ref={inspectorToggleRef}
+              type="button"
+              className="tarot-toolbar-trigger tarot-card-trigger"
+              aria-label={`${isInspectorCollapsed ? "Open" : "Close"} selected card controls for ${selectedTitle}`}
+              aria-controls="selected-card-inspector"
+              aria-expanded={!isInspectorCollapsed}
+              onClick={() => {
+                setIsDeckMenuOpen(false);
+                setIsSpreadMenuOpen(false);
+                setIsArrangeMenuOpen(false);
+                setIsShuffleMenuOpen(false);
+                if (isInspectorCollapsed) {
+                  expandInspector();
+                } else {
+                  collapseInspector();
+                }
+              }}
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="5" y="3.5" width="14" height="17" rx="1.5" />
+                <path d="m12 7 .8 2.1 2.2.1-1.7 1.4.6 2.2-1.9-1.2-1.9 1.2.6-2.2-1.7-1.4 2.2-.1L12 7Z" />
+              </svg>
+              <span>Card</span>
+              <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="m8 10 4 4 4-4" />
+              </svg>
+            </button>
+            {!isInspectorCollapsed && (
+              <aside
+                id="selected-card-inspector"
+                className="tarot-inspector"
+                aria-label={`Selected card controls for ${selectedTitle}`}
+              >
+                <div className="tarot-inspector-heading">
+                  <p className="tarot-eyebrow">Selected card</p>
+                  <button
+                    ref={inspectorCollapseRef}
+                    type="button"
+                    className="tarot-inspector-collapse"
+                    aria-label="Collapse selected card controls"
+                    aria-expanded="true"
+                    onClick={collapseInspector}
+                  >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="m7 10 5 5 5-5" />
+                    </svg>
+                  </button>
+                </div>
+                <h2>{selectedTitle}</h2>
+                <p>{selectedHint}</p>
+                <div className="tarot-card-browser">
+                  <label htmlFor="drawn-card">Browse cards on the table</label>
+                  <select
+                    id="drawn-card"
+                    name="drawn-card"
+                    autoComplete="off"
+                    value={session.selectedCardId ?? ""}
+                    disabled={tableCards.length === 0}
+                    onChange={(event) =>
+                      dispatch({
+                        type: "select",
+                        cardId: event.target.value || null,
+                      })
+                    }
+                  >
+                    <option value="">Select a drawn card</option>
+                    {tableCards.map((card, index) => {
+                      const definition = activeCardSet.cards.find(
+                        (candidate) => candidate.id === card.cardId
+                      );
+
+                      return (
+                        <option key={card.id} value={card.id}>
+                          {card.faceUp
+                            ? definition?.name ?? `Card ${index + 1}`
+                            : `Face-down card ${index + 1}`}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+                <div className="tarot-inspector-actions">
+                  <button type="button" onClick={flipSelected}>
+                    Flip <Shortcut>F</Shortcut>
+                  </button>
+                  <button type="button" onClick={() => turnSelected(-15)}>
+                    Turn −15° <Shortcut>[</Shortcut>
+                  </button>
+                  <button type="button" onClick={() => turnSelected(15)}>
+                    Turn +15° <Shortcut>]</Shortcut>
+                  </button>
+                  <button type="button" onClick={() => turnSelected(180)}>
+                    Reverse <Shortcut>R</Shortcut>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => reorderSelected("backward")}
+                    disabled={!canSendBackward}
+                  >
+                    Send back <Shortcut>Pg↓</Shortcut>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => reorderSelected("forward")}
+                    disabled={!canBringForward}
+                  >
+                    Bring forward <Shortcut>Pg↑</Shortcut>
+                  </button>
+                </div>
+              </aside>
+            )}
+          </div>
+        )}
+        {activeCardSet.kind === "tarot" &&
+          tableCards.length === 0 &&
+          !isDeckMoveMode && (
+            <div className="tarot-spread-menu" ref={spreadMenuRef}>
+              <button
+                ref={spreadMenuTriggerRef}
+                type="button"
+                className="tarot-toolbar-trigger tarot-spread-trigger"
+                aria-label="Choose a tarot spread"
+                aria-controls="spread-actions"
+                aria-expanded={isSpreadMenuOpen}
+                aria-haspopup="dialog"
+                onClick={() => {
+                  const willOpen = !isSpreadMenuOpen;
+                  setIsDeckMenuOpen(false);
+                  setIsArrangeMenuOpen(false);
+                  setIsShuffleMenuOpen(false);
+                  setIsSpreadMenuOpen(willOpen);
+                }}
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3.5" y="8" width="5" height="8" rx="1" />
+                  <rect x="9.5" y="5" width="5" height="11" rx="1" />
+                  <rect x="15.5" y="8" width="5" height="8" rx="1" />
+                </svg>
+                <span>Spreads</span>
+                <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m8 10 4 4 4-4" />
+                </svg>
+              </button>
+              {isSpreadMenuOpen && (
+                <section
+                  id="spread-actions"
+                  className="tarot-spread-actions"
+                  role="dialog"
+                  aria-label="Popular tarot spreads"
+                >
+                  <span>Choose a spread</span>
+                  <div>
+                    {popularTarotSpreads.map((spread) => (
+                      <button
+                        key={spread.id}
+                        type="button"
+                        onClick={() => {
+                          dealSpread(spread);
+                          setIsSpreadMenuOpen(false);
+                          window.requestAnimationFrame(() =>
+                            canvasShellRef.current?.focus()
+                          );
+                        }}
+                        disabled={
+                          !isSceneLayoutReady || deckCount < spread.slots.length
+                        }
+                      >
+                        {spread.label}
+                        <small>{spread.shortLabel}</small>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              )}
+            </div>
+          )}
         <div className="tarot-arrange-menu" ref={arrangeMenuRef}>
           <button
             ref={arrangeMenuTriggerRef}
             type="button"
-            className="tarot-arrange-trigger"
+            className="tarot-toolbar-trigger tarot-arrange-trigger"
             aria-label="Arrange cards and undo"
             aria-controls="arrange-actions"
             aria-expanded={isArrangeMenuOpen}
             aria-haspopup="dialog"
             onClick={() => {
+              const willOpen = !isArrangeMenuOpen;
+              setIsDeckMenuOpen(false);
+              setIsSpreadMenuOpen(false);
               setIsShuffleMenuOpen(false);
-              setIsArrangeMenuOpen((isOpen) => !isOpen);
+              if (selectedCard?.zone === "table") {
+                setIsInspectorCollapsed(true);
+              }
+              setIsArrangeMenuOpen(willOpen);
             }}
             disabled={
               !topDeckCard && !tableCards.length && !session.history.length
@@ -845,6 +967,9 @@ export function TarotStudio() {
                   type="button"
                   onClick={() => {
                     dispatch({ type: "select", cardId: null });
+                    setIsDeckMenuOpen(false);
+                    setIsSpreadMenuOpen(false);
+                    setIsShuffleMenuOpen(false);
                     setIsDeckMoveMode(true);
                     setIsArrangeMenuOpen(false);
                     window.requestAnimationFrame(() =>
@@ -875,14 +1000,20 @@ export function TarotStudio() {
           <button
             ref={shuffleMenuTriggerRef}
             type="button"
-            className="tarot-shuffle-trigger"
+            className="tarot-toolbar-trigger tarot-shuffle-trigger"
             aria-label="Shuffle"
             aria-controls="shuffle-actions"
             aria-expanded={isShuffleMenuOpen}
             aria-haspopup="dialog"
             onClick={() => {
+              const willOpen = !isShuffleMenuOpen;
+              setIsDeckMenuOpen(false);
+              setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
-              setIsShuffleMenuOpen((isOpen) => !isOpen);
+              if (selectedCard?.zone === "table") {
+                setIsInspectorCollapsed(true);
+              }
+              setIsShuffleMenuOpen(willOpen);
             }}
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -99,6 +99,23 @@ function useDockPopover({
     const closeOnOutsidePress = (event: PointerEvent) => {
       if (!containerRef.current?.contains(event.target as Node)) {
         setIsOpen(false);
+
+        const target = event.target;
+
+        if (target instanceof HTMLElement) {
+          const tableRegion = target.closest<HTMLElement>(
+            ".tarot-canvas-shell"
+          );
+          const isFocusableControl = target.closest(
+            "button, select, input, textarea, a[href], [tabindex]"
+          );
+
+          if (tableRegion) {
+            window.requestAnimationFrame(() => tableRegion.focus());
+          } else if (!isFocusableControl) {
+            window.requestAnimationFrame(() => triggerRef.current?.focus());
+          }
+        }
       }
     };
     const closeOnEscape = (event: globalThis.KeyboardEvent) => {

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -539,9 +539,11 @@ export function TarotStudio() {
       )}
 
       <div className="tarot-set-picker">
-        <label htmlFor="card-set">Card set</label>
+        <label htmlFor="card-set">Deck</label>
         <select
           id="card-set"
+          name="card-set"
+          autoComplete="off"
           value={activeCardSetId}
           onChange={(event) => {
             const nextCardSet = getCardSet(event.target.value);
@@ -603,6 +605,8 @@ export function TarotStudio() {
               <label htmlFor="drawn-card">Browse cards on the table</label>
               <select
                 id="drawn-card"
+                name="drawn-card"
+                autoComplete="off"
                 value={session.selectedCardId ?? ""}
                 disabled={tableCards.length === 0}
                 onChange={(event) =>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -17,6 +17,11 @@ import {
 } from "react";
 import { cardSets, getCardSet } from "@/data/card-sets";
 import {
+  createCardSoundEngine,
+  type CardSoundEvent,
+  type CardSoundPlayOptions,
+} from "@/lib/card-sounds";
+import {
   createLayout,
   createTarotSession,
   getRemainingDeckCount,
@@ -42,6 +47,9 @@ import {
 
 const WHEEL_LAYER_COOLDOWN = 110;
 const WHEEL_LAYER_THRESHOLD = 36;
+const DOCK_EDGE_REVEAL_DISTANCE = 52;
+const DOCK_HIDE_DELAY = 850;
+const DOCK_INITIAL_HIDE_DELAY = 1800;
 
 const TarotScene = dynamic(
   () => import("./TarotScene").then((module) => module.TarotScene),
@@ -65,6 +73,201 @@ function useReducedMotionPreference() {
   }, []);
 
   return reducedMotion;
+}
+
+function useCardSounds() {
+  const engineRef = useRef<ReturnType<typeof createCardSoundEngine> | null>(
+    null
+  );
+  const [isMuted, setIsMuted] = useState(false);
+
+  useEffect(() => {
+    const engine = createCardSoundEngine();
+    engineRef.current = engine;
+    setIsMuted(engine.getMuted());
+
+    return () => {
+      engine.dispose();
+
+      if (engineRef.current === engine) {
+        engineRef.current = null;
+      }
+    };
+  }, []);
+
+  const play = useCallback(
+    (event: CardSoundEvent, options?: CardSoundPlayOptions) => {
+      engineRef.current?.play(event, options);
+    },
+    []
+  );
+  const toggle = useCallback(() => {
+    const engine = engineRef.current;
+
+    if (!engine) {
+      return;
+    }
+
+    setIsMuted(engine.toggleMuted());
+  }, []);
+
+  return { isMuted, play, toggle };
+}
+
+function useAutoHidingDock(
+  isPinned: boolean,
+  fallbackFocusRef: RefObject<HTMLElement | null>
+) {
+  const dockRef = useRef<HTMLElement>(null);
+  const hideTimerRef = useRef<number | null>(null);
+  const finePointerRef = useRef(false);
+  const keyboardFocusRef = useRef(true);
+  const pointerInsideRef = useRef(false);
+  const pinnedRef = useRef(isPinned);
+  const [isVisible, setIsVisible] = useState(true);
+
+  const clearHideTimer = useCallback(() => {
+    if (hideTimerRef.current === null) {
+      return;
+    }
+
+    window.clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = null;
+  }, []);
+  const showDock = useCallback(() => {
+    clearHideTimer();
+    setIsVisible(true);
+  }, [clearHideTimer]);
+  const scheduleHide = useCallback(
+    (delay = DOCK_HIDE_DELAY) => {
+      if (
+        !finePointerRef.current ||
+        pinnedRef.current ||
+        pointerInsideRef.current ||
+        hideTimerRef.current !== null
+      ) {
+        return;
+      }
+
+      hideTimerRef.current = window.setTimeout(() => {
+        hideTimerRef.current = null;
+        const dock = dockRef.current;
+
+        if (
+          !finePointerRef.current ||
+          pinnedRef.current ||
+          pointerInsideRef.current
+        ) {
+          return;
+        }
+
+        if (dock?.contains(document.activeElement)) {
+          if (keyboardFocusRef.current) {
+            return;
+          }
+
+          fallbackFocusRef.current?.focus({ preventScroll: true });
+        }
+
+        setIsVisible(false);
+      }, delay);
+    },
+    [fallbackFocusRef]
+  );
+
+  useEffect(() => {
+    pinnedRef.current = isPinned;
+
+    if (isPinned) {
+      showDock();
+    } else {
+      scheduleHide();
+    }
+  }, [isPinned, scheduleHide, showDock]);
+
+  useEffect(() => {
+    const finePointer = window.matchMedia(
+      "(min-width: 768px) and (hover: hover) and (pointer: fine)"
+    );
+    const updatePointerMode = () => {
+      finePointerRef.current = finePointer.matches;
+
+      if (finePointer.matches) {
+        scheduleHide(DOCK_INITIAL_HIDE_DELAY);
+      } else {
+        showDock();
+      }
+    };
+    const revealFromBottomEdge = (event: PointerEvent) => {
+      if (!finePointerRef.current || event.pointerType !== "mouse") {
+        return;
+      }
+
+      keyboardFocusRef.current = false;
+
+      if (event.clientY >= window.innerHeight - DOCK_EDGE_REVEAL_DISTANCE) {
+        showDock();
+      } else {
+        scheduleHide();
+      }
+    };
+    const noteKeyboardUse = (event: globalThis.KeyboardEvent) => {
+      if (
+        event.key === "Tab" ||
+        dockRef.current?.contains(document.activeElement)
+      ) {
+        keyboardFocusRef.current = true;
+      }
+    };
+
+    updatePointerMode();
+    finePointer.addEventListener("change", updatePointerMode);
+    document.addEventListener("keydown", noteKeyboardUse, true);
+    document.addEventListener("pointermove", revealFromBottomEdge, {
+      capture: true,
+      passive: true,
+    });
+
+    return () => {
+      clearHideTimer();
+      finePointer.removeEventListener("change", updatePointerMode);
+      document.removeEventListener("keydown", noteKeyboardUse, true);
+      document.removeEventListener("pointermove", revealFromBottomEdge, true);
+    };
+  }, [clearHideTimer, scheduleHide, showDock]);
+
+  const onPointerEnter = useCallback(() => {
+    pointerInsideRef.current = true;
+    showDock();
+  }, [showDock]);
+  const onPointerLeave = useCallback(() => {
+    pointerInsideRef.current = false;
+    scheduleHide();
+  }, [scheduleHide]);
+  const onPointerDown = useCallback(() => {
+    keyboardFocusRef.current = false;
+    showDock();
+  }, [showDock]);
+  const onFocus = useCallback(() => {
+    showDock();
+  }, [showDock]);
+  const onBlur = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      if (!dockRef.current?.contains(document.activeElement)) {
+        scheduleHide();
+      }
+    });
+  }, [scheduleHide]);
+
+  return {
+    dockRef,
+    isVisible,
+    onBlur,
+    onFocus,
+    onPointerDown,
+    onPointerEnter,
+    onPointerLeave,
+  };
 }
 
 function Shortcut({ children }: { children: ReactNode }) {
@@ -179,6 +382,11 @@ export function TarotStudio() {
     createTarotSession
   );
   const reducedMotion = useReducedMotionPreference();
+  const {
+    isMuted: areCardSoundsMuted,
+    play: playCardSound,
+    toggle: toggleCardSounds,
+  } = useCardSounds();
   const tableCards = getTableCards(session);
   const topDeckCard = getTopDeckCard(session);
   const selectedCard = session.cards.find(
@@ -193,6 +401,23 @@ export function TarotStudio() {
   const hasSelectedTableCard = selectedCard?.zone === "table";
   const isInspectorOpen =
     hasSelectedTableCard && !isInspectorCollapsed && !isDeckMoveMode;
+  const isDockPinned =
+    isDeckMenuOpen ||
+    isZoomMenuOpen ||
+    isSpreadMenuOpen ||
+    isArrangeMenuOpen ||
+    isShuffleMenuOpen ||
+    isInspectorOpen ||
+    isDeckMoveMode;
+  const {
+    dockRef,
+    isVisible: isDockVisible,
+    onBlur: handleDockBlur,
+    onFocus: handleDockFocus,
+    onPointerDown: handleDockPointerDown,
+    onPointerEnter: handleDockPointerEnter,
+    onPointerLeave: handleDockPointerLeave,
+  } = useAutoHidingDock(isDockPinned, canvasShellRef);
   const canSendBackward = selectedTableIndex > 0;
   const canBringForward =
     selectedTableIndex >= 0 && selectedTableIndex < tableCards.length - 1;
@@ -301,8 +526,9 @@ export function TarotStudio() {
     }
 
     activeSpreadRef.current = null;
+    playCardSound("draw");
     dispatch({ type: "draw", cardId: topDeckCard.id, position: [0.3, 0] });
-  }, [topDeckCard]);
+  }, [playCardSound, topDeckCard]);
 
   const arrangeCards = useCallback(
     (layout: TableLayout) => {
@@ -311,12 +537,13 @@ export function TarotStudio() {
       }
 
       activeSpreadRef.current = null;
+      playCardSound("arrange");
       dispatch({
         type: "layout",
         placements: createLayout(tableCards, activeCardSet, layout),
       });
     },
-    [activeCardSet, tableCards]
+    [activeCardSet, playCardSound, tableCards]
   );
 
   const dealSpread = useCallback(
@@ -330,6 +557,7 @@ export function TarotStudio() {
       const presentation = getSpreadPresentation(spread, layout);
       activeSpreadRef.current = spread;
       setViewZoom(presentation.zoom);
+      playCardSound("arrange");
 
       dispatch({
         type: "deal-spread",
@@ -337,29 +565,32 @@ export function TarotStudio() {
         deckPosition: presentation.deckPosition,
       });
     },
-    []
+    [playCardSound]
   );
 
   const flipSelected = useCallback(() => {
     if (selectedCard?.zone === "table") {
+      playCardSound("flip");
       dispatch({ type: "flip", cardId: selectedCard.id });
     }
-  }, [selectedCard]);
+  }, [playCardSound, selectedCard]);
 
   const turnSelected = useCallback((degrees: number) => {
     if (selectedCard?.zone === "table") {
       activeSpreadRef.current = null;
+      playCardSound("rotate");
       dispatch({ type: "rotate", cardId: selectedCard.id, degrees });
     }
-  }, [selectedCard]);
+  }, [playCardSound, selectedCard]);
 
   const reorderSelected = useCallback(
     (direction: CardLayerDirection) => {
       if (selectedCard?.zone === "table") {
+        playCardSound("move", { intensity: 0.7 });
         dispatch({ type: "reorder", cardId: selectedCard.id, direction });
       }
     },
-    [selectedCard]
+    [playCardSound, selectedCard]
   );
 
   const handleLayoutChange = useCallback((layout: SceneTableLayout) => {
@@ -385,33 +616,38 @@ export function TarotStudio() {
   const handleDraw = useCallback(
     (cardId: string, position: TablePoint, rotation?: number) => {
       activeSpreadRef.current = null;
+      playCardSound("draw");
       dispatch({ type: "draw", cardId, position, rotation });
     },
-    []
+    [playCardSound]
   );
 
   const handleMoveDeck = useCallback((position: TablePoint) => {
     activeSpreadRef.current = null;
     setIsDeckMoveMode(false);
+    playCardSound("drop");
     dispatch({ type: "move-deck", position });
-  }, []);
+  }, [playCardSound]);
 
   const handleMove = useCallback(
     (cardId: string, position: TablePoint, rotation?: number) => {
       activeSpreadRef.current = null;
+      playCardSound("drop");
       dispatch({ type: "move", cardId, position, rotation });
     },
-    []
+    [playCardSound]
   );
 
   const handleFlip = useCallback((cardId: string) => {
+    playCardSound("flip");
     dispatch({ type: "flip", cardId });
-  }, []);
+  }, [playCardSound]);
 
   const handleRotate = useCallback((cardId: string, degrees: number) => {
     activeSpreadRef.current = null;
+    playCardSound("rotate");
     dispatch({ type: "rotate", cardId, degrees });
-  }, []);
+  }, [playCardSound]);
 
   const handleHover = useCallback((cardId: string | null) => {
     hoveredCardIdRef.current = cardId;
@@ -429,8 +665,9 @@ export function TarotStudio() {
       setViewZoom(1);
     }
 
+    playCardSound("arrange");
     dispatch({ type: "undo" });
-  }, [session.history]);
+  }, [playCardSound, session.history]);
 
   const adjustViewZoom = useCallback((delta: number) => {
     setViewZoom((current) =>
@@ -474,13 +711,14 @@ export function TarotStudio() {
         wheel.accumulatedDelta < 0 ? "forward" : "backward";
       wheel.accumulatedDelta = 0;
       wheel.lastChangeAt = event.timeStamp;
+      playCardSound("move", { intensity: 0.65 });
       dispatch({
         type: "reorder",
         cardId: hoveredCardId,
         direction: layerDirection,
       });
     },
-    []
+    [playCardSound]
   );
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -568,6 +806,7 @@ export function TarotStudio() {
     if (nudge && selectedCard?.zone === "table") {
       event.preventDefault();
       activeSpreadRef.current = null;
+      playCardSound("move", { intensity: 0.6 });
       dispatch({
         type: "nudge",
         cardId: selectedCard.id,
@@ -631,10 +870,23 @@ export function TarotStudio() {
           onFlip={handleFlip}
           onRotate={handleRotate}
           onHover={handleHover}
+          onSound={playCardSound}
         />
       </div>
 
-      <nav className="tarot-toolbar" aria-label="Table actions">
+      <nav
+        ref={dockRef}
+        className="tarot-toolbar"
+        aria-label="Table actions"
+        data-dock-state={
+          isDockVisible || isDockPinned ? "visible" : "hidden"
+        }
+        onPointerEnter={handleDockPointerEnter}
+        onPointerLeave={handleDockPointerLeave}
+        onPointerDownCapture={handleDockPointerDown}
+        onFocusCapture={handleDockFocus}
+        onBlurCapture={handleDockBlur}
+      >
         <div className="tarot-deck-menu" ref={deckMenuRef}>
           <button
             ref={deckMenuTriggerRef}
@@ -685,6 +937,7 @@ export function TarotStudio() {
                   setIsDeckMoveMode(false);
                   setIsSceneLayoutReady(false);
                   setActiveCardSetId(nextCardSet.id);
+                  playCardSound("shuffle");
                   dispatch({ type: "new-shuffle", cardSet: nextCardSet });
                   setViewZoom(1);
                   setIsDeckMenuOpen(false);
@@ -990,6 +1243,7 @@ export function TarotStudio() {
                 onClick={() => {
                   activeSpreadRef.current = null;
                   setIsDeckMoveMode(false);
+                  playCardSound("shuffle");
                   dispatch({ type: "new-shuffle", cardSet: activeCardSet });
                   closeShuffleMenu();
                   setViewZoom(1);
@@ -1001,6 +1255,24 @@ export function TarotStudio() {
             </div>
           )}
         </div>
+        <button
+          type="button"
+          className="tarot-toolbar-trigger tarot-sound-toggle"
+          aria-label="Card sounds"
+          aria-pressed={!areCardSoundsMuted}
+          title={areCardSoundsMuted ? "Card sounds off" : "Card sounds on"}
+          onClick={toggleCardSounds}
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M5 10h3.2L13 6.2v11.6L8.2 14H5z" />
+            {areCardSoundsMuted ? (
+              <path d="m16.5 9.2 4.3 5.6m0-5.6-4.3 5.6" />
+            ) : (
+              <path d="M16.5 9.2a4 4 0 0 1 0 5.6M18.8 7a7 7 0 0 1 0 10" />
+            )}
+          </svg>
+          <span>Sound</span>
+        </button>
         <div className="tarot-card-menu">
           <button
             ref={inspectorToggleRef}
@@ -1067,12 +1339,14 @@ export function TarotStudio() {
                   autoComplete="off"
                   value={session.selectedCardId ?? ""}
                   disabled={tableCards.length === 0}
-                  onChange={(event) =>
-                    dispatch({
-                      type: "select",
-                      cardId: event.target.value || null,
-                    })
-                  }
+                  onChange={(event) => {
+                    const cardId = event.target.value || null;
+
+                    if (cardId) {
+                      playCardSound("pickup", { intensity: 0.7 });
+                    }
+                    handleSelect(cardId);
+                  }}
                 >
                   <option value="">Select a drawn card</option>
                   {tableCards.map((card, index) => {

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -30,7 +30,7 @@ import {
   loadTarotWorkspace,
   saveTarotWorkspace,
 } from "@/lib/tarot-workspace";
-import type { CardLayerDirection, TableLayout } from "@/types";
+import type { CardLayerDirection, TableLayout, TablePoint } from "@/types";
 import {
   MAX_VIEW_ZOOM,
   MIN_VIEW_ZOOM,
@@ -69,6 +69,7 @@ function Shortcut({ children }: { children: ReactNode }) {
 }
 
 export function TarotStudio() {
+  const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
   const activeSpreadRef = useRef<TarotSpread | null>(null);
@@ -76,6 +77,8 @@ export function TarotStudio() {
   const arrangeMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const shuffleMenuRef = useRef<HTMLDivElement>(null);
   const shuffleMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const inspectorCollapseRef = useRef<HTMLButtonElement>(null);
+  const inspectorToggleRef = useRef<HTMLButtonElement>(null);
   const layerWheelRef = useRef({
     accumulatedDelta: 0,
     direction: 0,
@@ -86,6 +89,7 @@ export function TarotStudio() {
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
   const [isShuffleMenuOpen, setIsShuffleMenuOpen] = useState(false);
   const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(false);
+  const [isDeckMoveMode, setIsDeckMoveMode] = useState(false);
   const [isSceneLayoutReady, setIsSceneLayoutReady] = useState(false);
   const [isWorkspaceReady, setIsWorkspaceReady] = useState(false);
   const activeCardSet = useMemo(
@@ -159,6 +163,14 @@ export function TarotStudio() {
       return;
     }
 
+    const focusTimer = window.requestAnimationFrame(() => {
+      arrangeMenuRef.current
+        ?.querySelector<HTMLButtonElement>(
+          "[role='dialog'] button:not(:disabled)"
+        )
+        ?.focus();
+    });
+
     const closeOnOutsidePress = (event: PointerEvent) => {
       if (!arrangeMenuRef.current?.contains(event.target as Node)) {
         setIsArrangeMenuOpen(false);
@@ -175,6 +187,7 @@ export function TarotStudio() {
     document.addEventListener("keydown", closeOnEscape);
 
     return () => {
+      window.cancelAnimationFrame(focusTimer);
       document.removeEventListener("pointerdown", closeOnOutsidePress);
       document.removeEventListener("keydown", closeOnEscape);
     };
@@ -184,6 +197,14 @@ export function TarotStudio() {
     if (!isShuffleMenuOpen) {
       return;
     }
+
+    const focusTimer = window.requestAnimationFrame(() => {
+      shuffleMenuRef.current
+        ?.querySelector<HTMLButtonElement>(
+          "[role='dialog'] button:not(:disabled)"
+        )
+        ?.focus();
+    });
 
     const closeOnOutsidePress = (event: PointerEvent) => {
       if (!shuffleMenuRef.current?.contains(event.target as Node)) {
@@ -201,6 +222,7 @@ export function TarotStudio() {
     document.addEventListener("keydown", closeOnEscape);
 
     return () => {
+      window.cancelAnimationFrame(focusTimer);
       document.removeEventListener("pointerdown", closeOnOutsidePress);
       document.removeEventListener("keydown", closeOnEscape);
     };
@@ -211,6 +233,26 @@ export function TarotStudio() {
       setIsInspectorCollapsed(false);
     }
   }, [selectedCard?.zone]);
+
+  const collapseInspector = useCallback(() => {
+    setIsInspectorCollapsed(true);
+    window.requestAnimationFrame(() => inspectorToggleRef.current?.focus());
+  }, []);
+
+  const expandInspector = useCallback(() => {
+    setIsInspectorCollapsed(false);
+    window.requestAnimationFrame(() => inspectorCollapseRef.current?.focus());
+  }, []);
+
+  const closeArrangeMenu = useCallback(() => {
+    setIsArrangeMenuOpen(false);
+    window.requestAnimationFrame(() => arrangeMenuTriggerRef.current?.focus());
+  }, []);
+
+  const closeShuffleMenu = useCallback(() => {
+    setIsShuffleMenuOpen(false);
+    window.requestAnimationFrame(() => shuffleMenuTriggerRef.current?.focus());
+  }, []);
 
   const drawCard = useCallback(() => {
     if (!topDeckCard) {
@@ -295,6 +337,45 @@ export function TarotStudio() {
     }
   }, []);
 
+  const handleSelect = useCallback((cardId: string | null) => {
+    dispatch({ type: "select", cardId });
+  }, []);
+
+  const handleDraw = useCallback(
+    (cardId: string, position: TablePoint, rotation?: number) => {
+      activeSpreadRef.current = null;
+      dispatch({ type: "draw", cardId, position, rotation });
+    },
+    []
+  );
+
+  const handleMoveDeck = useCallback((position: TablePoint) => {
+    activeSpreadRef.current = null;
+    setIsDeckMoveMode(false);
+    dispatch({ type: "move-deck", position });
+  }, []);
+
+  const handleMove = useCallback(
+    (cardId: string, position: TablePoint, rotation?: number) => {
+      activeSpreadRef.current = null;
+      dispatch({ type: "move", cardId, position, rotation });
+    },
+    []
+  );
+
+  const handleFlip = useCallback((cardId: string) => {
+    dispatch({ type: "flip", cardId });
+  }, []);
+
+  const handleRotate = useCallback((cardId: string, degrees: number) => {
+    activeSpreadRef.current = null;
+    dispatch({ type: "rotate", cardId, degrees });
+  }, []);
+
+  const handleHover = useCallback((cardId: string | null) => {
+    hoveredCardIdRef.current = cardId;
+  }, []);
+
   const undoLastAction = useCallback(() => {
     const previous = session.history[session.history.length - 1];
 
@@ -369,6 +450,11 @@ export function TarotStudio() {
     }
 
     const key = event.key.toLowerCase();
+
+    if (key === "escape" && isDeckMoveMode) {
+      setIsDeckMoveMode(false);
+      return;
+    }
 
     if (key === "f" && selectedCard?.zone === "table") {
       event.preventDefault();
@@ -464,7 +550,7 @@ export function TarotStudio() {
   const selectedHint = selectedCard?.faceUp
     ? `${Math.abs(normalizedRotation - 180) < 0.8 ? "Reversed · " : normalizedRotation > 0.8 ? `Rotation ${Math.round(normalizedRotation)}° · ` : ""}${activeCardSet.kind === "lenormand" ? "Lenormand" : selectedDefinition?.arcana === "major" ? "Major Arcana" : "Minor Arcana"} · Layer ${selectedTableIndex + 1} of ${tableCards.length}`
     : selectedCard
-      ? `Face down · Layer ${selectedTableIndex + 1} of ${tableCards.length}. Scroll over it to restack.`
+      ? `Face down · Layer ${selectedTableIndex + 1} of ${tableCards.length}. Use the layer controls to restack.`
       : "Draw a card or tap one on the table.";
 
   if (!isWorkspaceReady) {
@@ -482,10 +568,11 @@ export function TarotStudio() {
     <main className="tarot-app">
       <div className="tarot-grain" aria-hidden="true" />
       <div
+        ref={canvasShellRef}
         className="tarot-canvas-shell"
         tabIndex={0}
         role="region"
-        aria-label="Interactive card table. Drag the top card to draw it, hold Control or Command while dragging to move the whole deck, drag table cards to arrange them, scroll over a card to change its layer, and drag near a selected card edge to rotate it."
+        aria-label="Interactive card table. Drag the top card to draw it, drag table cards to arrange them, use the card controls to flip, rotate, or change layers, and use Arrange to move the whole deck without keyboard modifiers."
         onKeyDown={handleKeyDown}
         onWheel={handleTableWheel}
       >
@@ -494,32 +581,21 @@ export function TarotStudio() {
           session={session}
           reducedMotion={reducedMotion}
           viewZoom={viewZoom}
+          deckMoveMode={isDeckMoveMode}
           onLayoutChange={handleLayoutChange}
-          onSelect={(cardId) => dispatch({ type: "select", cardId })}
-          onDraw={(cardId, position, rotation) => {
-            activeSpreadRef.current = null;
-            dispatch({ type: "draw", cardId, position, rotation });
-          }}
-          onMoveDeck={(position) => {
-            activeSpreadRef.current = null;
-            dispatch({ type: "move-deck", position });
-          }}
-          onMove={(cardId, position, rotation) => {
-            activeSpreadRef.current = null;
-            dispatch({ type: "move", cardId, position, rotation });
-          }}
-          onFlip={(cardId) => dispatch({ type: "flip", cardId })}
-          onRotate={(cardId, degrees) => {
-            activeSpreadRef.current = null;
-            dispatch({ type: "rotate", cardId, degrees });
-          }}
-          onHover={(cardId) => {
-            hoveredCardIdRef.current = cardId;
-          }}
+          onSelect={handleSelect}
+          onDraw={handleDraw}
+          onMoveDeck={handleMoveDeck}
+          onMove={handleMove}
+          onFlip={handleFlip}
+          onRotate={handleRotate}
+          onHover={handleHover}
         />
       </div>
 
-      {activeCardSet.kind === "tarot" && tableCards.length === 0 && (
+      {activeCardSet.kind === "tarot" &&
+        tableCards.length === 0 &&
+        !isDeckMoveMode && (
         <section className="tarot-spread-actions" aria-label="Popular tarot spreads">
           <span>Spreads</span>
           {popularTarotSpreads.map((spread) => (
@@ -548,6 +624,7 @@ export function TarotStudio() {
           onChange={(event) => {
             const nextCardSet = getCardSet(event.target.value);
             activeSpreadRef.current = null;
+            setIsDeckMoveMode(false);
             setIsSceneLayoutReady(false);
             setActiveCardSetId(nextCardSet.id);
             dispatch({ type: "new-shuffle", cardSet: nextCardSet });
@@ -565,14 +642,30 @@ export function TarotStudio() {
         </span>
       </div>
 
+      {isDeckMoveMode && (
+        <div className="tarot-mode-hint" role="status">
+          <span>Drag the deck to reposition it</span>
+          <button
+            type="button"
+            onClick={() => {
+              setIsDeckMoveMode(false);
+              canvasShellRef.current?.focus();
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
       {selectedCard?.zone === "table" &&
         (isInspectorCollapsed ? (
           <button
+            ref={inspectorToggleRef}
             type="button"
             className="tarot-inspector-toggle"
             aria-label={`Expand selected card controls for ${selectedTitle}`}
             aria-expanded="false"
-            onClick={() => setIsInspectorCollapsed(false)}
+            onClick={expandInspector}
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <rect x="5" y="3.5" width="14" height="17" rx="1.5" />
@@ -588,11 +681,12 @@ export function TarotStudio() {
             <div className="tarot-inspector-heading">
               <p className="tarot-eyebrow">Selected card</p>
               <button
+                ref={inspectorCollapseRef}
                 type="button"
                 className="tarot-inspector-collapse"
                 aria-label="Collapse selected card controls"
                 aria-expanded="true"
-                onClick={() => setIsInspectorCollapsed(true)}
+                onClick={collapseInspector}
               >
                 <svg viewBox="0 0 24 24" aria-hidden="true">
                   <path d="m7 10 5 5 5-5" />
@@ -700,7 +794,9 @@ export function TarotStudio() {
               setIsShuffleMenuOpen(false);
               setIsArrangeMenuOpen((isOpen) => !isOpen);
             }}
-            disabled={!tableCards.length && !session.history.length}
+            disabled={
+              !topDeckCard && !tableCards.length && !session.history.length
+            }
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M5 7.5h10v12H5zM9 4.5h10v12" />
@@ -737,7 +833,7 @@ export function TarotStudio() {
                     type="button"
                     onClick={() => {
                       arrangeCards(layout);
-                      setIsArrangeMenuOpen(false);
+                      closeArrangeMenu();
                     }}
                     disabled={!tableCards.length}
                   >
@@ -748,8 +844,23 @@ export function TarotStudio() {
                 <button
                   type="button"
                   onClick={() => {
-                    undoLastAction();
+                    dispatch({ type: "select", cardId: null });
+                    setIsDeckMoveMode(true);
                     setIsArrangeMenuOpen(false);
+                    window.requestAnimationFrame(() =>
+                      canvasShellRef.current?.focus()
+                    );
+                  }}
+                  disabled={!topDeckCard}
+                >
+                  <span>Move deck</span>
+                  <small>Then drag the pile</small>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    undoLastAction();
+                    closeArrangeMenu();
                   }}
                   disabled={!session.history.length}
                 >
@@ -795,8 +906,9 @@ export function TarotStudio() {
                 type="button"
                 onClick={() => {
                   activeSpreadRef.current = null;
+                  setIsDeckMoveMode(false);
                   dispatch({ type: "new-shuffle", cardSet: activeCardSet });
-                  setIsShuffleMenuOpen(false);
+                  closeShuffleMenu();
                   setViewZoom(1);
                 }}
               >

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -143,6 +143,8 @@ export function TarotStudio() {
   const activeSpreadRef = useRef<TarotSpread | null>(null);
   const deckMenuRef = useRef<HTMLDivElement>(null);
   const deckMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const zoomMenuRef = useRef<HTMLDivElement>(null);
+  const zoomMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const spreadMenuRef = useRef<HTMLDivElement>(null);
   const spreadMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const arrangeMenuRef = useRef<HTMLDivElement>(null);
@@ -159,10 +161,11 @@ export function TarotStudio() {
   const [activeCardSetId, setActiveCardSetId] = useState(cardSets[0].id);
   const [viewZoom, setViewZoom] = useState(1);
   const [isDeckMenuOpen, setIsDeckMenuOpen] = useState(false);
+  const [isZoomMenuOpen, setIsZoomMenuOpen] = useState(false);
   const [isSpreadMenuOpen, setIsSpreadMenuOpen] = useState(false);
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
   const [isShuffleMenuOpen, setIsShuffleMenuOpen] = useState(false);
-  const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(false);
+  const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(true);
   const [isDeckMoveMode, setIsDeckMoveMode] = useState(false);
   const [isSceneLayoutReady, setIsSceneLayoutReady] = useState(false);
   const [isWorkspaceReady, setIsWorkspaceReady] = useState(false);
@@ -187,6 +190,9 @@ export function TarotStudio() {
   const selectedTableIndex = selectedCard
     ? tableCards.findIndex((card) => card.id === selectedCard.id)
     : -1;
+  const hasSelectedTableCard = selectedCard?.zone === "table";
+  const isInspectorOpen =
+    hasSelectedTableCard && !isInspectorCollapsed && !isDeckMoveMode;
   const canSendBackward = selectedTableIndex > 0;
   const canBringForward =
     selectedTableIndex >= 0 && selectedTableIndex < tableCards.length - 1;
@@ -202,7 +208,7 @@ export function TarotStudio() {
       setViewZoom(
         Math.min(MAX_VIEW_ZOOM, Math.max(MIN_VIEW_ZOOM, workspace.viewZoom))
       );
-      setIsInspectorCollapsed(workspace.isInspectorCollapsed);
+      setIsInspectorCollapsed(true);
       dispatch({ type: "restore", session: workspace.session });
     }
 
@@ -239,6 +245,12 @@ export function TarotStudio() {
     triggerRef: deckMenuTriggerRef,
   });
   useDockPopover({
+    containerRef: zoomMenuRef,
+    isOpen: isZoomMenuOpen,
+    setIsOpen: setIsZoomMenuOpen,
+    triggerRef: zoomMenuTriggerRef,
+  });
+  useDockPopover({
     containerRef: spreadMenuRef,
     isOpen: isSpreadMenuOpen,
     setIsOpen: setIsSpreadMenuOpen,
@@ -259,7 +271,7 @@ export function TarotStudio() {
 
   useEffect(() => {
     if (selectedCard?.zone !== "table") {
-      setIsInspectorCollapsed(false);
+      setIsInspectorCollapsed(true);
     }
   }, [selectedCard?.zone]);
 
@@ -634,6 +646,7 @@ export function TarotStudio() {
             aria-haspopup="dialog"
             onClick={() => {
               const willOpen = !isDeckMenuOpen;
+              setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
               setIsShuffleMenuOpen(false);
@@ -692,31 +705,65 @@ export function TarotStudio() {
             </div>
           )}
         </div>
-        <div className="tarot-zoom-controls" aria-label="Table zoom">
+        <div className="tarot-zoom-menu" ref={zoomMenuRef}>
           <button
+            ref={zoomMenuTriggerRef}
             type="button"
-            aria-label="Zoom out"
-            onClick={() => adjustViewZoom(-0.1)}
-            disabled={viewZoom <= MIN_VIEW_ZOOM}
+            className="tarot-toolbar-trigger tarot-zoom-trigger"
+            aria-label={`Table zoom, ${Math.round(viewZoom * 100)} percent`}
+            aria-controls="zoom-actions"
+            aria-expanded={isZoomMenuOpen}
+            aria-haspopup="dialog"
+            onClick={() => {
+              const willOpen = !isZoomMenuOpen;
+              setIsDeckMenuOpen(false);
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsShuffleMenuOpen(false);
+              setIsInspectorCollapsed(true);
+              setIsZoomMenuOpen(willOpen);
+            }}
           >
-            −
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="10.5" cy="10.5" r="5.5" />
+              <path d="m14.5 14.5 5 5M8 10.5h5M10.5 8v5" />
+            </svg>
+            <span>Zoom</span>
+            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m8 10 4 4 4-4" />
+            </svg>
           </button>
-          <button
-            type="button"
-            aria-label="Reset table zoom"
-            title="Reset zoom"
-            onClick={() => setViewZoom(1)}
+          <div
+            id="zoom-actions"
+            className={`tarot-zoom-controls${isZoomMenuOpen ? " tarot-zoom-controls--open" : ""}`}
+            role={isZoomMenuOpen ? "dialog" : undefined}
+            aria-label="Table zoom"
           >
-            {Math.round(viewZoom * 100)}%
-          </button>
-          <button
-            type="button"
-            aria-label="Zoom in"
-            onClick={() => adjustViewZoom(0.1)}
-            disabled={viewZoom >= MAX_VIEW_ZOOM}
-          >
-            +
-          </button>
+            <button
+              type="button"
+              aria-label="Zoom out"
+              onClick={() => adjustViewZoom(-0.1)}
+              disabled={viewZoom <= MIN_VIEW_ZOOM}
+            >
+              −
+            </button>
+            <button
+              type="button"
+              aria-label="Reset table zoom"
+              title="Reset zoom"
+              onClick={() => setViewZoom(1)}
+            >
+              {Math.round(viewZoom * 100)}%
+            </button>
+            <button
+              type="button"
+              aria-label="Zoom in"
+              onClick={() => adjustViewZoom(0.1)}
+              disabled={viewZoom >= MAX_VIEW_ZOOM}
+            >
+              +
+            </button>
+          </div>
         </div>
         {isDeckMoveMode && (
           <button
@@ -735,122 +782,6 @@ export function TarotStudio() {
             <span>Cancel</span>
           </button>
         )}
-        {selectedCard?.zone === "table" && !isDeckMoveMode && (
-          <div className="tarot-card-menu">
-            <button
-              ref={inspectorToggleRef}
-              type="button"
-              className="tarot-toolbar-trigger tarot-card-trigger"
-              aria-label={`${isInspectorCollapsed ? "Open" : "Close"} selected card controls for ${selectedTitle}`}
-              aria-controls="selected-card-inspector"
-              aria-expanded={!isInspectorCollapsed}
-              onClick={() => {
-                setIsDeckMenuOpen(false);
-                setIsSpreadMenuOpen(false);
-                setIsArrangeMenuOpen(false);
-                setIsShuffleMenuOpen(false);
-                if (isInspectorCollapsed) {
-                  expandInspector();
-                } else {
-                  collapseInspector();
-                }
-              }}
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <rect x="5" y="3.5" width="14" height="17" rx="1.5" />
-                <path d="m12 7 .8 2.1 2.2.1-1.7 1.4.6 2.2-1.9-1.2-1.9 1.2.6-2.2-1.7-1.4 2.2-.1L12 7Z" />
-              </svg>
-              <span>Card</span>
-              <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="m8 10 4 4 4-4" />
-              </svg>
-            </button>
-            {!isInspectorCollapsed && (
-              <aside
-                id="selected-card-inspector"
-                className="tarot-inspector"
-                aria-label={`Selected card controls for ${selectedTitle}`}
-              >
-                <div className="tarot-inspector-heading">
-                  <p className="tarot-eyebrow">Selected card</p>
-                  <button
-                    ref={inspectorCollapseRef}
-                    type="button"
-                    className="tarot-inspector-collapse"
-                    aria-label="Collapse selected card controls"
-                    aria-expanded="true"
-                    onClick={collapseInspector}
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <path d="m7 10 5 5 5-5" />
-                    </svg>
-                  </button>
-                </div>
-                <h2>{selectedTitle}</h2>
-                <p>{selectedHint}</p>
-                <div className="tarot-card-browser">
-                  <label htmlFor="drawn-card">Browse cards on the table</label>
-                  <select
-                    id="drawn-card"
-                    name="drawn-card"
-                    autoComplete="off"
-                    value={session.selectedCardId ?? ""}
-                    disabled={tableCards.length === 0}
-                    onChange={(event) =>
-                      dispatch({
-                        type: "select",
-                        cardId: event.target.value || null,
-                      })
-                    }
-                  >
-                    <option value="">Select a drawn card</option>
-                    {tableCards.map((card, index) => {
-                      const definition = activeCardSet.cards.find(
-                        (candidate) => candidate.id === card.cardId
-                      );
-
-                      return (
-                        <option key={card.id} value={card.id}>
-                          {card.faceUp
-                            ? definition?.name ?? `Card ${index + 1}`
-                            : `Face-down card ${index + 1}`}
-                        </option>
-                      );
-                    })}
-                  </select>
-                </div>
-                <div className="tarot-inspector-actions">
-                  <button type="button" onClick={flipSelected}>
-                    Flip <Shortcut>F</Shortcut>
-                  </button>
-                  <button type="button" onClick={() => turnSelected(-15)}>
-                    Turn −15° <Shortcut>[</Shortcut>
-                  </button>
-                  <button type="button" onClick={() => turnSelected(15)}>
-                    Turn +15° <Shortcut>]</Shortcut>
-                  </button>
-                  <button type="button" onClick={() => turnSelected(180)}>
-                    Reverse <Shortcut>R</Shortcut>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => reorderSelected("backward")}
-                    disabled={!canSendBackward}
-                  >
-                    Send back <Shortcut>Pg↓</Shortcut>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => reorderSelected("forward")}
-                    disabled={!canBringForward}
-                  >
-                    Bring forward <Shortcut>Pg↑</Shortcut>
-                  </button>
-                </div>
-              </aside>
-            )}
-          </div>
-        )}
         {activeCardSet.kind === "tarot" &&
           tableCards.length === 0 &&
           !isDeckMoveMode && (
@@ -866,6 +797,7 @@ export function TarotStudio() {
                 onClick={() => {
                   const willOpen = !isSpreadMenuOpen;
                   setIsDeckMenuOpen(false);
+                  setIsZoomMenuOpen(false);
                   setIsArrangeMenuOpen(false);
                   setIsShuffleMenuOpen(false);
                   setIsSpreadMenuOpen(willOpen);
@@ -926,6 +858,7 @@ export function TarotStudio() {
             onClick={() => {
               const willOpen = !isArrangeMenuOpen;
               setIsDeckMenuOpen(false);
+              setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsShuffleMenuOpen(false);
               if (selectedCard?.zone === "table") {
@@ -985,6 +918,7 @@ export function TarotStudio() {
                   onClick={() => {
                     dispatch({ type: "select", cardId: null });
                     setIsDeckMenuOpen(false);
+                    setIsZoomMenuOpen(false);
                     setIsSpreadMenuOpen(false);
                     setIsShuffleMenuOpen(false);
                     setIsDeckMoveMode(true);
@@ -1025,6 +959,7 @@ export function TarotStudio() {
             onClick={() => {
               const willOpen = !isShuffleMenuOpen;
               setIsDeckMenuOpen(false);
+              setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
               if (selectedCard?.zone === "table") {
@@ -1064,6 +999,126 @@ export function TarotStudio() {
                 <small>Restart with all {activeCardSet.cards.length} cards</small>
               </button>
             </div>
+          )}
+        </div>
+        <div className="tarot-card-menu">
+          <button
+            ref={inspectorToggleRef}
+            type="button"
+            className="tarot-toolbar-trigger tarot-card-trigger"
+            aria-label={
+              hasSelectedTableCard
+                ? `${isInspectorOpen ? "Close" : "Open"} selected card controls for ${selectedTitle}`
+                : "Select a card to use card controls"
+            }
+            aria-controls="selected-card-inspector"
+            aria-expanded={isInspectorOpen}
+            disabled={!hasSelectedTableCard || isDeckMoveMode}
+            onClick={() => {
+              setIsDeckMenuOpen(false);
+              setIsZoomMenuOpen(false);
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsShuffleMenuOpen(false);
+              if (isInspectorOpen) {
+                collapseInspector();
+              } else {
+                expandInspector();
+              }
+            }}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="5" y="3.5" width="14" height="17" rx="1.5" />
+              <path d="m12 7 .8 2.1 2.2.1-1.7 1.4.6 2.2-1.9-1.2-1.9 1.2.6-2.2-1.7-1.4 2.2-.1L12 7Z" />
+            </svg>
+            <span>Card</span>
+            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m8 10 4 4 4-4" />
+            </svg>
+          </button>
+          {isInspectorOpen && (
+            <aside
+              id="selected-card-inspector"
+              className="tarot-inspector"
+              aria-label={`Selected card controls for ${selectedTitle}`}
+            >
+              <div className="tarot-inspector-heading">
+                <p className="tarot-eyebrow">Selected card</p>
+                <button
+                  ref={inspectorCollapseRef}
+                  type="button"
+                  className="tarot-inspector-collapse"
+                  aria-label="Collapse selected card controls"
+                  aria-expanded="true"
+                  onClick={collapseInspector}
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="m7 10 5 5 5-5" />
+                  </svg>
+                </button>
+              </div>
+              <h2>{selectedTitle}</h2>
+              <p>{selectedHint}</p>
+              <div className="tarot-card-browser">
+                <label htmlFor="drawn-card">Browse cards on the table</label>
+                <select
+                  id="drawn-card"
+                  name="drawn-card"
+                  autoComplete="off"
+                  value={session.selectedCardId ?? ""}
+                  disabled={tableCards.length === 0}
+                  onChange={(event) =>
+                    dispatch({
+                      type: "select",
+                      cardId: event.target.value || null,
+                    })
+                  }
+                >
+                  <option value="">Select a drawn card</option>
+                  {tableCards.map((card, index) => {
+                    const definition = activeCardSet.cards.find(
+                      (candidate) => candidate.id === card.cardId
+                    );
+
+                    return (
+                      <option key={card.id} value={card.id}>
+                        {card.faceUp
+                          ? definition?.name ?? `Card ${index + 1}`
+                          : `Face-down card ${index + 1}`}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+              <div className="tarot-inspector-actions">
+                <button type="button" onClick={flipSelected}>
+                  Flip <Shortcut>F</Shortcut>
+                </button>
+                <button type="button" onClick={() => turnSelected(-15)}>
+                  Turn −15° <Shortcut>[</Shortcut>
+                </button>
+                <button type="button" onClick={() => turnSelected(15)}>
+                  Turn +15° <Shortcut>]</Shortcut>
+                </button>
+                <button type="button" onClick={() => turnSelected(180)}>
+                  Reverse <Shortcut>R</Shortcut>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => reorderSelected("backward")}
+                  disabled={!canSendBackward}
+                >
+                  Send back <Shortcut>Pg↓</Shortcut>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => reorderSelected("forward")}
+                  disabled={!canBringForward}
+                >
+                  Bring forward <Shortcut>Pg↑</Shortcut>
+                </button>
+              </div>
+            </aside>
           )}
         </div>
       </nav>

--- a/src/lib/card-sounds.ts
+++ b/src/lib/card-sounds.ts
@@ -1,0 +1,273 @@
+/**
+ * Lightweight, asset-free sound effects for the tarot table. Create an engine
+ * inside a client component and call `play` directly from user interactions so
+ * the AudioContext is only allocated after a browser gesture.
+ */
+
+export const CARD_SOUND_EVENTS = [
+  "pickup",
+  "move",
+  "drop",
+  "flip",
+  "rotate",
+  "shuffle",
+  "arrange",
+  "draw",
+] as const;
+
+export type CardSoundEvent = (typeof CARD_SOUND_EVENTS)[number];
+
+export type CardSoundEngineOptions = {
+  /** Starts muted when no persisted choice exists. Defaults to false. */
+  muted?: boolean;
+  /** A localStorage key for the user's mute preference. */
+  storageKey?: string;
+  /** Overall volume multiplier, constrained to the subtle 0–1 range. */
+  volume?: number;
+};
+
+export type CardSoundPlayOptions = {
+  /** Scales an individual effect without allowing unexpectedly loud audio. */
+  intensity?: number;
+};
+
+export type CardSoundEngine = {
+  /**
+   * Plays an effect. Call from a pointer, click, or keyboard event handler to
+   * satisfy browser autoplay rules and lazily create the AudioContext.
+   */
+  play: (event: CardSoundEvent, options?: CardSoundPlayOptions) => void;
+  /** Prepares audio after a user gesture without playing an effect. */
+  prime: () => void;
+  getMuted: () => boolean;
+  setMuted: (muted: boolean) => void;
+  toggleMuted: () => boolean;
+  /** Releases the AudioContext when its owning component unmounts. */
+  dispose: () => void;
+};
+
+type Tone = {
+  delay?: number;
+  duration: number;
+  endFrequency?: number;
+  frequency: number;
+  type: OscillatorType;
+  volume: number;
+};
+
+const DEFAULT_STORAGE_KEY = "tarot.card-sounds-muted";
+const DEFAULT_VOLUME = 0.42;
+const THROTTLE_MS: Record<CardSoundEvent, number> = {
+  pickup: 75,
+  move: 70,
+  drop: 45,
+  flip: 100,
+  rotate: 65,
+  shuffle: 140,
+  arrange: 160,
+  draw: 110,
+};
+
+type LegacyAudioWindow = Window & {
+  webkitAudioContext?: new () => AudioContext;
+};
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function now() {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+function readMuted(storageKey: string, fallback: boolean) {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  try {
+    const value = window.localStorage.getItem(storageKey);
+    return value === null ? fallback : value === "true";
+  } catch {
+    return fallback;
+  }
+}
+
+function persistMuted(storageKey: string, muted: boolean) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, String(muted));
+  } catch {
+    // Storage can be unavailable in private browsing or embedded previews.
+  }
+}
+
+function getTones(event: CardSoundEvent): Tone[] {
+  const shimmer = 1 + (Math.random() - 0.5) * 0.06;
+
+  switch (event) {
+    case "pickup":
+      return [
+        { duration: 0.045, endFrequency: 530 * shimmer, frequency: 390 * shimmer, type: "sine", volume: 0.07 },
+        { delay: 0.022, duration: 0.04, endFrequency: 710 * shimmer, frequency: 620 * shimmer, type: "triangle", volume: 0.035 },
+      ];
+    case "move":
+      return [
+        { duration: 0.028, endFrequency: 245 * shimmer, frequency: 210 * shimmer, type: "sine", volume: 0.025 },
+      ];
+    case "drop":
+      return [
+        { duration: 0.065, endFrequency: 132 * shimmer, frequency: 228 * shimmer, type: "sine", volume: 0.09 },
+        { delay: 0.008, duration: 0.032, endFrequency: 310 * shimmer, frequency: 360 * shimmer, type: "triangle", volume: 0.026 },
+      ];
+    case "flip":
+      return [
+        { duration: 0.09, endFrequency: 660 * shimmer, frequency: 345 * shimmer, type: "triangle", volume: 0.062 },
+        { delay: 0.065, duration: 0.035, endFrequency: 445 * shimmer, frequency: 495 * shimmer, type: "sine", volume: 0.026 },
+      ];
+    case "rotate":
+      return [
+        { duration: 0.05, endFrequency: 275 * shimmer, frequency: 390 * shimmer, type: "sine", volume: 0.042 },
+      ];
+    case "shuffle":
+      return [
+        { duration: 0.045, endFrequency: 240 * shimmer, frequency: 330 * shimmer, type: "triangle", volume: 0.038 },
+        { delay: 0.052, duration: 0.045, endFrequency: 310 * shimmer, frequency: 220 * shimmer, type: "triangle", volume: 0.036 },
+        { delay: 0.106, duration: 0.055, endFrequency: 195 * shimmer, frequency: 290 * shimmer, type: "sine", volume: 0.045 },
+      ];
+    case "arrange":
+      return [
+        { duration: 0.05, endFrequency: 285 * shimmer, frequency: 370 * shimmer, type: "sine", volume: 0.035 },
+        { delay: 0.045, duration: 0.05, endFrequency: 365 * shimmer, frequency: 295 * shimmer, type: "triangle", volume: 0.038 },
+      ];
+    case "draw":
+      return [
+        { duration: 0.055, endFrequency: 515 * shimmer, frequency: 325 * shimmer, type: "sine", volume: 0.06 },
+        { delay: 0.042, duration: 0.065, endFrequency: 625 * shimmer, frequency: 470 * shimmer, type: "triangle", volume: 0.046 },
+      ];
+  }
+}
+
+function playTone(
+  context: AudioContext,
+  tone: Tone,
+  volume: number
+) {
+  const startAt = context.currentTime + (tone.delay ?? 0);
+  const stopAt = startAt + tone.duration;
+  const oscillator = context.createOscillator();
+  const gain = context.createGain();
+  const peak = Math.max(0.0001, tone.volume * volume);
+
+  oscillator.type = tone.type;
+  oscillator.frequency.setValueAtTime(tone.frequency, startAt);
+  oscillator.frequency.exponentialRampToValueAtTime(
+    Math.max(1, tone.endFrequency ?? tone.frequency),
+    stopAt
+  );
+  gain.gain.setValueAtTime(0.0001, startAt);
+  gain.gain.exponentialRampToValueAtTime(peak, startAt + 0.008);
+  gain.gain.exponentialRampToValueAtTime(0.0001, stopAt);
+
+  oscillator.connect(gain);
+  gain.connect(context.destination);
+  oscillator.onended = () => {
+    oscillator.disconnect();
+    gain.disconnect();
+  };
+  oscillator.start(startAt);
+  oscillator.stop(stopAt + 0.015);
+}
+
+/**
+ * Creates a browser-only sound engine without allocating audio resources until
+ * `prime` or `play` is called from an interaction handler.
+ */
+export function createCardSoundEngine(
+  options: CardSoundEngineOptions = {}
+): CardSoundEngine {
+  const storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+  const volume = clamp(options.volume ?? DEFAULT_VOLUME, 0, 1);
+  let muted = readMuted(storageKey, options.muted ?? false);
+  let context: AudioContext | null = null;
+  let disposed = false;
+  const lastPlayedAt = new Map<CardSoundEvent, number>();
+
+  const ensureContext = () => {
+    if (disposed || typeof window === "undefined") {
+      return null;
+    }
+
+    if (!context) {
+      const Constructor = window.AudioContext ??
+        (window as LegacyAudioWindow).webkitAudioContext;
+
+      if (!Constructor) {
+        return null;
+      }
+
+      context = new Constructor();
+    }
+
+    if (context.state === "suspended") {
+      void context.resume().catch(() => undefined);
+    }
+
+    return context;
+  };
+
+  return {
+    play(event, playOptions = {}) {
+      if (muted || disposed) {
+        return;
+      }
+
+      const playedAt = now();
+      const previous = lastPlayedAt.get(event) ?? -Infinity;
+
+      if (playedAt - previous < THROTTLE_MS[event]) {
+        return;
+      }
+
+      const audioContext = ensureContext();
+
+      if (!audioContext) {
+        return;
+      }
+
+      lastPlayedAt.set(event, playedAt);
+      const intensity = clamp(playOptions.intensity ?? 1, 0.25, 1);
+
+      getTones(event).forEach((tone) => {
+        playTone(audioContext, tone, volume * intensity);
+      });
+    },
+    prime() {
+      ensureContext();
+    },
+    getMuted() {
+      return muted;
+    },
+    setMuted(nextMuted) {
+      muted = nextMuted;
+      persistMuted(storageKey, muted);
+    },
+    toggleMuted() {
+      muted = !muted;
+      persistMuted(storageKey, muted);
+      return muted;
+    },
+    dispose() {
+      disposed = true;
+      lastPlayedAt.clear();
+
+      if (context) {
+        void context.close().catch(() => undefined);
+        context = null;
+      }
+    },
+  };
+}

--- a/src/lib/card-sounds.ts
+++ b/src/lib/card-sounds.ts
@@ -31,12 +31,17 @@ export type CardSoundPlayOptions = {
   intensity?: number;
 };
 
+export type CardSoundPlayer = (
+  event: CardSoundEvent,
+  options?: CardSoundPlayOptions
+) => void;
+
 export type CardSoundEngine = {
   /**
    * Plays an effect. Call from a pointer, click, or keyboard event handler to
    * satisfy browser autoplay rules and lazily create the AudioContext.
    */
-  play: (event: CardSoundEvent, options?: CardSoundPlayOptions) => void;
+  play: CardSoundPlayer;
   /** Prepares audio after a user gesture without playing an effect. */
   prime: () => void;
   getMuted: () => boolean;
@@ -46,17 +51,26 @@ export type CardSoundEngine = {
   dispose: () => void;
 };
 
-type Tone = {
+type PaperStroke = {
+  attack?: number;
   delay?: number;
   duration: number;
-  endFrequency?: number;
-  frequency: number;
-  type: OscillatorType;
+  endHighpass?: number;
+  endLowpass?: number;
+  highpass: number;
+  lowpass: number;
   volume: number;
 };
 
+type ActivePaperStroke = {
+  cleanup: () => void;
+  source: AudioBufferSourceNode;
+};
+
 const DEFAULT_STORAGE_KEY = "tarot.card-sounds-muted";
-const DEFAULT_VOLUME = 0.42;
+const DEFAULT_VOLUME = 0.32;
+const PAPER_NOISE_SECONDS = 0.72;
+const MAX_ACTIVE_MOVE_STROKES = 8;
 const THROTTLE_MS: Record<CardSoundEvent, number> = {
   pickup: 75,
   move: 70,
@@ -105,81 +119,300 @@ function persistMuted(storageKey: string, muted: boolean) {
   }
 }
 
-function getTones(event: CardSoundEvent): Tone[] {
-  const shimmer = 1 + (Math.random() - 0.5) * 0.06;
+const PAPER_STROKES: Record<CardSoundEvent, readonly PaperStroke[]> = {
+  pickup: [
+    {
+      duration: 0.052,
+      endHighpass: 1_500,
+      endLowpass: 6_500,
+      highpass: 1_050,
+      lowpass: 5_400,
+      volume: 0.055,
+    },
+    {
+      delay: 0.026,
+      duration: 0.018,
+      endHighpass: 1_700,
+      endLowpass: 5_600,
+      highpass: 2_200,
+      lowpass: 7_200,
+      volume: 0.025,
+    },
+  ],
+  move: [
+    {
+      duration: 0.085,
+      endHighpass: 1_050,
+      endLowpass: 6_200,
+      highpass: 720,
+      lowpass: 4_800,
+      volume: 0.045,
+    },
+  ],
+  drop: [
+    {
+      attack: 0.002,
+      duration: 0.028,
+      endHighpass: 350,
+      endLowpass: 1_800,
+      highpass: 550,
+      lowpass: 2_600,
+      volume: 0.05,
+    },
+    {
+      attack: 0.002,
+      delay: 0.018,
+      duration: 0.06,
+      endHighpass: 45,
+      endLowpass: 700,
+      highpass: 80,
+      lowpass: 1_200,
+      volume: 0.075,
+    },
+    {
+      delay: 0.034,
+      duration: 0.045,
+      endHighpass: 600,
+      endLowpass: 2_400,
+      highpass: 900,
+      lowpass: 3_500,
+      volume: 0.035,
+    },
+  ],
+  flip: [
+    {
+      duration: 0.105,
+      endHighpass: 1_650,
+      endLowpass: 3_600,
+      highpass: 800,
+      lowpass: 6_500,
+      volume: 0.055,
+    },
+    {
+      delay: 0.058,
+      duration: 0.055,
+      endHighpass: 850,
+      endLowpass: 4_200,
+      highpass: 1_800,
+      lowpass: 7_000,
+      volume: 0.035,
+    },
+  ],
+  rotate: [
+    {
+      duration: 0.06,
+      endHighpass: 900,
+      endLowpass: 4_200,
+      highpass: 1_400,
+      lowpass: 5_900,
+      volume: 0.034,
+    },
+  ],
+  shuffle: [
+    {
+      duration: 0.048,
+      endHighpass: 1_300,
+      endLowpass: 4_000,
+      highpass: 650,
+      lowpass: 6_200,
+      volume: 0.038,
+    },
+    {
+      delay: 0.04,
+      duration: 0.05,
+      endHighpass: 700,
+      endLowpass: 5_800,
+      highpass: 1_350,
+      lowpass: 4_100,
+      volume: 0.036,
+    },
+    {
+      delay: 0.082,
+      duration: 0.052,
+      endHighpass: 1_450,
+      endLowpass: 3_900,
+      highpass: 720,
+      lowpass: 6_400,
+      volume: 0.04,
+    },
+    {
+      delay: 0.126,
+      duration: 0.045,
+      endHighpass: 680,
+      endLowpass: 4_800,
+      highpass: 1_250,
+      lowpass: 3_700,
+      volume: 0.034,
+    },
+  ],
+  arrange: [
+    {
+      duration: 0.068,
+      endHighpass: 950,
+      endLowpass: 5_600,
+      highpass: 620,
+      lowpass: 4_300,
+      volume: 0.038,
+    },
+    {
+      delay: 0.055,
+      duration: 0.072,
+      endHighpass: 650,
+      endLowpass: 4_100,
+      highpass: 1_000,
+      lowpass: 5_700,
+      volume: 0.036,
+    },
+  ],
+  draw: [
+    {
+      duration: 0.135,
+      endHighpass: 1_450,
+      endLowpass: 6_500,
+      highpass: 650,
+      lowpass: 4_200,
+      volume: 0.06,
+    },
+    {
+      delay: 0.006,
+      duration: 0.022,
+      endHighpass: 1_500,
+      endLowpass: 5_700,
+      highpass: 2_000,
+      lowpass: 7_200,
+      volume: 0.03,
+    },
+    {
+      delay: 0.102,
+      duration: 0.04,
+      endHighpass: 950,
+      endLowpass: 4_200,
+      highpass: 1_600,
+      lowpass: 6_000,
+      volume: 0.025,
+    },
+  ],
+};
 
-  switch (event) {
-    case "pickup":
-      return [
-        { duration: 0.045, endFrequency: 530 * shimmer, frequency: 390 * shimmer, type: "sine", volume: 0.07 },
-        { delay: 0.022, duration: 0.04, endFrequency: 710 * shimmer, frequency: 620 * shimmer, type: "triangle", volume: 0.035 },
-      ];
-    case "move":
-      return [
-        { duration: 0.028, endFrequency: 245 * shimmer, frequency: 210 * shimmer, type: "sine", volume: 0.025 },
-      ];
-    case "drop":
-      return [
-        { duration: 0.065, endFrequency: 132 * shimmer, frequency: 228 * shimmer, type: "sine", volume: 0.09 },
-        { delay: 0.008, duration: 0.032, endFrequency: 310 * shimmer, frequency: 360 * shimmer, type: "triangle", volume: 0.026 },
-      ];
-    case "flip":
-      return [
-        { duration: 0.09, endFrequency: 660 * shimmer, frequency: 345 * shimmer, type: "triangle", volume: 0.062 },
-        { delay: 0.065, duration: 0.035, endFrequency: 445 * shimmer, frequency: 495 * shimmer, type: "sine", volume: 0.026 },
-      ];
-    case "rotate":
-      return [
-        { duration: 0.05, endFrequency: 275 * shimmer, frequency: 390 * shimmer, type: "sine", volume: 0.042 },
-      ];
-    case "shuffle":
-      return [
-        { duration: 0.045, endFrequency: 240 * shimmer, frequency: 330 * shimmer, type: "triangle", volume: 0.038 },
-        { delay: 0.052, duration: 0.045, endFrequency: 310 * shimmer, frequency: 220 * shimmer, type: "triangle", volume: 0.036 },
-        { delay: 0.106, duration: 0.055, endFrequency: 195 * shimmer, frequency: 290 * shimmer, type: "sine", volume: 0.045 },
-      ];
-    case "arrange":
-      return [
-        { duration: 0.05, endFrequency: 285 * shimmer, frequency: 370 * shimmer, type: "sine", volume: 0.035 },
-        { delay: 0.045, duration: 0.05, endFrequency: 365 * shimmer, frequency: 295 * shimmer, type: "triangle", volume: 0.038 },
-      ];
-    case "draw":
-      return [
-        { duration: 0.055, endFrequency: 515 * shimmer, frequency: 325 * shimmer, type: "sine", volume: 0.06 },
-        { delay: 0.042, duration: 0.065, endFrequency: 625 * shimmer, frequency: 470 * shimmer, type: "triangle", volume: 0.046 },
-      ];
-  }
+function jitter(value: number, amount = 0.12) {
+  return value * (1 + (Math.random() * 2 - 1) * amount);
 }
 
-function playTone(
-  context: AudioContext,
-  tone: Tone,
-  volume: number
-) {
-  const startAt = context.currentTime + (tone.delay ?? 0);
-  const stopAt = startAt + tone.duration;
-  const oscillator = context.createOscillator();
-  const gain = context.createGain();
-  const peak = Math.max(0.0001, tone.volume * volume);
+function createPaperNoise(context: AudioContext) {
+  const length = Math.ceil(context.sampleRate * PAPER_NOISE_SECONDS);
+  const buffer = context.createBuffer(1, length, context.sampleRate);
+  const channel = buffer.getChannelData(0);
+  let smoothedNoise = 0;
+  let clusterSamples = 0;
+  let clusterLevel = 1;
 
-  oscillator.type = tone.type;
-  oscillator.frequency.setValueAtTime(tone.frequency, startAt);
-  oscillator.frequency.exponentialRampToValueAtTime(
-    Math.max(1, tone.endFrequency ?? tone.frequency),
+  for (let index = 0; index < length; index += 1) {
+    if (clusterSamples <= 0) {
+      clusterSamples = Math.round(
+        context.sampleRate * (0.001 + Math.random() * 0.007)
+      );
+      clusterLevel = 0.42 + Math.random() * 0.58;
+    }
+
+    const whiteNoise = Math.random() * 2 - 1;
+    smoothedNoise = smoothedNoise * 0.82 + whiteNoise * 0.18;
+    const fiberClick = Math.random() < 0.0025 ? whiteNoise * 0.75 : 0;
+    channel[index] = clamp(
+      (whiteNoise * 0.58 + smoothedNoise * 0.42) * clusterLevel + fiberClick,
+      -1,
+      1
+    );
+    clusterSamples -= 1;
+  }
+
+  return buffer;
+}
+
+function playPaperStroke({
+  activeStrokes,
+  context,
+  noise,
+  output,
+  stroke,
+  intensity,
+}: {
+  activeStrokes: Set<ActivePaperStroke>;
+  context: AudioContext;
+  noise: AudioBuffer;
+  output: AudioNode;
+  stroke: PaperStroke;
+  intensity: number;
+}) {
+  const delay = Math.max(0, jitter(stroke.delay ?? 0, 0.08));
+  const duration = Math.max(0.012, jitter(stroke.duration));
+  const startAt = context.currentTime + delay;
+  const stopAt = startAt + duration;
+  const attackAt = Math.min(
+    stopAt - 0.004,
+    startAt + Math.max(0.001, stroke.attack ?? duration * 0.08)
+  );
+  const source = context.createBufferSource();
+  const highpass = context.createBiquadFilter();
+  const lowpass = context.createBiquadFilter();
+  const gain = context.createGain();
+  const peak = Math.max(0.0001, jitter(stroke.volume) * intensity);
+  let cleanedUp = false;
+
+  source.buffer = noise;
+  source.loop = true;
+  source.playbackRate.value = jitter(1, 0.14);
+  highpass.type = "highpass";
+  highpass.Q.value = 0.55;
+  highpass.frequency.setValueAtTime(jitter(stroke.highpass), startAt);
+  highpass.frequency.exponentialRampToValueAtTime(
+    Math.max(20, jitter(stroke.endHighpass ?? stroke.highpass)),
+    stopAt
+  );
+  lowpass.type = "lowpass";
+  lowpass.Q.value = 0.7;
+  lowpass.frequency.setValueAtTime(jitter(stroke.lowpass), startAt);
+  lowpass.frequency.exponentialRampToValueAtTime(
+    Math.max(40, jitter(stroke.endLowpass ?? stroke.lowpass)),
     stopAt
   );
   gain.gain.setValueAtTime(0.0001, startAt);
-  gain.gain.exponentialRampToValueAtTime(peak, startAt + 0.008);
-  gain.gain.exponentialRampToValueAtTime(0.0001, stopAt);
+  gain.gain.linearRampToValueAtTime(peak, attackAt);
 
-  oscillator.connect(gain);
-  gain.connect(context.destination);
-  oscillator.onended = () => {
-    oscillator.disconnect();
-    gain.disconnect();
+  if (duration >= 0.055) {
+    const notchAt = startAt + duration * 0.52;
+    gain.gain.linearRampToValueAtTime(peak * 0.48, notchAt);
+    gain.gain.linearRampToValueAtTime(
+      peak * 0.82,
+      Math.min(stopAt - 0.006, notchAt + duration * 0.13)
+    );
+  }
+
+  gain.gain.exponentialRampToValueAtTime(0.0001, stopAt);
+  source.connect(highpass);
+  highpass.connect(lowpass);
+  lowpass.connect(gain);
+  gain.connect(output);
+
+  const activeStroke: ActivePaperStroke = {
+    source,
+    cleanup: () => {
+      if (cleanedUp) {
+        return;
+      }
+
+      cleanedUp = true;
+      activeStrokes.delete(activeStroke);
+      source.disconnect();
+      highpass.disconnect();
+      lowpass.disconnect();
+      gain.disconnect();
+    },
   };
-  oscillator.start(startAt);
-  oscillator.stop(stopAt + 0.015);
+
+  activeStrokes.add(activeStroke);
+  source.onended = activeStroke.cleanup;
+  source.start(startAt, Math.random() * noise.duration);
+  source.stop(stopAt + 0.012);
 }
 
 /**
@@ -193,10 +426,13 @@ export function createCardSoundEngine(
   const volume = clamp(options.volume ?? DEFAULT_VOLUME, 0, 1);
   let muted = readMuted(storageKey, options.muted ?? false);
   let context: AudioContext | null = null;
+  let paperNoise: AudioBuffer | null = null;
+  let output: GainNode | null = null;
   let disposed = false;
+  const activeStrokes = new Set<ActivePaperStroke>();
   const lastPlayedAt = new Map<CardSoundEvent, number>();
 
-  const ensureContext = () => {
+  const ensureAudioGraph = () => {
     if (disposed || typeof window === "undefined") {
       return null;
     }
@@ -212,11 +448,25 @@ export function createCardSoundEngine(
       context = new Constructor();
     }
 
-    if (context.state === "suspended") {
+    if (context.state === "closed") {
+      return null;
+    }
+
+    if (context.state !== "running") {
       void context.resume().catch(() => undefined);
     }
 
-    return context;
+    if (!paperNoise) {
+      paperNoise = createPaperNoise(context);
+    }
+
+    if (!output) {
+      output = context.createGain();
+      output.gain.value = volume;
+      output.connect(context.destination);
+    }
+
+    return { context, noise: paperNoise, output };
   };
 
   return {
@@ -232,21 +482,31 @@ export function createCardSoundEngine(
         return;
       }
 
-      const audioContext = ensureContext();
+      const audioGraph = ensureAudioGraph();
 
-      if (!audioContext) {
+      if (
+        !audioGraph ||
+        (event === "move" && activeStrokes.size >= MAX_ACTIVE_MOVE_STROKES)
+      ) {
         return;
       }
 
       lastPlayedAt.set(event, playedAt);
       const intensity = clamp(playOptions.intensity ?? 1, 0.25, 1);
 
-      getTones(event).forEach((tone) => {
-        playTone(audioContext, tone, volume * intensity);
+      PAPER_STROKES[event].forEach((stroke) => {
+        playPaperStroke({
+          activeStrokes,
+          context: audioGraph.context,
+          intensity,
+          noise: audioGraph.noise,
+          output: audioGraph.output,
+          stroke,
+        });
       });
     },
     prime() {
-      ensureContext();
+      ensureAudioGraph();
     },
     getMuted() {
       return muted;
@@ -263,6 +523,19 @@ export function createCardSoundEngine(
     dispose() {
       disposed = true;
       lastPlayedAt.clear();
+      activeStrokes.forEach((stroke) => {
+        try {
+          stroke.source.stop();
+        } catch {
+          // A source that already ended is safe to clean up directly.
+        }
+
+        stroke.cleanup();
+      });
+      activeStrokes.clear();
+      output?.disconnect();
+      output = null;
+      paperNoise = null;
 
       if (context) {
         void context.close().catch(() => undefined);

--- a/src/lib/card-sounds.ts
+++ b/src/lib/card-sounds.ts
@@ -57,6 +57,7 @@ type PaperStroke = {
   duration: number;
   endHighpass?: number;
   endLowpass?: number;
+  grainPulse?: boolean;
   highpass: number;
   lowpass: number;
   volume: number;
@@ -73,7 +74,7 @@ const PAPER_NOISE_SECONDS = 0.72;
 const MAX_ACTIVE_MOVE_STROKES = 8;
 const THROTTLE_MS: Record<CardSoundEvent, number> = {
   pickup: 75,
-  move: 70,
+  move: 120,
   drop: 45,
   flip: 100,
   rotate: 65,
@@ -141,12 +142,14 @@ const PAPER_STROKES: Record<CardSoundEvent, readonly PaperStroke[]> = {
   ],
   move: [
     {
-      duration: 0.085,
-      endHighpass: 1_050,
-      endLowpass: 6_200,
-      highpass: 720,
-      lowpass: 4_800,
-      volume: 0.045,
+      attack: 0.018,
+      duration: 0.16,
+      endHighpass: 320,
+      endLowpass: 2_200,
+      grainPulse: false,
+      highpass: 240,
+      lowpass: 2_600,
+      volume: 0.022,
     },
   ],
   drop: [
@@ -378,7 +381,7 @@ function playPaperStroke({
   gain.gain.setValueAtTime(0.0001, startAt);
   gain.gain.linearRampToValueAtTime(peak, attackAt);
 
-  if (duration >= 0.055) {
+  if (stroke.grainPulse !== false && duration >= 0.055) {
     const notchAt = startAt + duration * 0.52;
     gain.gain.linearRampToValueAtTime(peak * 0.48, notchAt);
     gain.gain.linearRampToValueAtTime(


### PR DESCRIPTION
## Why

The table should feel physical and card-focused while its controls stay predictable on desktop and mobile. Press-only shadow changes, cursor-escape drops, and a permanently visible toolbar made the experience feel less tactile and polished.

## What changed

- consolidated every non-card action into one responsive bottom dock, with the selected-card trigger permanently rightmost and disabled until a table card is selected
- made the desktop dock fade in place after inactivity, reveal from the bottom edge, and stay pinned for open menus or keyboard focus while remaining visible on touch layouts
- kept a pressed card at its resting depth until movement begins, removing the overlapping border/shadow artifact without losing drag shadows
- moved drag completion to canvas and document pointer capture so very fast cursor-escape releases commit at the latest projected position instead of snapping back
- added procedural filtered paper-and-card textures for pickup, rubbing, landing, flipping, rotating, shuffling, arranging, layering, nudging, spreading, and undo; continuous dragging uses a darker, quieter, pulse-free glide, and Sound persists beside Card
- kept disclosures, safe areas, reduced motion, compact widths, deck movement, and selected-card controls consistent across the refreshed dock

Live browser checks covered stationary press rendering, extreme cursor-escape drops with reload persistence, the pickup/rub/drop sound path, mute persistence, fixed-position dock fade frames, dock pinning, and 320px/354px responsive layouts. A fake Web Audio graph also verified every card-sound recipe, reuse, throttling, cleanup, volume limits, and the smoother below-3 kHz drag band. Lint, type checking, and the production build are green.
