### PR TITLE
Deepen mystical card sounds and layer the deck

### DIFF
--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -5,7 +5,6 @@ import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import {
   type MutableRefObject,
   memo,
-  Suspense,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -29,7 +28,7 @@ import {
   getTopDeckCard,
 } from "@/lib/tarot-session";
 import type { CardSoundPlayer } from "@/lib/card-sounds";
-import { CardArtwork, CARD_THICKNESS, CardMesh } from "./CardMesh";
+import { CARD_THICKNESS, CardMesh } from "./CardMesh";
 import {
   createSceneTableLayout,
   MIN_VIEW_ZOOM,
@@ -45,6 +44,15 @@ const DECK_CARD_RENDER_ORDER = 20;
 const TABLE_CARD_RENDER_ORDER = 100;
 const CARD_RENDER_ORDER_STEP = 10;
 const DRAG_RENDER_ORDER = 10_000;
+const DECK_LAYER_REGISTRATION = [
+  [-0.0065, 0.0035],
+  [0.006, 0.0025],
+  [-0.0035, -0.004],
+  [0.008, -0.0015],
+  [-0.005, 0.0013],
+  [0.003, -0.0045],
+  [-0.0007, 0.0042],
+] as const;
 const CELESTIAL_MARKS = [
   [-0.38, 0.31, 0.018],
   [-0.29, 0.18, 0.011],
@@ -120,10 +128,15 @@ function AnimatedCameraZoom({
 
 function getDeckMetrics(count: number) {
   const layerCount =
-    count > 0 ? Math.min(12, Math.max(1, Math.ceil(count / 7))) : 0;
-  const layerThickness = 0.034;
-  const layerStep = 0.023;
-  const firstCenter = TABLE_SURFACE_Z + 0.007 + layerThickness / 2;
+    count > 0
+      ? Math.min(
+          DECK_LAYER_REGISTRATION.length,
+          Math.max(1, Math.ceil(count / 11))
+        )
+      : 0;
+  const layerThickness = 0.012;
+  const layerStep = 0.016;
+  const firstCenter = TABLE_SURFACE_Z + 0.006 + layerThickness / 2;
   const topSurface = layerCount
     ? firstCenter + (layerCount - 1) * layerStep + layerThickness / 2
     : TABLE_SURFACE_Z + 0.007;
@@ -143,7 +156,6 @@ function DeckStack({
   position,
   width,
   height,
-  backUrl,
   reducedMotion,
   previewPositionRef,
 }: {
@@ -151,7 +163,6 @@ function DeckStack({
   position: TablePoint;
   width: number;
   height: number;
-  backUrl: string;
   reducedMotion: boolean;
   previewPositionRef: MutableRefObject<TablePoint | null>;
 }) {
@@ -217,31 +228,29 @@ function DeckStack({
     return null;
   }
 
-  const outerInset = Math.min(0.2, width * 0.08);
-  const ruleInset = Math.min(0.32, width * 0.13);
-  const artInset = Math.min(0.42, width * 0.17);
-  const topOffsetX = ((metrics.layerCount - 1) % 3 - 1) * 0.012;
-  const topOffsetY = ((metrics.layerCount - 1) % 2 ? -1 : 1) * 0.01;
-
   return (
     <group ref={groupRef} renderOrder={DECK_STACK_RENDER_ORDER}>
       {Array.from({ length: metrics.layerCount }, (_, index) => {
-        const offsetX = (index % 3 - 1) * 0.012;
-        const offsetY = (index % 2 ? -1 : 1) * 0.01;
+        const registration = DECK_LAYER_REGISTRATION[index];
+        const distanceFromTop = metrics.layerCount - index;
+        const offsetX =
+          registration[0] * width * 0.25 -
+          distanceFromTop * width * 0.0035;
+        const offsetY =
+          registration[1] * height * 0.25 +
+          distanceFromTop * height * 0.0025;
 
         return (
           <RoundedBox
             key={index}
             args={[width, height, metrics.layerThickness]}
-            radius={0.055}
-            smoothness={4}
+            radius={0.045}
+            smoothness={3}
             position={[
               offsetX,
               offsetY,
               metrics.firstCenter + index * metrics.layerStep,
             ]}
-            castShadow
-            receiveShadow
             renderOrder={index}
           >
             <meshStandardMaterial
@@ -250,49 +259,12 @@ function DeckStack({
                   ? TAROT_SCENE_PALETTE.cardEdge
                   : TAROT_SCENE_PALETTE.cardEdgeShadow
               }
-              roughness={0.72}
-              metalness={0.025}
-              depthTest={false}
-              depthWrite={false}
+              roughness={index % 2 ? 0.88 : 0.84}
+              metalness={0}
             />
           </RoundedBox>
         );
       })}
-      <mesh
-        position={[topOffsetX, topOffsetY, metrics.topSurface + 0.001]}
-        renderOrder={metrics.layerCount + 1}
-      >
-        <planeGeometry args={[width - outerInset, height - outerInset]} />
-        <meshStandardMaterial
-          color={TAROT_SCENE_PALETTE.cardField}
-          roughness={0.52}
-          metalness={0.12}
-          depthTest={false}
-          depthWrite={false}
-        />
-      </mesh>
-      <mesh
-        position={[topOffsetX, topOffsetY, metrics.topSurface + 0.003]}
-        renderOrder={metrics.layerCount + 2}
-      >
-        <planeGeometry args={[width - ruleInset, height - ruleInset]} />
-        <meshStandardMaterial
-          color={TAROT_SCENE_PALETTE.cardRule}
-          roughness={0.46}
-          metalness={0.48}
-          depthTest={false}
-          depthWrite={false}
-        />
-      </mesh>
-      <Suspense fallback={null}>
-        <CardArtwork
-          url={backUrl}
-          position={[topOffsetX, topOffsetY, metrics.topSurface + 0.005]}
-          width={width - artInset}
-          height={height - artInset}
-          renderOrder={metrics.layerCount + 3}
-        />
-      </Suspense>
     </group>
   );
 }
@@ -523,7 +495,6 @@ function TarotTable({
         position={deckPosition}
         width={layout.cardWidth}
         height={layout.cardHeight}
-        backUrl={cardSet.back.preview}
         reducedMotion={reducedMotion}
         previewPositionRef={deckPreviewPositionRef}
       />

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -5,6 +5,7 @@ import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import {
   type MutableRefObject,
   memo,
+  Suspense,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -28,7 +29,7 @@ import {
   getTopDeckCard,
 } from "@/lib/tarot-session";
 import type { CardSoundPlayer } from "@/lib/card-sounds";
-import { CARD_THICKNESS, CardMesh } from "./CardMesh";
+import { CardArtwork, CARD_THICKNESS, CardMesh } from "./CardMesh";
 import {
   createSceneTableLayout,
   MIN_VIEW_ZOOM,
@@ -151,11 +152,29 @@ function getDeckMetrics(count: number) {
   };
 }
 
+function getDeckLayerOffset(
+  index: number,
+  layerCount: number,
+  width: number,
+  height: number
+): TablePoint {
+  const registration = DECK_LAYER_REGISTRATION[index];
+  const distanceFromTop = layerCount - index;
+
+  return [
+    registration[0] * width * 0.25 -
+      distanceFromTop * width * 0.0035,
+    registration[1] * height * 0.25 +
+      distanceFromTop * height * 0.0025,
+  ];
+}
+
 function DeckStack({
   count,
   position,
   width,
   height,
+  backUrl,
   reducedMotion,
   previewPositionRef,
 }: {
@@ -163,6 +182,7 @@ function DeckStack({
   position: TablePoint;
   width: number;
   height: number;
+  backUrl: string;
   reducedMotion: boolean;
   previewPositionRef: MutableRefObject<TablePoint | null>;
 }) {
@@ -228,17 +248,25 @@ function DeckStack({
     return null;
   }
 
+  const outerInset = Math.min(0.2, width * 0.08);
+  const ruleInset = Math.min(0.32, width * 0.13);
+  const artInset = Math.min(0.42, width * 0.17);
+  const [topOffsetX, topOffsetY] = getDeckLayerOffset(
+    metrics.layerCount - 1,
+    metrics.layerCount,
+    width,
+    height
+  );
+
   return (
     <group ref={groupRef} renderOrder={DECK_STACK_RENDER_ORDER}>
       {Array.from({ length: metrics.layerCount }, (_, index) => {
-        const registration = DECK_LAYER_REGISTRATION[index];
-        const distanceFromTop = metrics.layerCount - index;
-        const offsetX =
-          registration[0] * width * 0.25 -
-          distanceFromTop * width * 0.0035;
-        const offsetY =
-          registration[1] * height * 0.25 +
-          distanceFromTop * height * 0.0025;
+        const [offsetX, offsetY] = getDeckLayerOffset(
+          index,
+          metrics.layerCount,
+          width,
+          height
+        );
 
         return (
           <RoundedBox
@@ -265,6 +293,43 @@ function DeckStack({
           </RoundedBox>
         );
       })}
+      {/* This passive face becomes the next card back while the live top card
+          is lifted, without adding another pointer target to the deck. */}
+      <mesh
+        position={[topOffsetX, topOffsetY, metrics.topSurface + 0.001]}
+        renderOrder={metrics.layerCount + 1}
+      >
+        <planeGeometry args={[width - outerInset, height - outerInset]} />
+        <meshStandardMaterial
+          color={TAROT_SCENE_PALETTE.cardField}
+          roughness={0.52}
+          metalness={0.12}
+          depthTest={false}
+          depthWrite={false}
+        />
+      </mesh>
+      <mesh
+        position={[topOffsetX, topOffsetY, metrics.topSurface + 0.003]}
+        renderOrder={metrics.layerCount + 2}
+      >
+        <planeGeometry args={[width - ruleInset, height - ruleInset]} />
+        <meshStandardMaterial
+          color={TAROT_SCENE_PALETTE.cardRule}
+          roughness={0.46}
+          metalness={0.48}
+          depthTest={false}
+          depthWrite={false}
+        />
+      </mesh>
+      <Suspense fallback={null}>
+        <CardArtwork
+          url={backUrl}
+          position={[topOffsetX, topOffsetY, metrics.topSurface + 0.005]}
+          width={width - artInset}
+          height={height - artInset}
+          renderOrder={metrics.layerCount + 3}
+        />
+      </Suspense>
     </group>
   );
 }
@@ -495,6 +560,7 @@ function TarotTable({
         position={deckPosition}
         width={layout.cardWidth}
         height={layout.cardHeight}
+        backUrl={cardSet.back.preview}
         reducedMotion={reducedMotion}
         previewPositionRef={deckPreviewPositionRef}
       />

--- a/src/lib/card-sounds.ts
+++ b/src/lib/card-sounds.ts
@@ -1,7 +1,7 @@
 /**
- * Lightweight, asset-free sound effects for the tarot table. Create an engine
- * inside a client component and call `play` directly from user interactions so
- * the AudioContext is only allocated after a browser gesture.
+ * Lightweight, asset-free sound effects for the tarot table. The palette uses
+ * low, softly enveloped tones and a bounded echo instead of noise textures so
+ * card interactions feel atmospheric without becoming sharp or fatiguing.
  */
 
 export const CARD_SOUND_EVENTS = [
@@ -51,36 +51,49 @@ export type CardSoundEngine = {
   dispose: () => void;
 };
 
-type PaperStroke = {
-  attack?: number;
+type MysticTone = {
+  attack: number;
   delay?: number;
   duration: number;
-  endHighpass?: number;
-  endLowpass?: number;
-  grainPulse?: boolean;
-  highpass: number;
-  lowpass: number;
+  echo?: number;
+  frequency: number;
+  lowpass?: number;
+  release: number;
+  type: "sine" | "triangle";
   volume: number;
 };
 
-type ActivePaperStroke = {
+type ActiveTone = {
   cleanup: () => void;
-  source: AudioBufferSourceNode;
+  event: CardSoundEvent;
+  oscillator: OscillatorNode;
+};
+
+type MysticAudioGraph = {
+  context: AudioContext;
+  delay: DelayNode;
+  echoFilter: BiquadFilterNode;
+  echoReturn: GainNode;
+  feedback: GainNode;
+  output: GainNode;
 };
 
 const DEFAULT_STORAGE_KEY = "tarot.card-sounds-muted";
-const DEFAULT_VOLUME = 0.32;
-const PAPER_NOISE_SECONDS = 0.72;
-const MAX_ACTIVE_MOVE_STROKES = 8;
+const DEFAULT_VOLUME = 0.2;
+const ECHO_DELAY_SECONDS = 0.24;
+const ECHO_FEEDBACK = 0.12;
+const ECHO_RETURN = 0.14;
+const MAX_ACTIVE_TONES = 6;
+const MAX_ACTIVE_MOVE_TONES = 1;
 const THROTTLE_MS: Record<CardSoundEvent, number> = {
-  pickup: 75,
-  move: 120,
-  drop: 45,
-  flip: 100,
-  rotate: 65,
-  shuffle: 140,
-  arrange: 160,
-  draw: 110,
+  pickup: 110,
+  move: 240,
+  drop: 150,
+  flip: 280,
+  rotate: 180,
+  shuffle: 420,
+  arrange: 360,
+  draw: 420,
 };
 
 type LegacyAudioWindow = Window & {
@@ -120,302 +133,237 @@ function persistMuted(storageKey: string, muted: boolean) {
   }
 }
 
-const PAPER_STROKES: Record<CardSoundEvent, readonly PaperStroke[]> = {
+// A fixed D-minor-nine palette keeps repeated gestures cohesive and avoids the
+// synthetic chirp created by random pitch or fast frequency sweeps.
+const MYSTIC_TONES: Record<CardSoundEvent, readonly MysticTone[]> = {
   pickup: [
     {
-      duration: 0.052,
-      endHighpass: 1_500,
-      endLowpass: 6_500,
-      highpass: 1_050,
-      lowpass: 5_400,
-      volume: 0.055,
-    },
-    {
-      delay: 0.026,
-      duration: 0.018,
-      endHighpass: 1_700,
-      endLowpass: 5_600,
-      highpass: 2_200,
-      lowpass: 7_200,
-      volume: 0.025,
+      attack: 0.032,
+      duration: 0.21,
+      frequency: 174.61,
+      release: 0.15,
+      type: "triangle",
+      volume: 0.045,
     },
   ],
   move: [
     {
-      attack: 0.018,
-      duration: 0.16,
-      endHighpass: 320,
-      endLowpass: 2_200,
-      grainPulse: false,
-      highpass: 240,
-      lowpass: 2_600,
-      volume: 0.022,
+      attack: 0.042,
+      duration: 0.145,
+      frequency: 146.83,
+      release: 0.088,
+      type: "sine",
+      volume: 0.018,
     },
   ],
   drop: [
     {
-      attack: 0.002,
-      duration: 0.028,
-      endHighpass: 350,
-      endLowpass: 1_800,
-      highpass: 550,
-      lowpass: 2_600,
-      volume: 0.05,
+      attack: 0.016,
+      duration: 0.285,
+      echo: 0.28,
+      frequency: 146.83,
+      release: 0.245,
+      type: "triangle",
+      volume: 0.06,
     },
     {
-      attack: 0.002,
-      delay: 0.018,
-      duration: 0.06,
-      endHighpass: 45,
-      endLowpass: 700,
-      highpass: 80,
-      lowpass: 1_200,
-      volume: 0.075,
-    },
-    {
+      attack: 0.042,
       delay: 0.034,
-      duration: 0.045,
-      endHighpass: 600,
-      endLowpass: 2_400,
-      highpass: 900,
-      lowpass: 3_500,
-      volume: 0.035,
+      duration: 0.31,
+      frequency: 110,
+      release: 0.225,
+      type: "sine",
+      volume: 0.026,
     },
   ],
   flip: [
     {
-      duration: 0.105,
-      endHighpass: 1_650,
-      endLowpass: 3_600,
-      highpass: 800,
-      lowpass: 6_500,
-      volume: 0.055,
+      attack: 0.045,
+      duration: 0.36,
+      echo: 0.5,
+      frequency: 164.81,
+      release: 0.265,
+      type: "triangle",
+      volume: 0.044,
     },
     {
-      delay: 0.058,
-      duration: 0.055,
-      endHighpass: 850,
-      endLowpass: 4_200,
-      highpass: 1_800,
-      lowpass: 7_000,
-      volume: 0.035,
+      attack: 0.068,
+      delay: 0.072,
+      duration: 0.405,
+      echo: 0.45,
+      frequency: 220,
+      release: 0.255,
+      type: "sine",
+      volume: 0.024,
     },
   ],
   rotate: [
     {
-      duration: 0.06,
-      endHighpass: 900,
-      endLowpass: 4_200,
-      highpass: 1_400,
-      lowpass: 5_900,
-      volume: 0.034,
+      attack: 0.035,
+      duration: 0.185,
+      frequency: 174.61,
+      release: 0.12,
+      type: "sine",
+      volume: 0.022,
     },
   ],
   shuffle: [
     {
-      duration: 0.048,
-      endHighpass: 1_300,
-      endLowpass: 4_000,
-      highpass: 650,
-      lowpass: 6_200,
-      volume: 0.038,
+      attack: 0.058,
+      duration: 0.34,
+      echo: 0.35,
+      frequency: 146.83,
+      release: 0.22,
+      type: "triangle",
+      volume: 0.026,
     },
     {
-      delay: 0.04,
-      duration: 0.05,
-      endHighpass: 700,
-      endLowpass: 5_800,
-      highpass: 1_350,
-      lowpass: 4_100,
-      volume: 0.036,
+      attack: 0.062,
+      delay: 0.062,
+      duration: 0.305,
+      echo: 0.3,
+      frequency: 110,
+      release: 0.185,
+      type: "sine",
+      volume: 0.021,
     },
     {
-      delay: 0.082,
-      duration: 0.052,
-      endHighpass: 1_450,
-      endLowpass: 3_900,
-      highpass: 720,
-      lowpass: 6_400,
-      volume: 0.04,
-    },
-    {
+      attack: 0.048,
       delay: 0.126,
-      duration: 0.045,
-      endHighpass: 680,
-      endLowpass: 4_800,
-      highpass: 1_250,
-      lowpass: 3_700,
-      volume: 0.034,
+      duration: 0.285,
+      echo: 0.35,
+      frequency: 174.61,
+      release: 0.175,
+      type: "triangle",
+      volume: 0.016,
     },
   ],
   arrange: [
     {
-      duration: 0.068,
-      endHighpass: 950,
-      endLowpass: 5_600,
-      highpass: 620,
-      lowpass: 4_300,
-      volume: 0.038,
+      attack: 0.065,
+      duration: 0.39,
+      echo: 0.4,
+      frequency: 174.61,
+      release: 0.24,
+      type: "triangle",
+      volume: 0.032,
     },
     {
-      delay: 0.055,
-      duration: 0.072,
-      endHighpass: 650,
-      endLowpass: 4_100,
-      highpass: 1_000,
-      lowpass: 5_700,
-      volume: 0.036,
+      attack: 0.072,
+      delay: 0.108,
+      duration: 0.36,
+      echo: 0.4,
+      frequency: 220,
+      release: 0.21,
+      type: "sine",
+      volume: 0.018,
     },
   ],
   draw: [
     {
-      duration: 0.135,
-      endHighpass: 1_450,
-      endLowpass: 6_500,
-      highpass: 650,
-      lowpass: 4_200,
-      volume: 0.06,
+      attack: 0.082,
+      duration: 0.62,
+      echo: 0.55,
+      frequency: 146.83,
+      release: 0.33,
+      type: "triangle",
+      volume: 0.04,
     },
     {
-      delay: 0.006,
-      duration: 0.022,
-      endHighpass: 1_500,
-      endLowpass: 5_700,
-      highpass: 2_000,
-      lowpass: 7_200,
-      volume: 0.03,
-    },
-    {
-      delay: 0.102,
-      duration: 0.04,
-      endHighpass: 950,
-      endLowpass: 4_200,
-      highpass: 1_600,
-      lowpass: 6_000,
+      attack: 0.078,
+      delay: 0.128,
+      duration: 0.52,
+      echo: 0.5,
+      frequency: 174.61,
+      release: 0.265,
+      type: "sine",
       volume: 0.025,
+    },
+    {
+      attack: 0.065,
+      delay: 0.252,
+      duration: 0.39,
+      echo: 0.45,
+      frequency: 261.63,
+      release: 0.195,
+      type: "sine",
+      volume: 0.014,
     },
   ],
 };
 
-function jitter(value: number, amount = 0.12) {
-  return value * (1 + (Math.random() * 2 - 1) * amount);
-}
-
-function createPaperNoise(context: AudioContext) {
-  const length = Math.ceil(context.sampleRate * PAPER_NOISE_SECONDS);
-  const buffer = context.createBuffer(1, length, context.sampleRate);
-  const channel = buffer.getChannelData(0);
-  let smoothedNoise = 0;
-  let clusterSamples = 0;
-  let clusterLevel = 1;
-
-  for (let index = 0; index < length; index += 1) {
-    if (clusterSamples <= 0) {
-      clusterSamples = Math.round(
-        context.sampleRate * (0.001 + Math.random() * 0.007)
-      );
-      clusterLevel = 0.42 + Math.random() * 0.58;
-    }
-
-    const whiteNoise = Math.random() * 2 - 1;
-    smoothedNoise = smoothedNoise * 0.82 + whiteNoise * 0.18;
-    const fiberClick = Math.random() < 0.0025 ? whiteNoise * 0.75 : 0;
-    channel[index] = clamp(
-      (whiteNoise * 0.58 + smoothedNoise * 0.42) * clusterLevel + fiberClick,
-      -1,
-      1
-    );
-    clusterSamples -= 1;
-  }
-
-  return buffer;
-}
-
-function playPaperStroke({
-  activeStrokes,
-  context,
-  noise,
-  output,
-  stroke,
+function playMysticTone({
+  activeTones,
+  event,
+  graph,
   intensity,
+  tone,
 }: {
-  activeStrokes: Set<ActivePaperStroke>;
-  context: AudioContext;
-  noise: AudioBuffer;
-  output: AudioNode;
-  stroke: PaperStroke;
+  activeTones: Set<ActiveTone>;
+  event: CardSoundEvent;
+  graph: MysticAudioGraph;
   intensity: number;
+  tone: MysticTone;
 }) {
-  const delay = Math.max(0, jitter(stroke.delay ?? 0, 0.08));
-  const duration = Math.max(0.012, jitter(stroke.duration));
-  const startAt = context.currentTime + delay;
-  const stopAt = startAt + duration;
-  const attackAt = Math.min(
-    stopAt - 0.004,
-    startAt + Math.max(0.001, stroke.attack ?? duration * 0.08)
+  const { context } = graph;
+  const startAt = context.currentTime + Math.max(0, tone.delay ?? 0);
+  const stopAt = startAt + tone.duration;
+  const attackAt = Math.min(stopAt - 0.008, startAt + tone.attack);
+  const releaseAt = Math.max(
+    attackAt + 0.004,
+    stopAt - Math.min(tone.release, tone.duration - 0.012)
   );
-  const source = context.createBufferSource();
-  const highpass = context.createBiquadFilter();
+  const oscillator = context.createOscillator();
   const lowpass = context.createBiquadFilter();
   const gain = context.createGain();
-  const peak = Math.max(0.0001, jitter(stroke.volume) * intensity);
+  const echoSend = tone.echo ? context.createGain() : null;
+  const peak = Math.max(0.0001, tone.volume * intensity);
   let cleanedUp = false;
 
-  source.buffer = noise;
-  source.loop = true;
-  source.playbackRate.value = jitter(1, 0.14);
-  highpass.type = "highpass";
-  highpass.Q.value = 0.55;
-  highpass.frequency.setValueAtTime(jitter(stroke.highpass), startAt);
-  highpass.frequency.exponentialRampToValueAtTime(
-    Math.max(20, jitter(stroke.endHighpass ?? stroke.highpass)),
-    stopAt
-  );
+  oscillator.type = tone.type;
+  oscillator.frequency.setValueAtTime(tone.frequency, startAt);
   lowpass.type = "lowpass";
-  lowpass.Q.value = 0.7;
-  lowpass.frequency.setValueAtTime(jitter(stroke.lowpass), startAt);
-  lowpass.frequency.exponentialRampToValueAtTime(
-    Math.max(40, jitter(stroke.endLowpass ?? stroke.lowpass)),
-    stopAt
+  lowpass.Q.value = 0.35;
+  lowpass.frequency.setValueAtTime(
+    tone.lowpass ?? (tone.type === "triangle" ? 1_500 : 1_400),
+    startAt
   );
   gain.gain.setValueAtTime(0.0001, startAt);
   gain.gain.linearRampToValueAtTime(peak, attackAt);
+  gain.gain.setValueAtTime(peak, releaseAt);
+  gain.gain.exponentialRampToValueAtTime(0.0001, stopAt);
 
-  if (stroke.grainPulse !== false && duration >= 0.055) {
-    const notchAt = startAt + duration * 0.52;
-    gain.gain.linearRampToValueAtTime(peak * 0.48, notchAt);
-    gain.gain.linearRampToValueAtTime(
-      peak * 0.82,
-      Math.min(stopAt - 0.006, notchAt + duration * 0.13)
-    );
+  oscillator.connect(lowpass);
+  lowpass.connect(gain);
+  gain.connect(graph.output);
+
+  if (echoSend) {
+    echoSend.gain.value = clamp(tone.echo ?? 0, 0, 0.65);
+    gain.connect(echoSend);
+    echoSend.connect(graph.delay);
   }
 
-  gain.gain.exponentialRampToValueAtTime(0.0001, stopAt);
-  source.connect(highpass);
-  highpass.connect(lowpass);
-  lowpass.connect(gain);
-  gain.connect(output);
-
-  const activeStroke: ActivePaperStroke = {
-    source,
+  const activeTone: ActiveTone = {
+    event,
+    oscillator,
     cleanup: () => {
       if (cleanedUp) {
         return;
       }
 
       cleanedUp = true;
-      activeStrokes.delete(activeStroke);
-      source.disconnect();
-      highpass.disconnect();
+      activeTones.delete(activeTone);
+      oscillator.disconnect();
       lowpass.disconnect();
       gain.disconnect();
+      echoSend?.disconnect();
     },
   };
 
-  activeStrokes.add(activeStroke);
-  source.onended = activeStroke.cleanup;
-  source.start(startAt, Math.random() * noise.duration);
-  source.stop(stopAt + 0.012);
+  activeTones.add(activeTone);
+  oscillator.onended = activeTone.cleanup;
+  oscillator.start(startAt);
+  oscillator.stop(stopAt + 0.02);
 }
 
 /**
@@ -429,11 +377,25 @@ export function createCardSoundEngine(
   const volume = clamp(options.volume ?? DEFAULT_VOLUME, 0, 1);
   let muted = readMuted(storageKey, options.muted ?? false);
   let context: AudioContext | null = null;
-  let paperNoise: AudioBuffer | null = null;
-  let output: GainNode | null = null;
+  let graph: MysticAudioGraph | null = null;
   let disposed = false;
-  const activeStrokes = new Set<ActivePaperStroke>();
+  const activeTones = new Set<ActiveTone>();
   const lastPlayedAt = new Map<CardSoundEvent, number>();
+
+  const stopTone = (tone: ActiveTone) => {
+    try {
+      tone.oscillator.stop();
+    } catch {
+      // A tone that already ended is safe to clean up directly.
+    }
+
+    tone.cleanup();
+  };
+
+  const silenceActiveTones = () => {
+    Array.from(activeTones).forEach(stopTone);
+    activeTones.clear();
+  };
 
   const ensureAudioGraph = () => {
     if (disposed || typeof window === "undefined") {
@@ -459,22 +421,63 @@ export function createCardSoundEngine(
       void context.resume().catch(() => undefined);
     }
 
-    if (!paperNoise) {
-      paperNoise = createPaperNoise(context);
-    }
+    if (!graph) {
+      const output = context.createGain();
+      const delay = context.createDelay(0.5);
+      const echoFilter = context.createBiquadFilter();
+      const echoReturn = context.createGain();
+      const feedback = context.createGain();
 
-    if (!output) {
-      output = context.createGain();
-      output.gain.value = volume;
+      output.gain.value = muted ? 0 : volume;
+      delay.delayTime.value = ECHO_DELAY_SECONDS;
+      echoFilter.type = "lowpass";
+      echoFilter.frequency.value = 1_600;
+      echoFilter.Q.value = 0.35;
+      echoReturn.gain.value = muted ? 0 : ECHO_RETURN;
+      feedback.gain.value = muted ? 0 : ECHO_FEEDBACK;
+
+      delay.connect(echoFilter);
+      echoFilter.connect(echoReturn);
+      echoReturn.connect(output);
+      echoFilter.connect(feedback);
+      feedback.connect(delay);
       output.connect(context.destination);
+
+      graph = {
+        context,
+        delay,
+        echoFilter,
+        echoReturn,
+        feedback,
+        output,
+      };
     }
 
-    return { context, noise: paperNoise, output };
+    return graph;
+  };
+
+  const setGraphMuted = (nextMuted: boolean) => {
+    if (!graph) {
+      return;
+    }
+
+    graph.output.gain.value = nextMuted ? 0 : volume;
+
+    if (nextMuted) {
+      graph.echoReturn.gain.value = 0;
+      graph.feedback.gain.value = 0;
+    }
   };
 
   return {
     play(event, playOptions = {}) {
       if (muted || disposed) {
+        return;
+      }
+
+      const requestedIntensity = clamp(playOptions.intensity ?? 1, 0.25, 1);
+
+      if (event === "move" && requestedIntensity < 0.3) {
         return;
       }
 
@@ -485,26 +488,51 @@ export function createCardSoundEngine(
         return;
       }
 
-      const audioGraph = ensureAudioGraph();
-
       if (
-        !audioGraph ||
-        (event === "move" && activeStrokes.size >= MAX_ACTIVE_MOVE_STROKES)
+        event === "move" &&
+        Array.from(activeTones).filter((tone) => tone.event === "move").length >=
+          MAX_ACTIVE_MOVE_TONES
       ) {
         return;
       }
 
-      lastPlayedAt.set(event, playedAt);
-      const intensity = clamp(playOptions.intensity ?? 1, 0.25, 1);
+      const audioGraph = ensureAudioGraph();
 
-      PAPER_STROKES[event].forEach((stroke) => {
-        playPaperStroke({
-          activeStrokes,
-          context: audioGraph.context,
+      if (!audioGraph) {
+        return;
+      }
+
+      const tones = MYSTIC_TONES[event];
+
+      while (activeTones.size + tones.length > MAX_ACTIVE_TONES) {
+        const oldest =
+          Array.from(activeTones).find((tone) => tone.event !== "draw") ??
+          activeTones.values().next().value;
+
+        if (!oldest) {
+          break;
+        }
+
+        stopTone(oldest);
+      }
+
+      lastPlayedAt.set(event, playedAt);
+      audioGraph.output.gain.value = volume;
+      audioGraph.echoReturn.gain.value = ECHO_RETURN;
+      audioGraph.feedback.gain.value = ECHO_FEEDBACK;
+      const intensity = ["flip", "shuffle", "arrange", "draw"].includes(
+        event
+      )
+        ? Math.min(requestedIntensity, 0.85)
+        : requestedIntensity;
+
+      tones.forEach((tone) => {
+        playMysticTone({
+          activeTones,
+          event,
+          graph: audioGraph,
           intensity,
-          noise: audioGraph.noise,
-          output: audioGraph.output,
-          stroke,
+          tone,
         });
       });
     },
@@ -517,28 +545,36 @@ export function createCardSoundEngine(
     setMuted(nextMuted) {
       muted = nextMuted;
       persistMuted(storageKey, muted);
+      setGraphMuted(muted);
+
+      if (muted) {
+        silenceActiveTones();
+      }
     },
     toggleMuted() {
       muted = !muted;
       persistMuted(storageKey, muted);
+      setGraphMuted(muted);
+
+      if (muted) {
+        silenceActiveTones();
+      }
+
       return muted;
     },
     dispose() {
       disposed = true;
       lastPlayedAt.clear();
-      activeStrokes.forEach((stroke) => {
-        try {
-          stroke.source.stop();
-        } catch {
-          // A source that already ended is safe to clean up directly.
-        }
+      silenceActiveTones();
 
-        stroke.cleanup();
-      });
-      activeStrokes.clear();
-      output?.disconnect();
-      output = null;
-      paperNoise = null;
+      if (graph) {
+        graph.delay.disconnect();
+        graph.echoFilter.disconnect();
+        graph.echoReturn.disconnect();
+        graph.feedback.disconnect();
+        graph.output.disconnect();
+        graph = null;
+      }
 
       if (context) {
         void context.close().catch(() => undefined);

--- a/src/lib/card-sounds.ts
+++ b/src/lib/card-sounds.ts
@@ -1,7 +1,8 @@
 /**
  * Lightweight, asset-free sound effects for the tarot table. The palette uses
- * low, softly enveloped tones and a bounded echo instead of noise textures so
- * card interactions feel atmospheric without becoming sharp or fatiguing.
+ * low, softly enveloped sine tones and a short dark room tail instead of noise
+ * textures so card interactions feel atmospheric without becoming sharp or
+ * fatiguing.
  */
 
 export const CARD_SOUND_EVENTS = [
@@ -55,11 +56,10 @@ type MysticTone = {
   attack: number;
   delay?: number;
   duration: number;
-  echo?: number;
   frequency: number;
   lowpass?: number;
+  reverb?: number;
   release: number;
-  type: "sine" | "triangle";
   volume: number;
 };
 
@@ -70,19 +70,19 @@ type ActiveTone = {
 };
 
 type MysticAudioGraph = {
+  convolver: ConvolverNode;
   context: AudioContext;
-  delay: DelayNode;
-  echoFilter: BiquadFilterNode;
-  echoReturn: GainNode;
-  feedback: GainNode;
   output: GainNode;
+  preDelay: DelayNode;
+  reverbFilter: BiquadFilterNode;
+  reverbReturn: GainNode;
 };
 
 const DEFAULT_STORAGE_KEY = "tarot.card-sounds-muted";
-const DEFAULT_VOLUME = 0.2;
-const ECHO_DELAY_SECONDS = 0.24;
-const ECHO_FEEDBACK = 0.12;
-const ECHO_RETURN = 0.14;
+const DEFAULT_VOLUME = 0.18;
+const REVERB_DURATION_SECONDS = 0.74;
+const REVERB_PRE_DELAY_SECONDS = 0.028;
+const REVERB_RETURN = 0.11;
 const MAX_ACTIVE_TONES = 6;
 const MAX_ACTIVE_MOVE_TONES = 1;
 const THROTTLE_MS: Record<CardSoundEvent, number> = {
@@ -133,161 +133,181 @@ function persistMuted(storageKey: string, muted: boolean) {
   }
 }
 
-// A fixed D-minor-nine palette keeps repeated gestures cohesive and avoids the
-// synthetic chirp created by random pitch or fast frequency sweeps.
+function createDarkReverbImpulse(context: AudioContext) {
+  const length = Math.max(
+    1,
+    Math.floor(context.sampleRate * REVERB_DURATION_SECONDS)
+  );
+  const impulse = context.createBuffer(2, length, context.sampleRate);
+
+  for (
+    let channelIndex = 0;
+    channelIndex < impulse.numberOfChannels;
+    channelIndex += 1
+  ) {
+    const channel = impulse.getChannelData(channelIndex);
+    let seed = 0x5f3759df ^ ((channelIndex + 1) * 0x45d9f3b);
+    let smoothed = 0;
+
+    for (let sampleIndex = 0; sampleIndex < length; sampleIndex += 1) {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const noise = (seed / 0xffffffff) * 2 - 1;
+      smoothed += (noise - smoothed) * 0.18;
+
+      const progress = sampleIndex / Math.max(1, length - 1);
+      const fadeIn = Math.min(1, progress / 0.025);
+      channel[sampleIndex] =
+        smoothed * fadeIn * Math.pow(1 - progress, 2.7) * 0.24;
+    }
+  }
+
+  return impulse;
+}
+
+// A low D-minor-nine palette keeps repeated gestures cohesive. Every voice is
+// a fixed sine wave: the depth comes from the harmony and room tail, never a
+// buzzy waveform, randomized pitch, or synthetic frequency sweep.
 const MYSTIC_TONES: Record<CardSoundEvent, readonly MysticTone[]> = {
   pickup: [
     {
-      attack: 0.032,
-      duration: 0.21,
-      frequency: 174.61,
-      release: 0.15,
-      type: "triangle",
-      volume: 0.045,
+      attack: 0.055,
+      duration: 0.28,
+      frequency: 146.83,
+      release: 0.19,
+      reverb: 0.08,
+      volume: 0.032,
     },
   ],
   move: [
     {
-      attack: 0.042,
-      duration: 0.145,
-      frequency: 146.83,
-      release: 0.088,
-      type: "sine",
-      volume: 0.018,
+      attack: 0.06,
+      duration: 0.24,
+      frequency: 110,
+      release: 0.16,
+      volume: 0.012,
     },
   ],
   drop: [
     {
-      attack: 0.016,
-      duration: 0.285,
-      echo: 0.28,
-      frequency: 146.83,
-      release: 0.245,
-      type: "triangle",
-      volume: 0.06,
+      attack: 0.045,
+      duration: 0.42,
+      frequency: 110,
+      release: 0.3,
+      reverb: 0.2,
+      volume: 0.045,
     },
     {
-      attack: 0.042,
-      delay: 0.034,
-      duration: 0.31,
-      frequency: 110,
-      release: 0.225,
-      type: "sine",
-      volume: 0.026,
+      attack: 0.072,
+      delay: 0.05,
+      duration: 0.4,
+      frequency: 146.83,
+      release: 0.27,
+      reverb: 0.14,
+      volume: 0.018,
     },
   ],
   flip: [
     {
-      attack: 0.045,
-      duration: 0.36,
-      echo: 0.5,
-      frequency: 164.81,
-      release: 0.265,
-      type: "triangle",
-      volume: 0.044,
+      attack: 0.068,
+      duration: 0.56,
+      frequency: 146.83,
+      release: 0.34,
+      reverb: 0.34,
+      volume: 0.034,
     },
     {
-      attack: 0.068,
-      delay: 0.072,
-      duration: 0.405,
-      echo: 0.45,
-      frequency: 220,
-      release: 0.255,
-      type: "sine",
-      volume: 0.024,
+      attack: 0.082,
+      delay: 0.085,
+      duration: 0.58,
+      frequency: 110,
+      release: 0.32,
+      reverb: 0.3,
+      volume: 0.022,
     },
   ],
   rotate: [
     {
-      attack: 0.035,
-      duration: 0.185,
-      frequency: 174.61,
-      release: 0.12,
-      type: "sine",
-      volume: 0.022,
+      attack: 0.06,
+      duration: 0.26,
+      frequency: 146.83,
+      release: 0.17,
+      reverb: 0.1,
+      volume: 0.016,
     },
   ],
   shuffle: [
     {
-      attack: 0.058,
-      duration: 0.34,
-      echo: 0.35,
-      frequency: 146.83,
-      release: 0.22,
-      type: "triangle",
-      volume: 0.026,
-    },
-    {
-      attack: 0.062,
-      delay: 0.062,
-      duration: 0.305,
-      echo: 0.3,
+      attack: 0.075,
+      duration: 0.48,
       frequency: 110,
-      release: 0.185,
-      type: "sine",
-      volume: 0.021,
+      release: 0.3,
+      reverb: 0.18,
+      volume: 0.019,
     },
     {
-      attack: 0.048,
-      delay: 0.126,
-      duration: 0.285,
-      echo: 0.35,
-      frequency: 174.61,
-      release: 0.175,
-      type: "triangle",
+      attack: 0.082,
+      delay: 0.07,
+      duration: 0.5,
+      frequency: 87.31,
+      release: 0.31,
+      reverb: 0.16,
       volume: 0.016,
+    },
+    {
+      attack: 0.07,
+      delay: 0.145,
+      duration: 0.42,
+      frequency: 146.83,
+      release: 0.25,
+      reverb: 0.12,
+      volume: 0.012,
     },
   ],
   arrange: [
     {
-      attack: 0.065,
-      duration: 0.39,
-      echo: 0.4,
-      frequency: 174.61,
-      release: 0.24,
-      type: "triangle",
-      volume: 0.032,
+      attack: 0.08,
+      duration: 0.54,
+      frequency: 146.83,
+      release: 0.32,
+      reverb: 0.26,
+      volume: 0.026,
     },
     {
-      attack: 0.072,
-      delay: 0.108,
-      duration: 0.36,
-      echo: 0.4,
-      frequency: 220,
-      release: 0.21,
-      type: "sine",
-      volume: 0.018,
+      attack: 0.09,
+      delay: 0.12,
+      duration: 0.52,
+      frequency: 174.61,
+      release: 0.3,
+      reverb: 0.2,
+      volume: 0.016,
     },
   ],
   draw: [
     {
-      attack: 0.082,
-      duration: 0.62,
-      echo: 0.55,
+      attack: 0.09,
+      duration: 0.74,
+      frequency: 110,
+      release: 0.4,
+      reverb: 0.4,
+      volume: 0.03,
+    },
+    {
+      attack: 0.09,
+      delay: 0.14,
+      duration: 0.66,
       frequency: 146.83,
-      release: 0.33,
-      type: "triangle",
-      volume: 0.04,
+      release: 0.35,
+      reverb: 0.32,
+      volume: 0.02,
     },
     {
-      attack: 0.078,
-      delay: 0.128,
+      attack: 0.08,
+      delay: 0.27,
       duration: 0.52,
-      echo: 0.5,
       frequency: 174.61,
-      release: 0.265,
-      type: "sine",
-      volume: 0.025,
-    },
-    {
-      attack: 0.065,
-      delay: 0.252,
-      duration: 0.39,
-      echo: 0.45,
-      frequency: 261.63,
-      release: 0.195,
-      type: "sine",
-      volume: 0.014,
+      release: 0.29,
+      reverb: 0.26,
+      volume: 0.012,
     },
   ],
 };
@@ -316,18 +336,15 @@ function playMysticTone({
   const oscillator = context.createOscillator();
   const lowpass = context.createBiquadFilter();
   const gain = context.createGain();
-  const echoSend = tone.echo ? context.createGain() : null;
+  const reverbSend = tone.reverb ? context.createGain() : null;
   const peak = Math.max(0.0001, tone.volume * intensity);
   let cleanedUp = false;
 
-  oscillator.type = tone.type;
+  oscillator.type = "sine";
   oscillator.frequency.setValueAtTime(tone.frequency, startAt);
   lowpass.type = "lowpass";
-  lowpass.Q.value = 0.35;
-  lowpass.frequency.setValueAtTime(
-    tone.lowpass ?? (tone.type === "triangle" ? 1_500 : 1_400),
-    startAt
-  );
+  lowpass.Q.value = 0.2;
+  lowpass.frequency.setValueAtTime(tone.lowpass ?? 1_050, startAt);
   gain.gain.setValueAtTime(0.0001, startAt);
   gain.gain.linearRampToValueAtTime(peak, attackAt);
   gain.gain.setValueAtTime(peak, releaseAt);
@@ -337,10 +354,10 @@ function playMysticTone({
   lowpass.connect(gain);
   gain.connect(graph.output);
 
-  if (echoSend) {
-    echoSend.gain.value = clamp(tone.echo ?? 0, 0, 0.65);
-    gain.connect(echoSend);
-    echoSend.connect(graph.delay);
+  if (reverbSend) {
+    reverbSend.gain.value = clamp(tone.reverb ?? 0, 0, 0.5);
+    gain.connect(reverbSend);
+    reverbSend.connect(graph.preDelay);
   }
 
   const activeTone: ActiveTone = {
@@ -356,7 +373,7 @@ function playMysticTone({
       oscillator.disconnect();
       lowpass.disconnect();
       gain.disconnect();
-      echoSend?.disconnect();
+      reverbSend?.disconnect();
     },
   };
 
@@ -423,33 +440,32 @@ export function createCardSoundEngine(
 
     if (!graph) {
       const output = context.createGain();
-      const delay = context.createDelay(0.5);
-      const echoFilter = context.createBiquadFilter();
-      const echoReturn = context.createGain();
-      const feedback = context.createGain();
+      const preDelay = context.createDelay(0.1);
+      const convolver = context.createConvolver();
+      const reverbFilter = context.createBiquadFilter();
+      const reverbReturn = context.createGain();
 
       output.gain.value = muted ? 0 : volume;
-      delay.delayTime.value = ECHO_DELAY_SECONDS;
-      echoFilter.type = "lowpass";
-      echoFilter.frequency.value = 1_600;
-      echoFilter.Q.value = 0.35;
-      echoReturn.gain.value = muted ? 0 : ECHO_RETURN;
-      feedback.gain.value = muted ? 0 : ECHO_FEEDBACK;
+      preDelay.delayTime.value = REVERB_PRE_DELAY_SECONDS;
+      convolver.buffer = createDarkReverbImpulse(context);
+      reverbFilter.type = "lowpass";
+      reverbFilter.frequency.value = 950;
+      reverbFilter.Q.value = 0.25;
+      reverbReturn.gain.value = muted ? 0 : REVERB_RETURN;
 
-      delay.connect(echoFilter);
-      echoFilter.connect(echoReturn);
-      echoReturn.connect(output);
-      echoFilter.connect(feedback);
-      feedback.connect(delay);
+      preDelay.connect(convolver);
+      convolver.connect(reverbFilter);
+      reverbFilter.connect(reverbReturn);
+      reverbReturn.connect(output);
       output.connect(context.destination);
 
       graph = {
+        convolver,
         context,
-        delay,
-        echoFilter,
-        echoReturn,
-        feedback,
         output,
+        preDelay,
+        reverbFilter,
+        reverbReturn,
       };
     }
 
@@ -464,8 +480,7 @@ export function createCardSoundEngine(
     graph.output.gain.value = nextMuted ? 0 : volume;
 
     if (nextMuted) {
-      graph.echoReturn.gain.value = 0;
-      graph.feedback.gain.value = 0;
+      graph.reverbReturn.gain.value = 0;
     }
   };
 
@@ -518,8 +533,7 @@ export function createCardSoundEngine(
 
       lastPlayedAt.set(event, playedAt);
       audioGraph.output.gain.value = volume;
-      audioGraph.echoReturn.gain.value = ECHO_RETURN;
-      audioGraph.feedback.gain.value = ECHO_FEEDBACK;
+      audioGraph.reverbReturn.gain.value = REVERB_RETURN;
       const intensity = ["flip", "shuffle", "arrange", "draw"].includes(
         event
       )
@@ -568,10 +582,10 @@ export function createCardSoundEngine(
       silenceActiveTones();
 
       if (graph) {
-        graph.delay.disconnect();
-        graph.echoFilter.disconnect();
-        graph.echoReturn.disconnect();
-        graph.feedback.disconnect();
+        graph.preDelay.disconnect();
+        graph.convolver.disconnect();
+        graph.reverbFilter.disconnect();
+        graph.reverbReturn.disconnect();
         graph.output.disconnect();
         graph = null;
       }


### PR DESCRIPTION
## Why

Card interactions had started to feel mystical, but triangle harmonics and a clearly timed echo still made the feedback sound electronic. The remaining deck also read as one solid slab, and lifting its top card exposed bare beige edge geometry instead of the next card back.

## What changed

- retuned all eight card interactions to fixed low sine harmonies with softer attacks and longer releases
- replaced the feedback echo with one shared 740 ms dark room tail, a 28 ms pre-delay, and a 950 Hz low-pass filter
- preserved lazy audio setup, voice caps, throttling, persisted mute, and cleanup without using audible noise or buffer sources
- rebuilt the remaining deck as up to seven thin, count-aware paper layers with restrained registration offsets and stable depth handling
- added a passive back cap to the paper stack so the next card remains visible during pickup while the live top card stays the deck's only pointer target

A deterministic Web Audio check covers topology, pitches, envelopes, limits, mute, throttling, and disposal. Desktop and responsive mobile browser QA covered a full deck, a held top-card drag, fast release, whole-deck movement, and animated flip with no runtime errors.
