### PR TITLE
Refine historic decks and localize the tarot table

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "validate:lenormand-assets": "node scripts/validate-lenormand-assets.mjs",
     "build:marseille-assets": "node scripts/build-marseille-assets.mjs",
     "validate:marseille-assets": "node scripts/validate-marseille-assets.mjs",
+    "validate:locales": "node scripts/validate-locales.mjs",
     "validate:card-readings": "node scripts/validate-card-readings.mjs"
   },
   "dependencies": {

--- a/scripts/validate-card-readings.mjs
+++ b/scripts/validate-card-readings.mjs
@@ -22,30 +22,103 @@ function loadTypeScriptModule(file) {
   return loadedModule.exports;
 }
 
-const { cardSets } = loadTypeScriptModule("src/data/card-sets.ts");
+const {
+  cardSets,
+  getCardDisplayName,
+  getCardSetDisplayDescription,
+  getCardSetDisplayLabel,
+  getCardSetDisplayShortLabel,
+} = loadTypeScriptModule("src/data/card-sets.ts");
 const { getCardReading } = loadTypeScriptModule(
   "src/data/card-readings.ts"
 );
 const failures = [];
+const locales = ["en", "pt-BR"];
+const pollackSource =
+  "https://redwheelweiser.com/book/seventy-eight-degrees-of-wisdom-9781578636655/";
+const englishAstrologyNames =
+  /^(Air|Aquarius|Aries|Cancer|Capricorn|Earth|Fire|Gemini|Jupiter|Leo|Mars|Mercury|Moon|Pisces|Sagittarius|Saturn|Scorpio|Sun|Taurus|Venus|Virgo|Water)\b/;
 
 for (const cardSet of cardSets) {
-  for (const card of cardSet.cards) {
-    const reading = getCardReading(cardSet.id, card);
-
-    if (!reading?.summary.trim()) {
-      failures.push(`${cardSet.id}:${card.id} has no summary`);
+  for (const locale of locales) {
+    if (!getCardSetDisplayLabel(cardSet, locale).trim()) {
+      failures.push(`${cardSet.id}:${locale} has no display label`);
     }
 
-    if (!reading || reading.correspondences.length < 2) {
-      failures.push(`${cardSet.id}:${card.id} has too few correspondences`);
+    if (!getCardSetDisplayShortLabel(cardSet, locale).trim()) {
+      failures.push(`${cardSet.id}:${locale} has no short display label`);
+    }
+
+    if (!getCardSetDisplayDescription(cardSet, locale).trim()) {
+      failures.push(`${cardSet.id}:${locale} has no display description`);
     }
 
     if (
-      !reading ||
-      reading.sources.length === 0 ||
-      reading.sources.some((source) => !source.href.startsWith("https://"))
+      locale === "pt-BR" &&
+      (!cardSet.displayLabels?.[locale] ||
+        !cardSet.displayShortLabels?.[locale] ||
+        !cardSet.displayDescriptions?.[locale])
     ) {
-      failures.push(`${cardSet.id}:${card.id} has invalid sources`);
+      failures.push(`${cardSet.id}:${locale} is missing direct localized deck metadata`);
+    }
+
+    for (const card of cardSet.cards) {
+      const cardKey = `${cardSet.id}:${card.id}:${locale}`;
+      const name = getCardDisplayName(card, locale);
+      const reading = getCardReading(cardSet.id, card, locale);
+
+      if (!name?.trim()) {
+        failures.push(`${cardKey} has no display name`);
+      }
+
+      if (locale === "pt-BR" && !card.displayNames?.[locale]) {
+        failures.push(`${cardKey} is missing a direct localized card name`);
+      }
+
+      if (!reading?.summary.trim()) {
+        failures.push(`${cardKey} has no summary`);
+      }
+
+      if (!reading || reading.correspondences.length < 2) {
+        failures.push(`${cardKey} has too few correspondences`);
+      }
+
+      if (
+        !reading ||
+        reading.sources.length === 0 ||
+        reading.sources.some(
+          (source) =>
+            !source.label.trim() ||
+            !source.locator?.trim() ||
+            !source.href.startsWith("https://")
+        )
+      ) {
+        failures.push(`${cardKey} has invalid sources`);
+      }
+
+      const hasPollack = reading?.sources.some(
+        (source) => source.href === pollackSource
+      );
+
+      if (cardSet.id === "rider-waite-smith") {
+        if (
+          !hasPollack ||
+          !reading?.perspective?.label ||
+          !reading.perspective.text
+        ) {
+          failures.push(`${cardKey} is missing the Rachel Pollack methodology lens`);
+        }
+
+        const astrology = reading?.correspondences.find(
+          ({ label }) => label === "Astrologia"
+        )?.value;
+
+        if (locale === "pt-BR" && astrology && englishAstrologyNames.test(astrology)) {
+          failures.push(`${cardKey} has untranslated astrology metadata`);
+        }
+      } else if (hasPollack || reading?.perspective) {
+        failures.push(`${cardKey} incorrectly includes the Rachel Pollack lens`);
+      }
     }
   }
 }
@@ -60,6 +133,6 @@ if (failures.length > 0) {
   );
 
   console.log(
-    `Validated ${cardCount} card readings across ${cardSets.length} decks.`
+    `Validated ${cardCount} card readings and display names in ${locales.length} locales across ${cardSets.length} decks.`
   );
 }

--- a/scripts/validate-locales.mjs
+++ b/scripts/validate-locales.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+const source = fs.readFileSync("src/i18n/locale.ts", "utf8");
+const code = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+  },
+}).outputText;
+const loadedModule = { exports: {} };
+
+Function("exports", "module", code)(loadedModule.exports, loadedModule);
+
+const { getBrowserLocale, isAppLocale } = loadedModule.exports;
+
+assert.equal(getBrowserLocale(["pt-BR", "en-US"]), "pt-BR");
+assert.equal(getBrowserLocale(["pt-PT"]), "pt-BR");
+assert.equal(getBrowserLocale(["en-US", "pt-BR"]), "en");
+assert.equal(getBrowserLocale(["es-419", "pt-BR"]), "pt-BR");
+assert.equal(getBrowserLocale(["en-US", "es-419"]), "en");
+assert.equal(getBrowserLocale([]), "en");
+assert.equal(isAppLocale("en"), true);
+assert.equal(isAppLocale("pt-BR"), true);
+assert.equal(isAppLocale("pt"), false);
+
+console.log("Validated browser locale resolution for English and Brazilian Portuguese.");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -916,7 +916,7 @@ button {
   bottom: calc(100% + 0.58rem);
   z-index: 4;
   width: min(19rem, calc(100vw - 2rem));
-  max-height: min(24rem, calc(100dvh - 7rem));
+  max-height: min(36rem, calc(100dvh - 7rem));
   padding: 0.68rem;
   overflow-y: auto;
   overscroll-behavior: contain;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -720,6 +720,7 @@ button {
 .tarot-deck-menu,
 .tarot-zoom-menu,
 .tarot-card-menu,
+.tarot-language-menu,
 .tarot-spread-menu,
 .tarot-arrange-menu,
 .tarot-shuffle-menu {
@@ -769,6 +770,94 @@ button {
 
 .tarot-sound-toggle[aria-pressed="false"] {
   color: var(--faint-ink);
+}
+
+.tarot-language-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.58rem);
+  z-index: 4;
+  width: 12.4rem;
+  padding: 0.52rem;
+  border: 1px solid var(--panel-edge);
+  border-radius: 0.82rem;
+  background: rgba(20, 11, 29, 0.98);
+  box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
+  animation: tarot-popover-enter 150ms ease-out both;
+}
+
+.tarot-language-popover > span {
+  display: block;
+  margin: 0.14rem 0.38rem 0.38rem;
+  color: var(--faint-ink);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.tarot-language-popover [role="radiogroup"] {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.tarot-language-popover button {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  width: 100%;
+  min-height: 2.8rem;
+  padding: 0.48rem 0.58rem;
+  border: 1px solid rgba(247, 239, 217, 0.12);
+  border-radius: 0.45rem;
+  background: rgba(48, 28, 59, 0.58);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease,
+    transform 160ms ease;
+}
+
+.tarot-language-popover button:hover,
+.tarot-language-popover button[aria-checked="true"] {
+  border-color: rgba(234, 212, 155, 0.5);
+  background: var(--control-hover);
+}
+
+.tarot-language-popover button:hover {
+  transform: translateY(-1px);
+}
+
+.tarot-language-popover button > span {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 0.71rem;
+  letter-spacing: 0.09em;
+}
+
+.tarot-language-popover button small {
+  color: var(--faint-ink);
+  font-size: 0.74rem;
+}
+
+.tarot-card-perspective {
+  margin-top: 0.72rem;
+  padding-top: 0.72rem;
+  border-top: 1px solid rgba(234, 212, 155, 0.12);
+}
+
+.tarot-card-perspective > span {
+  color: var(--faint-ink);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.tarot-card-perspective p {
+  margin: 0.3rem 0 0;
 }
 
 @media (min-width: 768px) and (hover: hover) and (pointer: fine) {
@@ -988,7 +1077,7 @@ select:focus-visible {
     left: auto;
     inset-inline-end: 0;
     width: min(20rem, calc(100vw - 1.25rem));
-    max-height: calc(100dvh - 6.2rem);
+    max-height: calc(100dvh - 7.5rem);
     min-height: 0;
     padding: 0.68rem 0.72rem 0.74rem;
     transform: none;
@@ -1062,7 +1151,7 @@ select:focus-visible {
     bottom: calc(100% + 0.42rem);
     left: auto;
     width: min(20rem, calc(100vw - 1.25rem));
-    max-height: calc(100dvh - 6.2rem);
+    max-height: calc(100dvh - 7.5rem);
     padding: 0.52rem;
     transform: none;
     animation-name: tarot-popover-enter;
@@ -1130,6 +1219,24 @@ select:focus-visible {
     display: none;
   }
 
+  .tarot-language-trigger {
+    width: 2.75rem;
+    padding: 0.24rem;
+  }
+
+  .tarot-language-trigger > span {
+    display: inline;
+    color: var(--accent-bright);
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+  }
+
+  .tarot-language-popover {
+    bottom: calc(100% + 0.42rem);
+    width: min(12.4rem, calc(100vw - 1.25rem));
+  }
+
   .tarot-toolbar-trigger svg,
   .tarot-mode-cancel svg {
     width: 1.05rem;
@@ -1158,8 +1265,12 @@ select:focus-visible {
 @media (max-width: 399px) {
   .tarot-toolbar-trigger,
   .tarot-mode-cancel {
-    width: 2.5rem;
-    min-height: 2.5rem;
+    width: 2.25rem;
+    min-height: 2.25rem;
+  }
+
+  .tarot-language-trigger {
+    width: 2.25rem;
   }
 }
 
@@ -1168,6 +1279,13 @@ select:focus-visible {
     gap: 0.16rem;
     max-width: calc(100vw - 0.5rem);
     padding: 0.2rem;
+  }
+
+  .tarot-toolbar-trigger,
+  .tarot-mode-cancel,
+  .tarot-language-trigger {
+    width: 2.15rem;
+    min-height: 2.15rem;
   }
 
   .tarot-zoom-controls {
@@ -1181,7 +1299,7 @@ select:focus-visible {
 
   .tarot-inspector {
     right: auto;
-    inset-inline-end: 0;
+    inset-inline-end: -0.7rem;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,6 +132,16 @@ button {
   cursor: grabbing;
 }
 
+.tarot-canvas-shell[data-space-pan="ready"],
+.tarot-canvas-shell[data-space-pan="ready"] .tarot-canvas {
+  cursor: grab;
+}
+
+.tarot-canvas-shell[data-space-pan="active"],
+.tarot-canvas-shell[data-space-pan="active"] .tarot-canvas {
+  cursor: grabbing;
+}
+
 .tarot-scene-loading {
   position: absolute;
   inset: 0;
@@ -201,9 +211,9 @@ button {
   left: 0;
   z-index: 4;
   display: grid;
-  gap: 0.38rem;
-  width: min(18.5rem, calc(100vw - 2rem));
-  padding: 0.62rem 0.68rem 0.68rem;
+  gap: 0.52rem;
+  width: min(20rem, calc(100vw - 2rem));
+  padding: 0.76rem 0.8rem 0.8rem;
   border: 1px solid var(--panel-edge);
   border-radius: 0.82rem;
   background: rgba(20, 11, 29, 0.98);
@@ -224,8 +234,8 @@ button {
 
 .tarot-set-picker select {
   width: 100%;
-  min-height: 2.75rem;
-  padding: 0.55rem 2.2rem 0.55rem 0.65rem;
+  min-height: 3rem;
+  padding: 0.62rem 2.35rem 0.62rem 0.72rem;
   border: 1px solid rgba(247, 239, 217, 0.2);
   border-radius: 0.55rem;
   color: var(--ink);
@@ -245,6 +255,16 @@ button {
 .tarot-set-picker option {
   color: var(--ink);
   background: #201229;
+}
+
+.tarot-set-picker .tarot-set-picker-description {
+  margin: 0.08rem 0 0;
+  color: var(--muted-ink);
+  font-family: var(--font-serif);
+  font-size: 0.82rem;
+  letter-spacing: 0;
+  line-height: 1.45;
+  text-transform: none;
 }
 
 .tarot-inspector {
@@ -515,6 +535,7 @@ button {
 .tarot-inspector-actions button,
 .tarot-zoom-controls button,
 .tarot-toolbar-trigger,
+.tarot-reset-trigger,
 .tarot-mode-cancel {
   min-height: 2.75rem;
   padding: 0.42rem 0.7rem;
@@ -534,6 +555,7 @@ button {
 .tarot-inspector-actions button:hover:not(:disabled),
 .tarot-zoom-controls button:hover:not(:disabled),
 .tarot-toolbar-trigger:hover:not(:disabled),
+.tarot-reset-trigger:hover:not(:disabled),
 .tarot-mode-cancel:hover:not(:disabled) {
   border-color: var(--accent-bright);
   background: var(--control-hover);
@@ -545,6 +567,7 @@ button {
 .tarot-inspector-actions button:disabled,
 .tarot-zoom-controls button:disabled,
 .tarot-toolbar-trigger:disabled,
+.tarot-reset-trigger:disabled,
 .tarot-arrange-popover button:disabled {
   cursor: not-allowed;
   opacity: 0.42;
@@ -722,8 +745,7 @@ button {
 .tarot-card-menu,
 .tarot-language-menu,
 .tarot-spread-menu,
-.tarot-arrange-menu,
-.tarot-shuffle-menu {
+.tarot-arrange-menu {
   position: relative;
   flex: 0 0 auto;
 }
@@ -738,11 +760,32 @@ button {
   color: var(--muted-ink);
 }
 
+.tarot-reset-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.34rem;
+  flex: 0 0 auto;
+  padding-inline: 0.62rem;
+  border-color: rgba(247, 239, 217, 0.18);
+  color: var(--muted-ink);
+}
+
 .tarot-zoom-trigger {
   display: none;
 }
 
 .tarot-toolbar-trigger svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.tarot-reset-trigger svg {
   width: 0.9rem;
   height: 0.9rem;
   fill: none;
@@ -867,15 +910,14 @@ button {
   }
 }
 
-.tarot-arrange-popover,
-.tarot-shuffle-popover {
+.tarot-arrange-popover {
   position: absolute;
   right: 0;
   bottom: calc(100% + 0.58rem);
   z-index: 4;
-  width: 13.5rem;
+  width: min(19rem, calc(100vw - 2rem));
   max-height: min(24rem, calc(100dvh - 7rem));
-  padding: 0.52rem;
+  padding: 0.68rem;
   overflow-y: auto;
   overscroll-behavior: contain;
   border: 1px solid var(--panel-edge);
@@ -888,13 +930,11 @@ button {
 
 .tarot-arrange-popover {
   left: 50%;
-  width: 17rem;
   transform: translateX(-50%);
 }
 
-.tarot-arrange-popover > p,
-.tarot-shuffle-popover > p {
-  margin: 0.14rem 0.38rem 0.38rem;
+.tarot-arrange-popover > p {
+  margin: 0.08rem 0.2rem 0.48rem;
   color: var(--faint-ink);
   font-family: var(--font-mono);
   font-size: 0.625rem;
@@ -902,17 +942,41 @@ button {
   text-transform: uppercase;
 }
 
-.tarot-arrange-popover > div {
+.tarot-arrange-popover > div:not(.tarot-arrange-section),
+.tarot-arrange-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.28rem;
+  gap: 0.38rem;
+}
+
+.tarot-arrange-section {
+  display: grid;
+  gap: 0.36rem;
+}
+
+.tarot-arrange-grid + .tarot-arrange-section,
+.tarot-arrange-section + .tarot-arrange-section {
+  margin-top: 0.64rem;
+  padding-top: 0.64rem;
+  border-top: 1px solid rgba(234, 212, 155, 0.14);
+}
+
+.tarot-arrange-section-title {
+  margin: 0 0.16rem;
+  color: var(--faint-ink);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.13em;
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 .tarot-arrange-popover button {
   display: grid;
   gap: 0.1rem;
-  min-height: 3.25rem;
-  padding: 0.48rem 0.56rem;
+  min-height: 3.45rem;
+  padding: 0.54rem 0.62rem;
   border: 1px solid rgba(247, 239, 217, 0.12);
   border-radius: 0.42rem;
   background: rgba(48, 28, 59, 0.58);
@@ -940,38 +1004,6 @@ button {
   font-size: 0.625rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.tarot-shuffle-popover button {
-  display: grid;
-  width: 100%;
-  gap: 0.12rem;
-  min-height: 3.25rem;
-  padding: 0.68rem 0.72rem;
-  border: 1px solid transparent;
-  border-radius: 0.18rem;
-  background: transparent;
-  color: var(--ink);
-  text-align: left;
-  cursor: pointer;
-  transition: border-color 160ms ease, background 160ms ease;
-}
-
-.tarot-shuffle-popover button:hover {
-  border-color: rgba(234, 212, 155, 0.38);
-  background: var(--control-hover);
-}
-
-.tarot-shuffle-popover button span {
-  font-size: 0.95rem;
-  line-height: 1.05;
-}
-
-.tarot-shuffle-popover button small {
-  color: var(--faint-ink);
-  font-family: var(--font-mono);
-  font-size: 0.625rem;
-  letter-spacing: 0.03em;
 }
 
 .tarot-live-status {
@@ -1057,8 +1089,8 @@ select:focus-visible {
 
   .tarot-set-picker {
     bottom: calc(100% + 0.42rem);
-    width: min(18rem, calc(100vw - 1.25rem));
-    padding: 0.52rem 0.58rem 0.58rem;
+    width: min(19rem, calc(100vw - 1.25rem));
+    padding: 0.62rem 0.66rem 0.68rem;
   }
 
   .tarot-set-picker label,
@@ -1067,7 +1099,7 @@ select:focus-visible {
   }
 
   .tarot-set-picker select {
-    min-height: 2.75rem;
+    min-height: 2.9rem;
     font-size: 0.86rem;
   }
 
@@ -1205,6 +1237,7 @@ select:focus-visible {
   }
 
   .tarot-toolbar-trigger,
+  .tarot-reset-trigger,
   .tarot-mode-cancel {
     width: 2.75rem;
     min-height: 2.75rem;
@@ -1214,6 +1247,7 @@ select:focus-visible {
   }
 
   .tarot-toolbar-trigger > span,
+  .tarot-reset-trigger > span,
   .tarot-mode-cancel > span,
   .tarot-menu-chevron {
     display: none;
@@ -1238,23 +1272,19 @@ select:focus-visible {
   }
 
   .tarot-toolbar-trigger svg,
+  .tarot-reset-trigger svg,
   .tarot-mode-cancel svg {
     width: 1.05rem;
     height: 1.05rem;
   }
 
   .tarot-arrange-popover {
-    right: -6.3rem;
-    left: auto;
+    right: auto;
+    left: 50%;
     bottom: calc(100% + 0.42rem);
-    width: min(17rem, calc(100vw - 1.25rem));
-    transform: none;
-    animation-name: tarot-popover-enter;
-  }
-
-  .tarot-shuffle-popover {
-    bottom: calc(100% + 0.42rem);
-    width: min(13.5rem, calc(100vw - 1.25rem));
+    width: min(19rem, calc(100vw - 1.25rem));
+    transform: translateX(-50%);
+    animation-name: tarot-arrange-popover-enter;
   }
 
   .tarot-live-status {
@@ -1264,6 +1294,7 @@ select:focus-visible {
 
 @media (max-width: 399px) {
   .tarot-toolbar-trigger,
+  .tarot-reset-trigger,
   .tarot-mode-cancel {
     width: 2.25rem;
     min-height: 2.25rem;
@@ -1282,6 +1313,7 @@ select:focus-visible {
   }
 
   .tarot-toolbar-trigger,
+  .tarot-reset-trigger,
   .tarot-mode-cancel,
   .tarot-language-trigger {
     width: 2.15rem;
@@ -1291,6 +1323,16 @@ select:focus-visible {
   .tarot-zoom-controls {
     grid-template-columns: 2.5rem 2.75rem 2.5rem;
     gap: 0.1rem;
+  }
+
+  .tarot-arrange-popover {
+    position: fixed;
+    right: 0.625rem;
+    bottom: calc(max(0.65rem, var(--safe-bottom)) + 3rem);
+    left: 0.625rem;
+    width: auto;
+    transform: none;
+    animation-name: tarot-popover-enter;
   }
 
   .tarot-spread-actions {

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -19,6 +19,7 @@ import {
   MathUtils,
   Mesh,
   Plane,
+  PlaneGeometry,
   Raycaster,
   Shape,
   SRGBColorSpace,
@@ -27,6 +28,7 @@ import {
   Vector3,
 } from "three";
 import type {
+  CardArtworkCrop,
   CardDefinition,
   CardSetDefinition,
   TableCard,
@@ -186,6 +188,7 @@ function useTextureForCard(url: string): Texture {
 
 export function CardArtwork({
   url,
+  crop,
   position,
   rotation,
   width,
@@ -193,6 +196,7 @@ export function CardArtwork({
   renderOrder = 3,
 }: {
   url: string;
+  crop?: CardArtworkCrop;
   position: [number, number, number];
   rotation?: [number, number, number];
   width: number;
@@ -200,14 +204,36 @@ export function CardArtwork({
   renderOrder?: number;
 }) {
   const texture = useTextureForCard(url);
+  const geometry = useMemo(() => {
+    const nextGeometry = new PlaneGeometry(width, height);
+
+    if (crop) {
+      const uvs = nextGeometry.attributes.uv;
+      const visibleWidth = 1 - crop.left - crop.right;
+      const visibleHeight = 1 - crop.top - crop.bottom;
+
+      for (let index = 0; index < uvs.count; index += 1) {
+        uvs.setXY(
+          index,
+          crop.left + uvs.getX(index) * visibleWidth,
+          crop.bottom + uvs.getY(index) * visibleHeight
+        );
+      }
+      uvs.needsUpdate = true;
+    }
+
+    return nextGeometry;
+  }, [crop, height, width]);
+
+  useEffect(() => () => geometry.dispose(), [geometry]);
 
   return (
     <mesh
+      geometry={geometry}
       position={position}
       rotation={rotation}
       renderOrder={renderOrder}
     >
-      <planeGeometry args={[width, height]} />
       <meshStandardMaterial
         map={texture}
         color="#fffdf7"
@@ -223,11 +249,13 @@ export function CardArtwork({
 
 function CardFaceLayers({
   artworkUrl,
+  artworkCrop,
   cardWidth,
   cardHeight,
   reverse = false,
 }: {
   artworkUrl: string;
+  artworkCrop?: CardArtworkCrop;
   cardWidth: number;
   cardHeight: number;
   reverse?: boolean;
@@ -244,6 +272,7 @@ function CardFaceLayers({
     <Suspense fallback={null}>
       <CardArtwork
         url={artworkUrl}
+        crop={artworkCrop}
         position={[0, 0, direction * (CARD_THICKNESS / 2 + 0.002)]}
         rotation={rotation}
         width={artworkWidth}
@@ -1280,12 +1309,14 @@ export const CardMesh = memo(function CardMesh({
         {hasRevealed && (
           <CardFaceLayers
             artworkUrl={frontTexture}
+            artworkCrop={cardSet.artworkCrop}
             cardWidth={cardWidth}
             cardHeight={cardHeight}
           />
         )}
         <CardFaceLayers
           artworkUrl={cardSet.back.preview}
+          artworkCrop={cardSet.artworkCrop}
           cardWidth={cardWidth}
           cardHeight={cardHeight}
           reverse

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -4,6 +4,7 @@ import { Line, RoundedBox, useTexture } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import {
   type MutableRefObject,
+  type RefCallback,
   memo,
   Suspense,
   useCallback,
@@ -71,12 +72,12 @@ const CELESTIAL_MARKS = [
   [0.16, -0.36, 0.015],
   [0.34, -0.19, 0.01],
 ] as const;
-const ASTROLOGICAL_MARKS = [
-  { kind: "moon", x: -0.39, y: 0.31, scale: 0.28, rotation: -0.3 },
-  { kind: "venus", x: 0.38, y: 0.29, scale: 0.24, rotation: 0.12 },
-  { kind: "sun", x: -0.4, y: -0.31, scale: 0.24, rotation: 0 },
-  { kind: "mars", x: 0.39, y: -0.28, scale: 0.22, rotation: -0.15 },
-  { kind: "mercury", x: 0.05, y: 0.38, scale: 0.2, rotation: 0.08 },
+const ASTROLOGICAL_KINDS = [
+  "moon",
+  "venus",
+  "sun",
+  "mars",
+  "mercury",
 ] as const;
 
 function createRoundedRectangleShape(
@@ -172,18 +173,54 @@ function createArcPoints(
   });
 }
 
-type AstrologicalMarkKind = (typeof ASTROLOGICAL_MARKS)[number]["kind"];
+type AstrologicalMarkKind = (typeof ASTROLOGICAL_KINDS)[number];
+
+type DriftingAstrologicalMark = {
+  kind: AstrologicalMarkKind;
+  x: number;
+  y: number;
+  scale: number;
+  rotation: number;
+  phase: number;
+  speed: number;
+  driftX: number;
+  driftY: number;
+};
+
+function createDriftingAstrologicalMarks(): DriftingAstrologicalMark[] {
+  return ASTROLOGICAL_KINDS.map((kind, index) => {
+    const angle =
+      (index / ASTROLOGICAL_KINDS.length) * Math.PI * 2 +
+      (Math.random() - 0.5) * 0.68;
+    const radiusX = 0.32 + Math.random() * 0.1;
+    const radiusY = 0.27 + Math.random() * 0.1;
+
+    return {
+      kind,
+      x: Math.cos(angle) * radiusX,
+      y: Math.sin(angle) * radiusY,
+      scale: 0.18 + Math.random() * 0.09,
+      rotation: (Math.random() - 0.5) * 0.5,
+      phase: Math.random() * Math.PI * 2,
+      speed: 0.045 + Math.random() * 0.035,
+      driftX: 0.025 + Math.random() * 0.035,
+      driftY: 0.02 + Math.random() * 0.03,
+    };
+  });
+}
 
 function AstrologicalMark({
   kind,
   position,
   rotation,
   scale,
+  markRef,
 }: {
   kind: AstrologicalMarkKind;
   position: [number, number, number];
   rotation: number;
   scale: number;
+  markRef?: RefCallback<Group>;
 }) {
   const paths = useMemo(() => {
     const circle = createArcPoints(0.7, 0, Math.PI * 2);
@@ -226,7 +263,12 @@ function AstrologicalMark({
   }, [kind]);
 
   return (
-    <group position={position} rotation={[0, 0, rotation]} scale={scale}>
+    <group
+      ref={markRef}
+      position={position}
+      rotation={[0, 0, rotation]}
+      scale={scale}
+    >
       {paths.map((points, index) => (
         <Line
           key={index}
@@ -240,6 +282,76 @@ function AstrologicalMark({
       ))}
     </group>
   );
+}
+
+function DriftingAstrologicalField({
+  width,
+  height,
+  reducedMotion,
+}: {
+  width: number;
+  height: number;
+  reducedMotion: boolean;
+}) {
+  const invalidate = useThree((state) => state.invalidate);
+  const marks = useMemo(createDriftingAstrologicalMarks, []);
+  const markRefs = useRef<Array<Group | null>>([]);
+
+  useEffect(() => {
+    invalidate();
+
+    if (reducedMotion) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        invalidate();
+      }
+    }, 66);
+
+    return () => window.clearInterval(interval);
+  }, [invalidate, reducedMotion]);
+
+  useFrame(({ clock }) => {
+    if (reducedMotion) {
+      return;
+    }
+
+    const elapsed = clock.getElapsedTime();
+
+    marks.forEach((mark, index) => {
+      const group = markRefs.current[index];
+
+      if (!group) {
+        return;
+      }
+
+      group.position.x =
+        (mark.x + Math.sin(elapsed * mark.speed + mark.phase) * mark.driftX) *
+        width;
+      group.position.y =
+        (mark.y +
+          Math.cos(elapsed * mark.speed * 0.82 + mark.phase) * mark.driftY) *
+        height;
+      group.rotation.z =
+        mark.rotation +
+        Math.sin(elapsed * mark.speed * 0.65 + mark.phase) * 0.16;
+    });
+  });
+
+  return marks.map((mark, index) => (
+    <AstrologicalMark
+      key={`${mark.kind}:${index}`}
+      kind={mark.kind}
+      position={[mark.x * width, mark.y * height, 0.001]}
+      rotation={mark.rotation}
+      scale={mark.scale}
+      markRef={(group) => {
+        markRefs.current[index] = group;
+      }}
+    />
+  ));
 }
 
 type TarotSceneProps = {
@@ -557,11 +669,13 @@ function TableSurface({
   width,
   height,
   dragBounds,
+  reducedMotion,
   onSelect,
 }: {
   width: number;
   height: number;
   dragBounds: SceneBounds;
+  reducedMotion: boolean;
   onSelect: (cardId: string | null) => void;
 }) {
   const visibleWidth = (width / MIN_VIEW_ZOOM) * 1.04;
@@ -653,15 +767,11 @@ function TableSurface({
             />
           </mesh>
         ))}
-        {ASTROLOGICAL_MARKS.map((mark) => (
-          <AstrologicalMark
-            key={mark.kind}
-            kind={mark.kind}
-            position={[mark.x * width, mark.y * height, 0.001]}
-            rotation={mark.rotation}
-            scale={mark.scale}
-          />
-        ))}
+        <DriftingAstrologicalField
+          width={width}
+          height={height}
+          reducedMotion={reducedMotion}
+        />
       </group>
     </>
   );
@@ -793,6 +903,7 @@ function TarotTable({
         width={baseViewportWidth}
         height={baseViewportHeight}
         dragBounds={layout.dragBounds}
+        reducedMotion={reducedMotion}
         onSelect={onSelect}
       />
       <DeckStack

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -188,9 +188,15 @@ type DriftingAstrologicalMark = {
 };
 
 function createDriftingAstrologicalMarks(): DriftingAstrologicalMark[] {
-  return ASTROLOGICAL_KINDS.map((kind, index) => {
+  const markCount = 4 + Math.floor(Math.random() * 3);
+
+  return Array.from({ length: markCount }, (_, index) => {
+    const kind =
+      ASTROLOGICAL_KINDS[
+        Math.floor(Math.random() * ASTROLOGICAL_KINDS.length)
+      ];
     const angle =
-      (index / ASTROLOGICAL_KINDS.length) * Math.PI * 2 +
+      (index / markCount) * Math.PI * 2 +
       (Math.random() - 0.5) * 0.68;
     const radiusX = 0.32 + Math.random() * 0.1;
     const radiusY = 0.27 + Math.random() * 0.1;

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -20,6 +20,7 @@ import {
   SRGBColorSpace,
 } from "three";
 import type {
+  CardArtworkCrop,
   CardSetDefinition,
   TablePoint,
   TarotSession,
@@ -412,6 +413,7 @@ function DeckStack({
   width,
   height,
   backUrl,
+  artworkCrop,
   reducedMotion,
   previewPositionRef,
 }: {
@@ -421,6 +423,7 @@ function DeckStack({
   width: number;
   height: number;
   backUrl: string;
+  artworkCrop?: CardArtworkCrop;
   reducedMotion: boolean;
   previewPositionRef: MutableRefObject<TablePoint | null>;
 }) {
@@ -538,6 +541,7 @@ function DeckStack({
               card is lifted, without adding another pointer target. */}
           <CardArtwork
             url={backUrl}
+            crop={artworkCrop}
             position={[topOffsetX, topOffsetY, metrics.topSurface + 0.002]}
             width={width - frameInset}
             height={height - frameInset}
@@ -798,6 +802,7 @@ function TarotTable({
         width={layout.cardWidth}
         height={layout.cardHeight}
         backUrl={cardSet.back.preview}
+        artworkCrop={cardSet.artworkCrop}
         reducedMotion={reducedMotion}
         previewPositionRef={deckPreviewPositionRef}
       />

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -50,13 +50,18 @@ const TABLE_CARD_RENDER_ORDER = 100;
 const CARD_RENDER_ORDER_STEP = 10;
 const DRAG_RENDER_ORDER = 10_000;
 const DECK_LAYER_REGISTRATION = [
-  [-0.0065, 0.0035],
-  [0.006, 0.0025],
-  [-0.0035, -0.004],
-  [0.008, -0.0015],
-  [-0.005, 0.0013],
-  [0.003, -0.0045],
-  [-0.0007, 0.0042],
+  [-0.009, 0.005],
+  [0.006, 0.003],
+  [-0.005, -0.006],
+  [0.009, -0.002],
+  [-0.007, 0.002],
+  [0.004, -0.006],
+  [-0.002, 0.006],
+  [0.007, -0.004],
+  [-0.006, -0.001],
+  [0.003, 0.005],
+  [-0.004, -0.004],
+  [0.005, 0.001],
 ] as const;
 const CELESTIAL_MARKS = [
   [-0.38, 0.31, 0.018],
@@ -365,6 +370,12 @@ type TarotSceneProps = {
   session: TarotSession;
   reducedMotion: boolean;
   viewZoom: number;
+  /**
+   * The camera centre in scene world units. This intentionally stays
+   * independent from `viewZoom`, so callers can map a space-drag delta to
+   * world coordinates without rescaling the table or cards.
+   */
+  viewPan?: TablePoint;
   deckMoveMode: boolean;
   onLayoutChange: (layout: SceneTableLayout) => void;
   onSelect: (cardId: string | null) => void;
@@ -418,17 +429,35 @@ function AnimatedCameraZoom({
   return null;
 }
 
+function CameraPan({ value }: { value?: TablePoint }) {
+  const camera = useThree((state) => state.camera) as OrthographicCamera;
+  const invalidate = useThree((state) => state.invalidate);
+  const [x, y] = value ?? [0, 0];
+
+  useEffect(() => {
+    if (camera.position.x === x && camera.position.y === y) {
+      return;
+    }
+
+    camera.position.set(x, y, camera.position.z);
+    camera.updateMatrixWorld();
+    invalidate();
+  }, [camera, invalidate, x, y]);
+
+  return null;
+}
+
 function getDeckMetrics(count: number) {
   const layerCount =
     count > 0
       ? Math.min(
           DECK_LAYER_REGISTRATION.length,
-          Math.max(1, Math.ceil(count / 11))
+          Math.max(1, Math.ceil(count / 7))
         )
       : 0;
-  const layerThickness = 0.012;
-  const layerStep = 0.016;
-  const firstCenter = TABLE_SURFACE_Z + 0.006 + layerThickness / 2;
+  const layerThickness = 0.018;
+  const layerStep = 0.019;
+  const firstCenter = TABLE_SURFACE_Z + 0.008 + layerThickness / 2;
   const topSurface = layerCount
     ? firstCenter + (layerCount - 1) * layerStep + layerThickness / 2
     : TABLE_SURFACE_Z + 0.007;
@@ -449,14 +478,14 @@ function getDeckLayerOffset(
   width: number,
   height: number
 ): TablePoint {
-  const registration = DECK_LAYER_REGISTRATION[index];
-  const distanceFromTop = layerCount - index;
+  const registration =
+    DECK_LAYER_REGISTRATION[index % DECK_LAYER_REGISTRATION.length];
+  const depth =
+    layerCount <= 1 ? 0 : (layerCount - 1 - index) / (layerCount - 1);
 
   return [
-    registration[0] * width * 0.25 -
-      distanceFromTop * width * 0.0035,
-    registration[1] * height * 0.25 +
-      distanceFromTop * height * 0.0025,
+    (-depth * 0.014 + registration[0] * depth * 0.32) * width,
+    (-depth * 0.01 + registration[1] * depth * 0.32) * height,
   ];
 }
 
@@ -1001,6 +1030,7 @@ export const TarotScene = memo(function TarotScene(props: TarotSceneProps) {
         value={props.viewZoom}
         reducedMotion={props.reducedMotion}
       />
+      <CameraPan value={props.viewPan} />
       <TarotTable {...props} />
     </Canvas>
   );

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -74,7 +74,7 @@ const COLLECTION_ZOOM: Record<TarotCollectionId, number> = {
   all: MIN_VIEW_ZOOM,
   major: 0.48,
   minor: 0.35,
-  court: 0.62,
+  court: 0.48,
 };
 
 function getCollectionColumnCount(
@@ -104,7 +104,7 @@ function createCollectionPlacements(
   const rows = Math.max(1, Math.ceil(cardIds.length / columns));
   const horizontalGap =
     collection === "all" ? 0.37 : collection === "minor" ? 0.46 : 0.62;
-  const verticalGap = collection === "court" ? 0.82 : 0.76;
+  const verticalGap = 0.76;
 
   return new Map(
     cardIds.map((cardId, index) => {

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import {
   type Dispatch,
   type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
   type SetStateAction,
@@ -19,6 +20,7 @@ import {
   cardSets,
   getCardDisplayName,
   getCardSet,
+  getCardSetDisplayDescription,
   getCardSetDisplayLabel,
 } from "@/data/card-sets";
 import type { CardReading } from "@/data/card-readings";
@@ -44,8 +46,8 @@ import {
 } from "@/lib/tarot-session";
 import {
   getSpreadPresentation,
-  popularTarotSpreads,
-  type TarotSpread,
+  getPopularSpreads,
+  type CardSpread,
 } from "@/lib/tarot-spreads";
 import {
   loadTarotWorkspace,
@@ -64,6 +66,65 @@ const DOCK_EDGE_REVEAL_DISTANCE = 52;
 const DOCK_HIDE_DELAY = 850;
 const DOCK_INITIAL_HIDE_DELAY = 1800;
 const LANGUAGE_OPTIONS = ["en", "pt-BR"] as const satisfies readonly AppLocale[];
+const COURT_RANKS = new Set(["page", "knight", "queen", "king"]);
+
+type TarotCollectionId = "all" | "major" | "minor" | "court";
+
+const COLLECTION_ZOOM: Record<TarotCollectionId, number> = {
+  all: MIN_VIEW_ZOOM,
+  major: 0.48,
+  minor: 0.35,
+  court: 0.62,
+};
+
+function getCollectionColumnCount(
+  collection: TarotCollectionId,
+  cardCount: number
+) {
+  if (collection === "all") {
+    return 13;
+  }
+
+  if (collection === "minor") {
+    return 10;
+  }
+
+  if (collection === "major") {
+    return 6;
+  }
+
+  return Math.min(4, Math.max(1, cardCount));
+}
+
+function createCollectionPlacements(
+  cardIds: string[],
+  collection: TarotCollectionId
+) {
+  const columns = getCollectionColumnCount(collection, cardIds.length);
+  const rows = Math.max(1, Math.ceil(cardIds.length / columns));
+  const horizontalGap =
+    collection === "all" ? 0.37 : collection === "minor" ? 0.46 : 0.62;
+  const verticalGap = collection === "court" ? 0.82 : 0.76;
+
+  return new Map(
+    cardIds.map((cardId, index) => {
+      const column = index % columns;
+      const row = Math.floor(index / columns);
+
+      return [
+        cardId,
+        {
+          position: [
+            (column - (columns - 1) / 2) * horizontalGap,
+            ((rows - 1) / 2 - row) * verticalGap,
+          ] as TablePoint,
+          rotation: 0,
+          zIndex: index + 1,
+        },
+      ] as const;
+    })
+  );
+}
 
 const TarotScene = dynamic(
   () => import("./TarotScene").then((module) => module.TarotScene),
@@ -365,7 +426,14 @@ export function TarotStudio() {
   const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
-  const activeSpreadRef = useRef<TarotSpread | null>(null);
+  const activeSpreadRef = useRef<CardSpread | null>(null);
+  const spacePressedRef = useRef(false);
+  const panGestureRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    startPan: TablePoint;
+  } | null>(null);
   const deckMenuRef = useRef<HTMLDivElement>(null);
   const deckMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const zoomMenuRef = useRef<HTMLDivElement>(null);
@@ -374,8 +442,6 @@ export function TarotStudio() {
   const spreadMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const arrangeMenuRef = useRef<HTMLDivElement>(null);
   const arrangeMenuTriggerRef = useRef<HTMLButtonElement>(null);
-  const shuffleMenuRef = useRef<HTMLDivElement>(null);
-  const shuffleMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const languageMenuRef = useRef<HTMLDivElement>(null);
   const languageMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const inspectorCollapseRef = useRef<HTMLButtonElement>(null);
@@ -387,11 +453,14 @@ export function TarotStudio() {
   });
   const [activeCardSetId, setActiveCardSetId] = useState(cardSets[0].id);
   const [viewZoom, setViewZoom] = useState(1);
+  const [viewPan, setViewPan] = useState<TablePoint>([0, 0]);
+  const [spacePanState, setSpacePanState] = useState<
+    "idle" | "ready" | "active"
+  >("idle");
   const [isDeckMenuOpen, setIsDeckMenuOpen] = useState(false);
   const [isZoomMenuOpen, setIsZoomMenuOpen] = useState(false);
   const [isSpreadMenuOpen, setIsSpreadMenuOpen] = useState(false);
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
-  const [isShuffleMenuOpen, setIsShuffleMenuOpen] = useState(false);
   const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
   const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(true);
   const [isDeckMoveMode, setIsDeckMoveMode] = useState(false);
@@ -437,7 +506,6 @@ export function TarotStudio() {
     isZoomMenuOpen ||
     isSpreadMenuOpen ||
     isArrangeMenuOpen ||
-    isShuffleMenuOpen ||
     isLanguageMenuOpen ||
     isInspectorOpen ||
     isDeckMoveMode;
@@ -456,6 +524,10 @@ export function TarotStudio() {
   const deckCount = getRemainingDeckCount(session);
   const deckCardCount = getCardCount(locale, deckCount);
   const tableCardCount = getCardCount(locale, tableCards.length);
+  const availableSpreads = useMemo(
+    () => getPopularSpreads(activeCardSet.id),
+    [activeCardSet.id]
+  );
 
   useEffect(() => {
     const initialLocale = getInitialLocale();
@@ -525,12 +597,6 @@ export function TarotStudio() {
     isOpen: isArrangeMenuOpen,
     setIsOpen: setIsArrangeMenuOpen,
     triggerRef: arrangeMenuTriggerRef,
-  });
-  useDockPopover({
-    containerRef: shuffleMenuRef,
-    isOpen: isShuffleMenuOpen,
-    setIsOpen: setIsShuffleMenuOpen,
-    triggerRef: shuffleMenuTriggerRef,
   });
   useDockPopover({
     containerRef: languageMenuRef,
@@ -606,21 +672,6 @@ export function TarotStudio() {
     window.requestAnimationFrame(() => arrangeMenuTriggerRef.current?.focus());
   }, []);
 
-  const closeShuffleMenu = useCallback(() => {
-    setIsShuffleMenuOpen(false);
-    window.requestAnimationFrame(() => shuffleMenuTriggerRef.current?.focus());
-  }, []);
-
-  const drawCard = useCallback(() => {
-    if (!topDeckCard) {
-      return;
-    }
-
-    activeSpreadRef.current = null;
-    playCardSound("draw");
-    dispatch({ type: "draw", cardId: topDeckCard.id, position: [0.3, 0] });
-  }, [playCardSound, topDeckCard]);
-
   const arrangeCards = useCallback(
     (layout: TableLayout) => {
       if (tableCards.length === 0) {
@@ -638,7 +689,7 @@ export function TarotStudio() {
   );
 
   const dealSpread = useCallback(
-    (spread: TarotSpread) => {
+    (spread: CardSpread) => {
       const layout = sceneLayoutRef.current;
 
       if (!layout) {
@@ -647,6 +698,7 @@ export function TarotStudio() {
 
       const presentation = getSpreadPresentation(spread, layout);
       activeSpreadRef.current = spread;
+      setViewPan([0, 0]);
       setViewZoom(presentation.zoom);
       playCardSound("arrange");
 
@@ -811,11 +863,88 @@ export function TarotStudio() {
     if (previous.cards.every((card) => card.zone === "deck")) {
       activeSpreadRef.current = null;
       setViewZoom(1);
+      setViewPan([0, 0]);
     }
 
     playCardSound("arrange");
     dispatch({ type: "undo" });
   }, [playCardSound, session.history]);
+
+  const redoLastAction = useCallback(() => {
+    const next = session.redo[session.redo.length - 1];
+
+    if (!next) {
+      return;
+    }
+
+    if (next.cards.every((card) => card.zone === "deck")) {
+      activeSpreadRef.current = null;
+      setViewZoom(1);
+      setViewPan([0, 0]);
+    }
+
+    playCardSound("arrange");
+    dispatch({ type: "redo" });
+  }, [playCardSound, session.redo]);
+
+  const resetTable = useCallback(() => {
+    activeSpreadRef.current = null;
+    setIsDeckMoveMode(false);
+    setIsInspectorCollapsed(true);
+    setViewPan([0, 0]);
+    setViewZoom(1);
+    playCardSound("shuffle");
+    dispatch({ type: "reset-table", cardSet: activeCardSet });
+    window.requestAnimationFrame(() => canvasShellRef.current?.focus());
+  }, [activeCardSet, playCardSound]);
+
+  const showTarotCollection = useCallback(
+    (collection: TarotCollectionId) => {
+      if (activeCardSet.kind !== "tarot") {
+        return;
+      }
+
+      const definitions = activeCardSet.cards
+        .filter((definition) => {
+          if (collection === "all") {
+            return true;
+          }
+
+          if (collection === "major") {
+            return definition.arcana === "major";
+          }
+
+          if (collection === "minor") {
+            return definition.arcana === "minor";
+          }
+
+          return (
+            definition.arcana === "minor" &&
+            definition.rank !== undefined &&
+            COURT_RANKS.has(definition.rank)
+          );
+        })
+        .sort((first, second) => first.order - second.order);
+      const cardIds = definitions.map(
+        (definition) => `${activeCardSet.id}:${definition.id}`
+      );
+      const layout = sceneLayoutRef.current;
+
+      activeSpreadRef.current = null;
+      setIsDeckMoveMode(false);
+      setIsInspectorCollapsed(true);
+      setViewPan([0, 0]);
+      setViewZoom(COLLECTION_ZOOM[collection]);
+      playCardSound("arrange");
+      dispatch({
+        type: "show-collection",
+        cardIds,
+        placements: createCollectionPlacements(cardIds, collection),
+        deckPosition: layout?.deckPositionCandidates[0]?.position,
+      });
+    },
+    [activeCardSet, playCardSound]
+  );
 
   const adjustViewZoom = useCallback((delta: number) => {
     setViewZoom((current) =>
@@ -830,15 +959,29 @@ export function TarotStudio() {
     (event: ReactWheelEvent<HTMLDivElement>) => {
       const hoveredCardId = hoveredCardIdRef.current;
 
-      if (!hoveredCardId || event.ctrlKey || event.metaKey) {
+      if (event.ctrlKey || event.metaKey) {
         return;
       }
 
+      event.preventDefault();
       event.stopPropagation();
-      const wheel = layerWheelRef.current;
       const deltaMultiplier =
         event.deltaMode === 0 ? 1 : event.deltaMode === 1 ? 16 : 120;
       const normalizedDelta = event.deltaY * deltaMultiplier;
+
+      if (!hoveredCardId) {
+        if (normalizedDelta !== 0) {
+          const zoomStep = Math.min(
+            0.12,
+            Math.max(0.03, Math.abs(normalizedDelta) * 0.0014)
+          );
+          adjustViewZoom(normalizedDelta < 0 ? zoomStep : -zoomStep);
+        }
+
+        return;
+      }
+
+      const wheel = layerWheelRef.current;
       const direction = Math.sign(normalizedDelta);
 
       if (direction !== 0 && direction !== wheel.direction) {
@@ -866,8 +1009,139 @@ export function TarotStudio() {
         direction: layerDirection,
       });
     },
-    [playCardSound]
+    [adjustViewZoom, playCardSound]
   );
+
+  const finishPanGesture = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const gesture = panGestureRef.current;
+
+      if (!gesture || gesture.pointerId !== event.pointerId) {
+        return;
+      }
+
+      panGestureRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      setSpacePanState(spacePressedRef.current ? "ready" : "idle");
+    },
+    []
+  );
+
+  const handlePanPointerDownCapture = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!spacePressedRef.current || event.button !== 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      panGestureRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        startPan: [...viewPan] as TablePoint,
+      };
+      setSpacePanState("active");
+    },
+    [viewPan]
+  );
+
+  const handlePanPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const gesture = panGestureRef.current;
+      const layout = sceneLayoutRef.current;
+      const canvasWidth = canvasShellRef.current?.clientWidth ?? 0;
+
+      if (
+        !gesture ||
+        gesture.pointerId !== event.pointerId ||
+        !layout ||
+        canvasWidth <= 0
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      const unitsPerPixel =
+        (layout.viewportBounds.right - layout.viewportBounds.left) /
+        canvasWidth /
+        viewZoom;
+      const deltaX = event.clientX - gesture.startX;
+      const deltaY = event.clientY - gesture.startY;
+
+      setViewPan([
+        gesture.startPan[0] - deltaX * unitsPerPixel,
+        gesture.startPan[1] + deltaY * unitsPerPixel,
+      ]);
+    },
+    [viewZoom]
+  );
+
+  useEffect(() => {
+    const isInteractiveTarget = (target: EventTarget | null) =>
+      target instanceof HTMLElement &&
+      (target.isContentEditable ||
+        target.matches("button, select, input, textarea, a[href]"));
+    const handleGlobalKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() === "z" &&
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        !isInteractiveTarget(event.target)
+      ) {
+        event.preventDefault();
+
+        if (event.shiftKey) {
+          redoLastAction();
+        } else {
+          undoLastAction();
+        }
+
+        return;
+      }
+
+      if (
+        event.code === "Space" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !isInteractiveTarget(event.target)
+      ) {
+        event.preventDefault();
+        spacePressedRef.current = true;
+        setSpacePanState((current) =>
+          current === "active" ? current : "ready"
+        );
+      }
+    };
+    const handleGlobalKeyUp = (event: globalThis.KeyboardEvent) => {
+      if (event.code !== "Space") {
+        return;
+      }
+
+      spacePressedRef.current = false;
+      setSpacePanState(panGestureRef.current ? "active" : "idle");
+    };
+    const clearSpaceState = () => {
+      spacePressedRef.current = false;
+      panGestureRef.current = null;
+      setSpacePanState("idle");
+    };
+
+    document.addEventListener("keydown", handleGlobalKeyDown, true);
+    document.addEventListener("keyup", handleGlobalKeyUp, true);
+    window.addEventListener("blur", clearSpaceState);
+
+    return () => {
+      document.removeEventListener("keydown", handleGlobalKeyDown, true);
+      document.removeEventListener("keyup", handleGlobalKeyUp, true);
+      window.removeEventListener("blur", clearSpaceState);
+    };
+  }, [redoLastAction, undoLastAction]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement;
@@ -895,13 +1169,13 @@ export function TarotStudio() {
       return;
     }
 
-    if (event.key === "[" && selectedCard?.zone === "table") {
+    if (key === "j" && selectedCard?.zone === "table") {
       event.preventDefault();
       turnSelected(-15);
       return;
     }
 
-    if (event.key === "]" && selectedCard?.zone === "table") {
+    if (key === "l" && selectedCard?.zone === "table") {
       event.preventDefault();
       turnSelected(15);
       return;
@@ -922,24 +1196,19 @@ export function TarotStudio() {
     if (event.key === "0") {
       event.preventDefault();
       setViewZoom(1);
+      setViewPan([0, 0]);
       return;
     }
 
-    if (key === "pageup" && selectedCard?.zone === "table") {
+    if (key === "i" && selectedCard?.zone === "table") {
       event.preventDefault();
       reorderSelected("forward");
       return;
     }
 
-    if (key === "pagedown" && selectedCard?.zone === "table") {
+    if (key === "k" && selectedCard?.zone === "table") {
       event.preventDefault();
       reorderSelected("backward");
-      return;
-    }
-
-    if ((key === "enter" || key === " ") && !selectedCard) {
-      event.preventDefault();
-      drawCard();
       return;
     }
 
@@ -1014,14 +1283,20 @@ export function TarotStudio() {
         tabIndex={0}
         role="region"
         aria-label={messages.tableDescription}
+        data-space-pan={spacePanState}
         onKeyDown={handleKeyDown}
         onWheel={handleTableWheel}
+        onPointerDownCapture={handlePanPointerDownCapture}
+        onPointerMove={handlePanPointerMove}
+        onPointerUp={finishPanGesture}
+        onPointerCancel={finishPanGesture}
       >
         <TarotScene
           cardSet={activeCardSet}
           session={session}
           reducedMotion={reducedMotion}
           viewZoom={viewZoom}
+          viewPan={viewPan}
           deckMoveMode={isDeckMoveMode}
           onLayoutChange={handleLayoutChange}
           onSelect={handleSelect}
@@ -1068,7 +1343,6 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
-              setIsShuffleMenuOpen(false);
               setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
@@ -1108,6 +1382,7 @@ export function TarotStudio() {
                   playCardSound("shuffle");
                   dispatch({ type: "new-shuffle", cardSet: nextCardSet });
                   setViewZoom(1);
+                  setViewPan([0, 0]);
                   setIsDeckMenuOpen(false);
                   window.requestAnimationFrame(() =>
                     deckMenuTriggerRef.current?.focus()
@@ -1120,6 +1395,9 @@ export function TarotStudio() {
                   </option>
                 ))}
               </select>
+              <p className="tarot-set-picker-description">
+                {getCardSetDisplayDescription(activeCardSet, locale)}
+              </p>
               <span>
                 {messages.cardsInDeck(deckCardCount)}
               </span>
@@ -1140,7 +1418,6 @@ export function TarotStudio() {
               setIsDeckMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
-              setIsShuffleMenuOpen(false);
               setIsLanguageMenuOpen(false);
               setIsInspectorCollapsed(true);
               setIsZoomMenuOpen(willOpen);
@@ -1206,8 +1483,7 @@ export function TarotStudio() {
             <span>{messages.cancel}</span>
           </button>
         )}
-        {activeCardSet.kind === "tarot" &&
-          tableCards.length === 0 &&
+        {tableCards.length === 0 &&
           !isDeckMoveMode && (
             <div className="tarot-spread-menu" ref={spreadMenuRef}>
               <button
@@ -1223,7 +1499,6 @@ export function TarotStudio() {
                   setIsDeckMenuOpen(false);
                   setIsZoomMenuOpen(false);
                   setIsArrangeMenuOpen(false);
-                  setIsShuffleMenuOpen(false);
                   setIsLanguageMenuOpen(false);
                   setIsSpreadMenuOpen(willOpen);
                 }}
@@ -1247,7 +1522,7 @@ export function TarotStudio() {
                 >
                   <span>{messages.chooseASpread}</span>
                   <div>
-                    {popularTarotSpreads.map((spread) => (
+                    {availableSpreads.map((spread) => (
                       <button
                         key={spread.id}
                         type="button"
@@ -1285,7 +1560,6 @@ export function TarotStudio() {
               setIsDeckMenuOpen(false);
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
-              setIsShuffleMenuOpen(false);
               setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
@@ -1293,7 +1567,10 @@ export function TarotStudio() {
               setIsArrangeMenuOpen(willOpen);
             }}
             disabled={
-              !topDeckCard && !tableCards.length && !session.history.length
+              !topDeckCard &&
+              !tableCards.length &&
+              !session.history.length &&
+              !session.redo.length
             }
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -1317,7 +1594,7 @@ export function TarotStudio() {
               aria-label={messages.arrangeAndUndo}
             >
               <p>{messages.tableActionsTitle}</p>
-              <div>
+              <div className="tarot-arrange-grid">
                 {(
                   [
                     ["fan", ...messages.layouts.fan],
@@ -1346,7 +1623,6 @@ export function TarotStudio() {
                     setIsDeckMenuOpen(false);
                     setIsZoomMenuOpen(false);
                     setIsSpreadMenuOpen(false);
-                    setIsShuffleMenuOpen(false);
                     setIsLanguageMenuOpen(false);
                     setIsDeckMoveMode(true);
                     setIsArrangeMenuOpen(false);
@@ -1370,66 +1646,70 @@ export function TarotStudio() {
                   <span>{messages.undo[0]}</span>
                   <small>{messages.undo[1]}</small>
                 </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    redoLastAction();
+                    closeArrangeMenu();
+                  }}
+                  disabled={!session.redo.length}
+                >
+                  <span>{messages.redo[0]}</span>
+                  <small>{messages.redo[1]}</small>
+                </button>
               </div>
+              {activeCardSet.kind === "tarot" && (
+                <section
+                  className="tarot-arrange-section"
+                  aria-label={messages.tarotCollectionActions}
+                >
+                  <h3 className="tarot-arrange-section-title">
+                    {messages.tarotCollection}
+                  </h3>
+                  <div className="tarot-arrange-grid">
+                    {(
+                      ["all", "major", "minor", "court"] as const
+                    ).map((collection) => (
+                      <button
+                        key={collection}
+                        type="button"
+                        onClick={() => {
+                          showTarotCollection(collection);
+                          closeArrangeMenu();
+                        }}
+                      >
+                        <span>{messages.tarotCollections[collection][0]}</span>
+                        <small>
+                          {messages.tarotCollections[collection][1]}
+                        </small>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              )}
             </div>
           )}
         </div>
-        <div className="tarot-shuffle-menu" ref={shuffleMenuRef}>
-          <button
-            ref={shuffleMenuTriggerRef}
-            type="button"
-            className="tarot-toolbar-trigger tarot-shuffle-trigger"
-            aria-label={messages.shuffle}
-            aria-controls="shuffle-actions"
-            aria-expanded={isShuffleMenuOpen}
-            aria-haspopup="dialog"
-            onClick={() => {
-              const willOpen = !isShuffleMenuOpen;
-              setIsDeckMenuOpen(false);
-              setIsZoomMenuOpen(false);
-              setIsSpreadMenuOpen(false);
-              setIsArrangeMenuOpen(false);
-              setIsLanguageMenuOpen(false);
-              if (selectedCard?.zone === "table") {
-                setIsInspectorCollapsed(true);
-              }
-              setIsShuffleMenuOpen(willOpen);
-            }}
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M4 7h2.7c3.2 0 4 10 7.3 10H20" />
-              <path d="m17 14 3 3-3 3M4 17h2.7c1.2 0 2-.7 2.8-1.7M14.5 7H20m-3-3 3 3-3 3" />
-            </svg>
-            <span>{messages.shuffle}</span>
-            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
-              <path d="m8 10 4 4 4-4" />
-            </svg>
-          </button>
-          {isShuffleMenuOpen && (
-            <div
-              id="shuffle-actions"
-              className="tarot-shuffle-popover"
-              role="dialog"
-              aria-label={messages.shuffleActions}
-            >
-              <p>{messages.deckSession}</p>
-              <button
-                type="button"
-                onClick={() => {
-                  activeSpreadRef.current = null;
-                  setIsDeckMoveMode(false);
-                  playCardSound("shuffle");
-                  dispatch({ type: "new-shuffle", cardSet: activeCardSet });
-                  closeShuffleMenu();
-                  setViewZoom(1);
-                }}
-              >
-                <span>{messages.newShuffle}</span>
-                <small>{messages.restartWithAll(activeCardSet.cards.length)}</small>
-              </button>
-            </div>
-          )}
-        </div>
+        <button
+          type="button"
+          className="tarot-toolbar-trigger tarot-reset-trigger"
+          aria-label={`${messages.resetTable}. ${messages.resetTableDescription(activeCardSet.cards.length)}`}
+          title={messages.resetTableDescription(activeCardSet.cards.length)}
+          onClick={() => {
+            setIsDeckMenuOpen(false);
+            setIsZoomMenuOpen(false);
+            setIsSpreadMenuOpen(false);
+            setIsArrangeMenuOpen(false);
+            setIsLanguageMenuOpen(false);
+            resetTable();
+          }}
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M19 8a7.5 7.5 0 1 0 .2 7.6" />
+            <path d="M19 3.8V8h-4.2" />
+          </svg>
+          <span>{messages.resetTable}</span>
+        </button>
         <button
           type="button"
           className="tarot-toolbar-trigger tarot-sound-toggle"
@@ -1464,7 +1744,6 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
-              setIsShuffleMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
               }
@@ -1532,7 +1811,6 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
-              setIsShuffleMenuOpen(false);
               setIsLanguageMenuOpen(false);
               if (isInspectorOpen) {
                 collapseInspector();
@@ -1614,10 +1892,10 @@ export function TarotStudio() {
                     {messages.flip} <Shortcut>F</Shortcut>
                   </button>
                   <button type="button" onClick={() => turnSelected(-15)}>
-                    {messages.turnLeft} <Shortcut>[</Shortcut>
+                    {messages.turnLeft} <Shortcut>J</Shortcut>
                   </button>
                   <button type="button" onClick={() => turnSelected(15)}>
-                    {messages.turnRight} <Shortcut>]</Shortcut>
+                    {messages.turnRight} <Shortcut>L</Shortcut>
                   </button>
                   <button type="button" onClick={() => turnSelected(180)}>
                     {messages.reverse} <Shortcut>R</Shortcut>
@@ -1627,14 +1905,14 @@ export function TarotStudio() {
                     onClick={() => reorderSelected("backward")}
                     disabled={!canSendBackward}
                   >
-                    {messages.sendBack} <Shortcut>Pg↓</Shortcut>
+                    {messages.moveDown} <Shortcut>K</Shortcut>
                   </button>
                   <button
                     type="button"
                     onClick={() => reorderSelected("forward")}
                     disabled={!canBringForward}
                   >
-                    {messages.bringForward} <Shortcut>Pg↑</Shortcut>
+                    {messages.moveUp} <Shortcut>I</Shortcut>
                   </button>
                 </div>
               </div>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -15,8 +15,20 @@ import {
   useRef,
   useState,
 } from "react";
-import { cardSets, getCardSet } from "@/data/card-sets";
+import {
+  cardSets,
+  getCardDisplayName,
+  getCardSet,
+  getCardSetDisplayLabel,
+} from "@/data/card-sets";
 import type { CardReading } from "@/data/card-readings";
+import {
+  applyDocumentLocale,
+  getInitialLocale,
+  persistLocale,
+  type AppLocale,
+} from "@/i18n/locale";
+import { getCardCount, getMessages } from "@/i18n/messages";
 import {
   createCardSoundEngine,
   type CardSoundEvent,
@@ -51,12 +63,13 @@ const WHEEL_LAYER_THRESHOLD = 36;
 const DOCK_EDGE_REVEAL_DISTANCE = 52;
 const DOCK_HIDE_DELAY = 850;
 const DOCK_INITIAL_HIDE_DELAY = 1800;
+const LANGUAGE_OPTIONS = ["en", "pt-BR"] as const satisfies readonly AppLocale[];
 
 const TarotScene = dynamic(
   () => import("./TarotScene").then((module) => module.TarotScene),
   {
     ssr: false,
-    loading: () => <div className="tarot-scene-loading">Preparing the table…</div>,
+    loading: () => null,
   }
 );
 
@@ -304,7 +317,7 @@ function useDockPopover({
     const focusTimer = window.requestAnimationFrame(() => {
       containerRef.current
         ?.querySelector<HTMLElement>(
-          "[role='dialog'] button:not(:disabled), [role='dialog'] select:not(:disabled)"
+          "[role='dialog'] [role='radio'][aria-checked='true'], [role='dialog'] button:not(:disabled), [role='dialog'] select:not(:disabled)"
         )
         ?.focus();
     });
@@ -363,6 +376,8 @@ export function TarotStudio() {
   const arrangeMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const shuffleMenuRef = useRef<HTMLDivElement>(null);
   const shuffleMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const languageMenuRef = useRef<HTMLDivElement>(null);
+  const languageMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const inspectorCollapseRef = useRef<HTMLButtonElement>(null);
   const inspectorToggleRef = useRef<HTMLButtonElement>(null);
   const layerWheelRef = useRef({
@@ -377,6 +392,7 @@ export function TarotStudio() {
   const [isSpreadMenuOpen, setIsSpreadMenuOpen] = useState(false);
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
   const [isShuffleMenuOpen, setIsShuffleMenuOpen] = useState(false);
+  const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
   const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(true);
   const [isDeckMoveMode, setIsDeckMoveMode] = useState(false);
   const [isSceneLayoutReady, setIsSceneLayoutReady] = useState(false);
@@ -385,6 +401,8 @@ export function TarotStudio() {
     null
   );
   const [isReadingLoading, setIsReadingLoading] = useState(false);
+  const [locale, setLocale] = useState<AppLocale>("en");
+  const messages = getMessages(locale);
   const activeCardSet = useMemo(
     () => getCardSet(activeCardSetId),
     [activeCardSetId]
@@ -420,6 +438,7 @@ export function TarotStudio() {
     isSpreadMenuOpen ||
     isArrangeMenuOpen ||
     isShuffleMenuOpen ||
+    isLanguageMenuOpen ||
     isInspectorOpen ||
     isDeckMoveMode;
   const {
@@ -435,8 +454,15 @@ export function TarotStudio() {
   const canBringForward =
     selectedTableIndex >= 0 && selectedTableIndex < tableCards.length - 1;
   const deckCount = getRemainingDeckCount(session);
-  const deckCardNoun = deckCount === 1 ? "card" : "cards";
-  const tableCardNoun = tableCards.length === 1 ? "card" : "cards";
+  const deckCardCount = getCardCount(locale, deckCount);
+  const tableCardCount = getCardCount(locale, tableCards.length);
+
+  useEffect(() => {
+    const initialLocale = getInitialLocale();
+
+    setLocale(initialLocale);
+    applyDocumentLocale(initialLocale);
+  }, []);
 
   useEffect(() => {
     const workspace = loadTarotWorkspace(cardSets);
@@ -506,6 +532,12 @@ export function TarotStudio() {
     setIsOpen: setIsShuffleMenuOpen,
     triggerRef: shuffleMenuTriggerRef,
   });
+  useDockPopover({
+    containerRef: languageMenuRef,
+    isOpen: isLanguageMenuOpen,
+    setIsOpen: setIsLanguageMenuOpen,
+    triggerRef: languageMenuTriggerRef,
+  });
 
   useEffect(() => {
     if (selectedCard?.zone !== "table") {
@@ -533,7 +565,7 @@ export function TarotStudio() {
       .then(({ getCardReading }) => {
         if (!cancelled) {
           setSelectedReading(
-            getCardReading(activeCardSet.id, selectedDefinition) ?? null
+            getCardReading(activeCardSet.id, selectedDefinition, locale) ?? null
           );
         }
       })
@@ -554,6 +586,7 @@ export function TarotStudio() {
   }, [
     activeCardSet.id,
     isInspectorOpen,
+    locale,
     selectedCard?.faceUp,
     selectedDefinition,
   ]);
@@ -710,6 +743,63 @@ export function TarotStudio() {
   const handleHover = useCallback((cardId: string | null) => {
     hoveredCardIdRef.current = cardId;
   }, []);
+
+  const updateLocale = useCallback(
+    (nextLocale: AppLocale, closeMenu: boolean) => {
+      persistLocale(nextLocale);
+      applyDocumentLocale(nextLocale);
+      setLocale(nextLocale);
+
+      if (closeMenu) {
+        setIsLanguageMenuOpen(false);
+        window.requestAnimationFrame(() =>
+          languageMenuTriggerRef.current?.focus()
+        );
+        return;
+      }
+
+      window.requestAnimationFrame(() =>
+        languageMenuRef.current
+          ?.querySelector<HTMLButtonElement>(
+            `[data-locale-option="${nextLocale}"]`
+          )
+          ?.focus()
+      );
+    },
+    []
+  );
+
+  const handleLanguageRadioKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, currentLocale: AppLocale) => {
+      const currentIndex = LANGUAGE_OPTIONS.indexOf(currentLocale);
+      let nextIndex: number;
+
+      switch (event.key) {
+        case "ArrowLeft":
+        case "ArrowUp":
+          nextIndex =
+            (currentIndex - 1 + LANGUAGE_OPTIONS.length) %
+            LANGUAGE_OPTIONS.length;
+          break;
+        case "ArrowRight":
+        case "ArrowDown":
+          nextIndex = (currentIndex + 1) % LANGUAGE_OPTIONS.length;
+          break;
+        case "Home":
+          nextIndex = 0;
+          break;
+        case "End":
+          nextIndex = LANGUAGE_OPTIONS.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      updateLocale(LANGUAGE_OPTIONS[nextIndex], false);
+    },
+    [updateLocale]
+  );
 
   const undoLastAction = useCallback(() => {
     const previous = session.history[session.history.length - 1];
@@ -881,22 +971,35 @@ export function TarotStudio() {
     ? ((selectedCard.rotation % 360) + 360) % 360
     : 0;
   const selectedTitle = selectedCard?.faceUp
-    ? selectedDefinition?.name ?? "Selected card"
+    ? selectedDefinition
+      ? getCardDisplayName(selectedDefinition, locale)
+      : messages.selectedCard
     : selectedCard
-      ? "Face-down card"
-      : "Nothing selected";
+      ? messages.faceDownCard
+      : messages.selectCardControls;
   const selectedHint = selectedCard?.faceUp
-    ? `${Math.abs(normalizedRotation - 180) < 0.8 ? "Reversed · " : normalizedRotation > 0.8 ? `Rotation ${Math.round(normalizedRotation)}° · ` : ""}${activeCardSet.kind === "lenormand" ? "Lenormand" : selectedDefinition?.arcana === "major" ? "Major Arcana" : "Minor Arcana"} · Layer ${selectedTableIndex + 1} of ${tableCards.length}`
+    ? messages.selectedHint({
+        category:
+          activeCardSet.kind === "lenormand"
+            ? "lenormand"
+            : selectedDefinition?.arcana === "major"
+              ? "major"
+              : "minor",
+        layer: selectedTableIndex + 1,
+        total: tableCards.length,
+        rotation: normalizedRotation,
+        isReversed: Math.abs(normalizedRotation - 180) < 0.8,
+      })
     : selectedCard
-      ? `Face down · Layer ${selectedTableIndex + 1} of ${tableCards.length}. Use the layer controls to restack.`
-      : "Draw a card or tap one on the table.";
+      ? messages.faceDownHint(selectedTableIndex + 1, tableCards.length)
+      : messages.noSelectionHint;
 
   if (!isWorkspaceReady) {
     return (
       <main className="tarot-app tarot-app--restoring">
         <div className="tarot-grain" aria-hidden="true" />
         <div className="tarot-workspace-loading" role="status">
-          Opening the table…
+          {messages.loadingTable}
         </div>
       </main>
     );
@@ -910,7 +1013,7 @@ export function TarotStudio() {
         className="tarot-canvas-shell"
         tabIndex={0}
         role="region"
-        aria-label="Interactive card table. Drag the top card to draw it, drag table cards to arrange them, use the card controls to flip, rotate, or change layers, and use Arrange to move the whole deck without keyboard modifiers."
+        aria-label={messages.tableDescription}
         onKeyDown={handleKeyDown}
         onWheel={handleTableWheel}
       >
@@ -935,7 +1038,7 @@ export function TarotStudio() {
       <nav
         ref={dockRef}
         className="tarot-toolbar"
-        aria-label="Table actions"
+        aria-label={messages.tableActions}
         data-dock-state={
           isDockVisible || isDockPinned ? "visible" : "hidden"
         }
@@ -953,7 +1056,10 @@ export function TarotStudio() {
             ref={deckMenuTriggerRef}
             type="button"
             className="tarot-toolbar-trigger tarot-deck-trigger"
-            aria-label={`Choose deck. ${activeCardSet.label}, ${deckCount} ${deckCardNoun} remaining`}
+            aria-label={messages.deckTrigger(
+              getCardSetDisplayLabel(activeCardSet, locale),
+              deckCardCount
+            )}
             aria-controls="deck-actions"
             aria-expanded={isDeckMenuOpen}
             aria-haspopup="dialog"
@@ -963,6 +1069,7 @@ export function TarotStudio() {
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
               setIsShuffleMenuOpen(false);
+              setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
               }
@@ -974,7 +1081,7 @@ export function TarotStudio() {
               <path d="M8 3.8h10.2a1.8 1.8 0 0 1 1.8 1.8V17" />
               <path d="m11 10 .7 1.7 1.8.1-1.4 1.2.5 1.8-1.6-1-1.6 1 .5-1.8-1.4-1.2 1.8-.1L11 10Z" />
             </svg>
-            <span>Deck</span>
+            <span>{messages.deck}</span>
             <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
               <path d="m8 10 4 4 4-4" />
             </svg>
@@ -984,9 +1091,9 @@ export function TarotStudio() {
               id="deck-actions"
               className="tarot-set-picker"
               role="dialog"
-              aria-label="Choose deck"
+              aria-label={messages.chooseDeck}
             >
-              <label htmlFor="card-set">Deck</label>
+              <label htmlFor="card-set">{messages.deck}</label>
               <select
                 id="card-set"
                 name="card-set"
@@ -1009,12 +1116,12 @@ export function TarotStudio() {
               >
                 {cardSets.map((cardSet) => (
                   <option key={cardSet.id} value={cardSet.id}>
-                    {cardSet.label}
+                    {getCardSetDisplayLabel(cardSet, locale)}
                   </option>
                 ))}
               </select>
               <span>
-                {deckCount} {deckCardNoun} in the deck
+                {messages.cardsInDeck(deckCardCount)}
               </span>
             </div>
           )}
@@ -1024,7 +1131,7 @@ export function TarotStudio() {
             ref={zoomMenuTriggerRef}
             type="button"
             className="tarot-toolbar-trigger tarot-zoom-trigger"
-            aria-label={`Table zoom, ${Math.round(viewZoom * 100)} percent`}
+            aria-label={messages.tableZoom(Math.round(viewZoom * 100))}
             aria-controls="zoom-actions"
             aria-expanded={isZoomMenuOpen}
             aria-haspopup="dialog"
@@ -1034,6 +1141,7 @@ export function TarotStudio() {
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
               setIsShuffleMenuOpen(false);
+              setIsLanguageMenuOpen(false);
               setIsInspectorCollapsed(true);
               setIsZoomMenuOpen(willOpen);
             }}
@@ -1042,7 +1150,7 @@ export function TarotStudio() {
               <circle cx="10.5" cy="10.5" r="5.5" />
               <path d="m14.5 14.5 5 5M8 10.5h5M10.5 8v5" />
             </svg>
-            <span>Zoom</span>
+            <span>{messages.zoom}</span>
             <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
               <path d="m8 10 4 4 4-4" />
             </svg>
@@ -1051,11 +1159,11 @@ export function TarotStudio() {
             id="zoom-actions"
             className={`tarot-zoom-controls${isZoomMenuOpen ? " tarot-zoom-controls--open" : ""}`}
             role={isZoomMenuOpen ? "dialog" : undefined}
-            aria-label="Table zoom"
+            aria-label={messages.zoom}
           >
             <button
               type="button"
-              aria-label="Zoom out"
+              aria-label={messages.zoomOut}
               onClick={() => adjustViewZoom(-0.1)}
               disabled={viewZoom <= MIN_VIEW_ZOOM}
             >
@@ -1063,15 +1171,15 @@ export function TarotStudio() {
             </button>
             <button
               type="button"
-              aria-label="Reset table zoom"
-              title="Reset zoom"
+              aria-label={messages.resetZoom}
+              title={messages.resetZoom}
               onClick={() => setViewZoom(1)}
             >
               {Math.round(viewZoom * 100)}%
             </button>
             <button
               type="button"
-              aria-label="Zoom in"
+              aria-label={messages.zoomIn}
               onClick={() => adjustViewZoom(0.1)}
               disabled={viewZoom >= MAX_VIEW_ZOOM}
             >
@@ -1083,7 +1191,7 @@ export function TarotStudio() {
           <button
             type="button"
             className="tarot-mode-cancel"
-            aria-label="Cancel deck move mode"
+            aria-label={messages.cancelDeckMove}
             onClick={() => {
               setIsDeckMoveMode(false);
               canvasShellRef.current?.focus();
@@ -1092,8 +1200,10 @@ export function TarotStudio() {
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M6.5 12.5V8.8a1.4 1.4 0 0 1 2.8 0v2.4-5a1.4 1.4 0 0 1 2.8 0v4.5-3a1.4 1.4 0 0 1 2.8 0v3.6-2a1.4 1.4 0 0 1 2.8 0v5.2c0 3.6-2.2 5.5-5.7 5.5h-.7c-2.4 0-3.7-1.2-5.2-3.2L4.5 14a1.35 1.35 0 0 1 2-1.8l1.7 1.6" />
             </svg>
-            <span className="tarot-mode-cancel-label">Moving deck</span>
-            <span>Cancel</span>
+            <span className="tarot-mode-cancel-label">
+              {messages.movingDeck}
+            </span>
+            <span>{messages.cancel}</span>
           </button>
         )}
         {activeCardSet.kind === "tarot" &&
@@ -1104,7 +1214,7 @@ export function TarotStudio() {
                 ref={spreadMenuTriggerRef}
                 type="button"
                 className="tarot-toolbar-trigger tarot-spread-trigger"
-                aria-label="Choose a tarot spread"
+                aria-label={messages.chooseSpread}
                 aria-controls="spread-actions"
                 aria-expanded={isSpreadMenuOpen}
                 aria-haspopup="dialog"
@@ -1114,6 +1224,7 @@ export function TarotStudio() {
                   setIsZoomMenuOpen(false);
                   setIsArrangeMenuOpen(false);
                   setIsShuffleMenuOpen(false);
+                  setIsLanguageMenuOpen(false);
                   setIsSpreadMenuOpen(willOpen);
                 }}
               >
@@ -1122,7 +1233,7 @@ export function TarotStudio() {
                   <rect x="9.5" y="5" width="5" height="11" rx="1" />
                   <rect x="15.5" y="8" width="5" height="8" rx="1" />
                 </svg>
-                <span>Spreads</span>
+                <span>{messages.spreads}</span>
                 <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="m8 10 4 4 4-4" />
                 </svg>
@@ -1132,9 +1243,9 @@ export function TarotStudio() {
                   id="spread-actions"
                   className="tarot-spread-actions"
                   role="dialog"
-                  aria-label="Popular tarot spreads"
+                  aria-label={messages.popularSpreads}
                 >
-                  <span>Choose a spread</span>
+                  <span>{messages.chooseASpread}</span>
                   <div>
                     {popularTarotSpreads.map((spread) => (
                       <button
@@ -1151,8 +1262,8 @@ export function TarotStudio() {
                           !isSceneLayoutReady || deckCount < spread.slots.length
                         }
                       >
-                        {spread.label}
-                        <small>{spread.shortLabel}</small>
+                        {messages.spreadLabels[spread.id][0]}
+                        <small>{messages.spreadLabels[spread.id][1]}</small>
                       </button>
                     ))}
                   </div>
@@ -1165,7 +1276,7 @@ export function TarotStudio() {
             ref={arrangeMenuTriggerRef}
             type="button"
             className="tarot-toolbar-trigger tarot-arrange-trigger"
-            aria-label="Arrange cards and undo"
+            aria-label={messages.arrangeAndUndo}
             aria-controls="arrange-actions"
             aria-expanded={isArrangeMenuOpen}
             aria-haspopup="dialog"
@@ -1175,6 +1286,7 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsShuffleMenuOpen(false);
+              setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
               }
@@ -1188,7 +1300,7 @@ export function TarotStudio() {
               <path d="M5 7.5h10v12H5zM9 4.5h10v12" />
               <path d="M8 11.5h4M8 14.5h4" />
             </svg>
-            <span>Arrange</span>
+            <span>{messages.arrange}</span>
             <svg
               className="tarot-menu-chevron"
               viewBox="0 0 24 24"
@@ -1202,16 +1314,16 @@ export function TarotStudio() {
               id="arrange-actions"
               className="tarot-arrange-popover"
               role="dialog"
-              aria-label="Arrange cards and undo"
+              aria-label={messages.arrangeAndUndo}
             >
-              <p>Table actions</p>
+              <p>{messages.tableActionsTitle}</p>
               <div>
                 {(
                   [
-                    ["fan", "Fan", "Open arc"],
-                    ["grid", "Grid", "Even rows"],
-                    ["stack", "Stack", "Single pile"],
-                    ["sort", "Sort", "Deck order"],
+                    ["fan", ...messages.layouts.fan],
+                    ["grid", ...messages.layouts.grid],
+                    ["stack", ...messages.layouts.stack],
+                    ["sort", ...messages.layouts.sort],
                   ] as const
                 ).map(([layout, label, hint]) => (
                   <button
@@ -1235,6 +1347,7 @@ export function TarotStudio() {
                     setIsZoomMenuOpen(false);
                     setIsSpreadMenuOpen(false);
                     setIsShuffleMenuOpen(false);
+                    setIsLanguageMenuOpen(false);
                     setIsDeckMoveMode(true);
                     setIsArrangeMenuOpen(false);
                     window.requestAnimationFrame(() =>
@@ -1243,8 +1356,8 @@ export function TarotStudio() {
                   }}
                   disabled={!topDeckCard}
                 >
-                  <span>Move deck</span>
-                  <small>Then drag the pile</small>
+                  <span>{messages.moveDeck[0]}</span>
+                  <small>{messages.moveDeck[1]}</small>
                 </button>
                 <button
                   type="button"
@@ -1254,8 +1367,8 @@ export function TarotStudio() {
                   }}
                   disabled={!session.history.length}
                 >
-                  <span>Undo</span>
-                  <small>Last table move</small>
+                  <span>{messages.undo[0]}</span>
+                  <small>{messages.undo[1]}</small>
                 </button>
               </div>
             </div>
@@ -1266,7 +1379,7 @@ export function TarotStudio() {
             ref={shuffleMenuTriggerRef}
             type="button"
             className="tarot-toolbar-trigger tarot-shuffle-trigger"
-            aria-label="Shuffle"
+            aria-label={messages.shuffle}
             aria-controls="shuffle-actions"
             aria-expanded={isShuffleMenuOpen}
             aria-haspopup="dialog"
@@ -1276,6 +1389,7 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
+              setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
               }
@@ -1286,7 +1400,7 @@ export function TarotStudio() {
               <path d="M4 7h2.7c3.2 0 4 10 7.3 10H20" />
               <path d="m17 14 3 3-3 3M4 17h2.7c1.2 0 2-.7 2.8-1.7M14.5 7H20m-3-3 3 3-3 3" />
             </svg>
-            <span>Shuffle</span>
+            <span>{messages.shuffle}</span>
             <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
               <path d="m8 10 4 4 4-4" />
             </svg>
@@ -1296,9 +1410,9 @@ export function TarotStudio() {
               id="shuffle-actions"
               className="tarot-shuffle-popover"
               role="dialog"
-              aria-label="Shuffle actions"
+              aria-label={messages.shuffleActions}
             >
-              <p>Deck session</p>
+              <p>{messages.deckSession}</p>
               <button
                 type="button"
                 onClick={() => {
@@ -1310,8 +1424,8 @@ export function TarotStudio() {
                   setViewZoom(1);
                 }}
               >
-                <span>New shuffle</span>
-                <small>Restart with all {activeCardSet.cards.length} cards</small>
+                <span>{messages.newShuffle}</span>
+                <small>{messages.restartWithAll(activeCardSet.cards.length)}</small>
               </button>
             </div>
           )}
@@ -1319,9 +1433,9 @@ export function TarotStudio() {
         <button
           type="button"
           className="tarot-toolbar-trigger tarot-sound-toggle"
-          aria-label="Card sounds"
+          aria-label={messages.cardSounds}
           aria-pressed={!areCardSoundsMuted}
-          title={areCardSoundsMuted ? "Card sounds off" : "Card sounds on"}
+          title={areCardSoundsMuted ? messages.cardSoundsOff : messages.cardSoundsOn}
           onClick={toggleCardSounds}
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -1332,8 +1446,74 @@ export function TarotStudio() {
               <path d="M16.5 9.2a4 4 0 0 1 0 5.6M18.8 7a7 7 0 0 1 0 10" />
             )}
           </svg>
-          <span>Sound</span>
+          <span>{messages.cardSounds}</span>
         </button>
+        <div className="tarot-language-menu" ref={languageMenuRef}>
+          <button
+            ref={languageMenuTriggerRef}
+            type="button"
+            className="tarot-toolbar-trigger tarot-language-trigger"
+            aria-label={`${messages.language}: ${messages.localeLabel}`}
+            aria-controls="language-actions"
+            aria-expanded={isLanguageMenuOpen}
+            aria-haspopup="dialog"
+            onClick={() => {
+              const willOpen = !isLanguageMenuOpen;
+
+              setIsDeckMenuOpen(false);
+              setIsZoomMenuOpen(false);
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsShuffleMenuOpen(false);
+              if (selectedCard?.zone === "table") {
+                setIsInspectorCollapsed(true);
+              }
+              setIsLanguageMenuOpen(willOpen);
+            }}
+          >
+            <span>{messages.localeShortLabel}</span>
+            <svg
+              className="tarot-menu-chevron"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path d="m8 10 4 4 4-4" />
+            </svg>
+          </button>
+          {isLanguageMenuOpen && (
+            <section
+              id="language-actions"
+              className="tarot-language-popover"
+              role="dialog"
+              aria-label={messages.chooseLanguage}
+            >
+              <span>{messages.language}</span>
+              <div role="radiogroup" aria-label={messages.languageOptions}>
+                {LANGUAGE_OPTIONS.map((optionLocale) => {
+                  const optionMessages = getMessages(optionLocale);
+
+                  return (
+                    <button
+                      key={optionLocale}
+                      type="button"
+                      role="radio"
+                      aria-checked={locale === optionLocale}
+                      data-locale-option={optionLocale}
+                      tabIndex={locale === optionLocale ? 0 : -1}
+                      onKeyDown={(event) =>
+                        handleLanguageRadioKeyDown(event, optionLocale)
+                      }
+                      onClick={() => updateLocale(optionLocale, true)}
+                    >
+                      <span>{optionMessages.localeShortLabel}</span>
+                      <small>{optionMessages.localeLabel}</small>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+        </div>
         <div className="tarot-card-menu">
           <button
             ref={inspectorToggleRef}
@@ -1341,8 +1521,8 @@ export function TarotStudio() {
             className="tarot-toolbar-trigger tarot-card-trigger"
             aria-label={
               hasSelectedTableCard
-                ? `${isInspectorOpen ? "Close" : "Open"} selected card controls for ${selectedTitle}`
-                : "Select a card to use card controls"
+                ? messages.selectedCardControls(selectedTitle, isInspectorOpen)
+                : messages.selectCardControls
             }
             aria-controls="selected-card-inspector"
             aria-expanded={isInspectorOpen}
@@ -1353,6 +1533,7 @@ export function TarotStudio() {
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
               setIsShuffleMenuOpen(false);
+              setIsLanguageMenuOpen(false);
               if (isInspectorOpen) {
                 collapseInspector();
               } else {
@@ -1364,7 +1545,7 @@ export function TarotStudio() {
               <rect x="5" y="3.5" width="14" height="17" rx="1.5" />
               <path d="m12 7 .8 2.1 2.2.1-1.7 1.4.6 2.2-1.9-1.2-1.9 1.2.6-2.2-1.7-1.4 2.2-.1L12 7Z" />
             </svg>
-            <span>Card</span>
+            <span>{messages.card}</span>
             <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
               <path d="m8 10 4 4 4-4" />
             </svg>
@@ -1373,16 +1554,16 @@ export function TarotStudio() {
             <aside
               id="selected-card-inspector"
               className={`tarot-inspector${selectedCard?.faceUp ? " tarot-inspector--with-reading" : ""}`}
-              aria-label={`Selected card controls for ${selectedTitle}`}
+              aria-label={messages.selectedCardControls(selectedTitle, true)}
             >
               <div className="tarot-inspector-controls">
                 <div className="tarot-inspector-heading">
-                  <p className="tarot-eyebrow">Selected card</p>
+                  <p className="tarot-eyebrow">{messages.selectedCard}</p>
                   <button
                     ref={inspectorCollapseRef}
                     type="button"
                     className="tarot-inspector-collapse"
-                    aria-label="Collapse selected card controls"
+                    aria-label={messages.collapseCardControls}
                     aria-expanded="true"
                     onClick={collapseInspector}
                   >
@@ -1394,7 +1575,7 @@ export function TarotStudio() {
                 <h2>{selectedTitle}</h2>
                 <p>{selectedHint}</p>
                 <div className="tarot-card-browser">
-                  <label htmlFor="drawn-card">Browse cards on the table</label>
+                  <label htmlFor="drawn-card">{messages.browseTableCards}</label>
                   <select
                     id="drawn-card"
                     name="drawn-card"
@@ -1410,7 +1591,7 @@ export function TarotStudio() {
                       handleSelect(cardId);
                     }}
                   >
-                    <option value="">Select a drawn card</option>
+                    <option value="">{messages.selectDrawnCard}</option>
                     {tableCards.map((card, index) => {
                       const definition = activeCardSet.cards.find(
                         (candidate) => candidate.id === card.cardId
@@ -1419,8 +1600,10 @@ export function TarotStudio() {
                       return (
                         <option key={card.id} value={card.id}>
                           {card.faceUp
-                            ? definition?.name ?? `Card ${index + 1}`
-                            : `Face-down card ${index + 1}`}
+                            ? definition
+                              ? getCardDisplayName(definition, locale)
+                              : messages.cardNumber(index + 1)
+                            : messages.faceDownCardNumber(index + 1)}
                         </option>
                       );
                     })}
@@ -1428,30 +1611,30 @@ export function TarotStudio() {
                 </div>
                 <div className="tarot-inspector-actions">
                   <button type="button" onClick={flipSelected}>
-                    Flip <Shortcut>F</Shortcut>
+                    {messages.flip} <Shortcut>F</Shortcut>
                   </button>
                   <button type="button" onClick={() => turnSelected(-15)}>
-                    Turn −15° <Shortcut>[</Shortcut>
+                    {messages.turnLeft} <Shortcut>[</Shortcut>
                   </button>
                   <button type="button" onClick={() => turnSelected(15)}>
-                    Turn +15° <Shortcut>]</Shortcut>
+                    {messages.turnRight} <Shortcut>]</Shortcut>
                   </button>
                   <button type="button" onClick={() => turnSelected(180)}>
-                    Reverse <Shortcut>R</Shortcut>
+                    {messages.reverse} <Shortcut>R</Shortcut>
                   </button>
                   <button
                     type="button"
                     onClick={() => reorderSelected("backward")}
                     disabled={!canSendBackward}
                   >
-                    Send back <Shortcut>Pg↓</Shortcut>
+                    {messages.sendBack} <Shortcut>Pg↓</Shortcut>
                   </button>
                   <button
                     type="button"
                     onClick={() => reorderSelected("forward")}
                     disabled={!canBringForward}
                   >
-                    Bring forward <Shortcut>Pg↑</Shortcut>
+                    {messages.bringForward} <Shortcut>Pg↑</Shortcut>
                   </button>
                 </div>
               </div>
@@ -1459,12 +1642,12 @@ export function TarotStudio() {
                 <section
                   className="tarot-card-reading"
                   aria-busy={isReadingLoading}
-                  aria-label={`Symbolism and correspondences for ${selectedTitle}`}
+                  aria-label={messages.symbolism(selectedTitle)}
                 >
-                  <h3>Symbolism &amp; correspondences</h3>
+                  <h3>{messages.symbolismTitle}</h3>
                   {isReadingLoading && (
                     <p className="tarot-card-reading-loading">
-                      Opening the card notes…
+                      {messages.openingNotes}
                     </p>
                   )}
                   {selectedReading && (
@@ -1485,8 +1668,14 @@ export function TarotStudio() {
                           {selectedReading.traditionNote}
                         </p>
                       )}
+                      {selectedReading.perspective && (
+                        <div className="tarot-card-perspective">
+                          <span>{selectedReading.perspective.label}</span>
+                          <p>{selectedReading.perspective.text}</p>
+                        </div>
+                      )}
                       <div className="tarot-card-sources">
-                        <span>Sources</span>
+                        <span>{messages.sources}</span>
                         <ul>
                           {selectedReading.sources.map((source) => (
                             <li key={source.href}>
@@ -1513,8 +1702,8 @@ export function TarotStudio() {
 
       <p className="tarot-live-status" aria-live="polite">
         {deckCount === 0
-          ? "The deck is empty. Start a new shuffle to begin again."
-          : `${deckCount} ${deckCardNoun} ${deckCount === 1 ? "remains" : "remain"} in the deck. ${tableCards.length} ${tableCardNoun} ${tableCards.length === 1 ? "is" : "are"} on the table.`}
+          ? messages.emptyDeck
+          : messages.liveStatus(deckCardCount, tableCardCount)}
       </p>
     </main>
   );

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -1029,6 +1029,12 @@ export function TarotStudio() {
 
       event.preventDefault();
       event.stopPropagation();
+      hoveredCardIdRef.current = null;
+      layerWheelRef.current = {
+        accumulatedDelta: 0,
+        direction: 0,
+        lastChangeAt: 0,
+      };
       event.currentTarget.setPointerCapture(event.pointerId);
       panGestureRef.current = {
         pointerId: event.pointerId,

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -525,8 +525,8 @@ export function TarotStudio() {
   const deckCardCount = getCardCount(locale, deckCount);
   const tableCardCount = getCardCount(locale, tableCards.length);
   const availableSpreads = useMemo(
-    () => getPopularSpreads(activeCardSet.id),
-    [activeCardSet.id]
+    () => getPopularSpreads(activeCardSet.kind),
+    [activeCardSet.kind]
   );
 
   useEffect(() => {
@@ -862,8 +862,6 @@ export function TarotStudio() {
 
     if (previous.cards.every((card) => card.zone === "deck")) {
       activeSpreadRef.current = null;
-      setViewZoom(1);
-      setViewPan([0, 0]);
     }
 
     playCardSound("arrange");
@@ -875,12 +873,6 @@ export function TarotStudio() {
 
     if (!next) {
       return;
-    }
-
-    if (next.cards.every((card) => card.zone === "deck")) {
-      activeSpreadRef.current = null;
-      setViewZoom(1);
-      setViewPan([0, 0]);
     }
 
     playCardSound("arrange");
@@ -1082,16 +1074,19 @@ export function TarotStudio() {
   );
 
   useEffect(() => {
-    const isInteractiveTarget = (target: EventTarget | null) =>
+    const isTextEditingTarget = (target: EventTarget | null) =>
       target instanceof HTMLElement &&
       (target.isContentEditable ||
-        target.matches("button, select, input, textarea, a[href]"));
+        target.matches("select, input, textarea"));
+    const isInteractiveTarget = (target: EventTarget | null) =>
+      target instanceof HTMLElement &&
+      (isTextEditingTarget(target) || target.matches("button, a[href]"));
     const handleGlobalKeyDown = (event: globalThis.KeyboardEvent) => {
       if (
         event.key.toLowerCase() === "z" &&
         (event.metaKey || event.ctrlKey) &&
         !event.altKey &&
-        !isInteractiveTarget(event.target)
+        !isTextEditingTarget(event.target)
       ) {
         event.preventDefault();
 

--- a/src/data/card-readings.ts
+++ b/src/data/card-readings.ts
@@ -1,4 +1,5 @@
 import type { CardDefinition, TarotSuit } from "@/types";
+import type { AppLocale } from "@/i18n/locale";
 
 export type CardReading = {
   summary: string;
@@ -12,6 +13,10 @@ export type CardReading = {
     locator?: string;
   }>;
   traditionNote?: string;
+  perspective?: {
+    label: string;
+    text: string;
+  };
 };
 
 const WAITE_SOURCE = {
@@ -24,6 +29,12 @@ const BOOK_T_SOURCE = {
   label: "Golden Dawn attributions · The Equinox",
   href: "https://www.100thmonkeypress.com/biblio/acrowley/books/equinox_1_8_1912/equinox_1_8_1912.htm",
   locator: "Vol. I, No. VIII, 1912",
+} as const;
+
+const POLLACK_SOURCE = {
+  label: "Rachel Pollack · Seventy-Eight Degrees of Wisdom",
+  href: "https://redwheelweiser.com/book/seventy-eight-degrees-of-wisdom-9781578636655/",
+  locator: "Publisher overview; picture-led psychological tarot method",
 } as const;
 
 const DODAL_SOURCE = {
@@ -735,9 +746,19 @@ function getMajorReading(
         { label: "Astrology", value: reading.goldenDawn },
         { label: "Hebrew path", value: reading.hebrew },
       ],
-      sources: [WAITE_SOURCE, BOOK_T_SOURCE],
+      sources: [WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE],
       traditionNote:
         "The image note follows Waite’s companion text; astrology and Hebrew letters are labeled Golden Dawn correspondences.",
+      perspective:
+        majorKey === "fool"
+          ? {
+              label: "Rachel Pollack lens",
+              text: "A picture-led psychological reading can meet the Fool as the self at the threshold: open to experience, not yet fixed, and invited to discover itself through the journey. This is an original synopsis, not a quotation.",
+            }
+          : {
+              label: "Rachel Pollack lens",
+              text: "A picture-led psychological reading asks what in this scene is becoming conscious. Use the card as a prompt for self-discovery rather than a fixed prediction; this is a general methodology note, not a card-by-card paraphrase.",
+            },
     };
   }
 
@@ -781,9 +802,13 @@ function getMinorReading(
         { label: "Number or role", value: rankReading.correspondence },
         { label: "Esoteric theme", value: theme },
       ],
-      sources: [WAITE_SOURCE, BOOK_T_SOURCE],
+      sources: [WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE],
       traditionNote:
         "Smith’s image and Waite’s companion text ground the card; the elemental and number synthesis is presented as an editorial esoteric reading framework.",
+      perspective: {
+        label: "Rachel Pollack lens",
+        text: "A picture-led psychological reading asks what in this scene is becoming conscious. Use the card as a prompt for self-discovery rather than a fixed prediction; this is a general methodology note, not a card-by-card paraphrase.",
+      },
     };
   }
 
@@ -820,10 +845,380 @@ function getLenormandReading(definition: CardDefinition): CardReading | undefine
   };
 }
 
-export function getCardReading(
-  cardSetId: string,
+const PORTUGUESE_MAJOR_THEMES: Record<MajorKey, string> = {
+  fool: "Começos · liberdade · o desconhecido",
+  magician: "Vontade · habilidade · manifestação",
+  priestess: "Intuição · mistério · saber interior",
+  empress: "Criação · nutrição · abundância",
+  emperor: "Estrutura · autoridade · limites",
+  hierophant: "Tradição · ensino · iniciação",
+  lovers: "Escolha · união · valores alinhados",
+  chariot: "Direção · impulso · autodomínio",
+  strength: "Coragem · instinto · domínio gentil",
+  hermit: "Solidão · discernimento · orientação",
+  wheel: "Ciclos · mudança · fortuna em movimento",
+  justice: "Verdade · equilíbrio · consequência",
+  hanged: "Entrega · suspensão · nova perspectiva",
+  death: "Encerramento · liberação · transformação",
+  temperance: "Integração · cura · medida justa",
+  devil: "Apego · desejo · sombra",
+  tower: "Ruptura · revelação · libertação",
+  star: "Esperança · reparação · renovação",
+  moon: "Imaginação · incerteza · inconsciente",
+  sun: "Vitalidade · clareza · alegria",
+  judgement: "Despertar · chamado · acerto de contas",
+  world: "Conclusão · integração · totalidade",
+};
+
+const PORTUGUESE_SUIT_READINGS: Record<
+  TarotSuit,
+  { label: string; element: string; domain: string }
+> = {
+  wands: {
+    label: "Paus",
+    element: "Fogo 🜂",
+    domain: "vontade, iniciativa, criatividade e espírito",
+  },
+  cups: {
+    label: "Copas",
+    element: "Água 🜄",
+    domain: "afeto, relação, imaginação e receptividade",
+  },
+  swords: {
+    label: "Espadas",
+    element: "Ar 🜁",
+    domain: "pensamento, verdade, conflito e discernimento",
+  },
+  pentacles: {
+    label: "Ouros",
+    element: "Terra 🜃",
+    domain: "corpo, recursos, ofício e vida material",
+  },
+};
+
+const PORTUGUESE_RANKS: Record<
+  string,
+  { label: string; marseilleLabel: string; correspondence: string }
+> = {
+  "1": { label: "Ás", marseilleLabel: "Ás", correspondence: "Unidade · semente · potencial indiviso" },
+  "2": { label: "Dois", marseilleLabel: "Dois", correspondence: "Polaridade · relação · escolha" },
+  "3": { label: "Três", marseilleLabel: "Três", correspondence: "Crescimento · expressão · primeiro resultado" },
+  "4": { label: "Quatro", marseilleLabel: "Quatro", correspondence: "Estrutura · estabilidade · contenção" },
+  "5": { label: "Cinco", marseilleLabel: "Cinco", correspondence: "Ruptura · tensão · adaptação" },
+  "6": { label: "Seis", marseilleLabel: "Seis", correspondence: "Troca · harmonia · ajuste" },
+  "7": { label: "Sete", marseilleLabel: "Sete", correspondence: "Prova · avaliação · convicção" },
+  "8": { label: "Oito", marseilleLabel: "Oito", correspondence: "Organização · movimento · poder em forma" },
+  "9": { label: "Nove", marseilleLabel: "Nove", correspondence: "Amadurecimento · intensidade · quase conclusão" },
+  "10": { label: "Dez", marseilleLabel: "Dez", correspondence: "Conclusão · consequência · renovação do ciclo" },
+  page: { label: "Pajem", marseilleLabel: "Valete", correspondence: "Mensageiro · estudante · expressão emergente" },
+  knight: { label: "Cavaleiro", marseilleLabel: "Cavaleiro", correspondence: "Movimento · busca · força em prova" },
+  queen: { label: "Rainha", marseilleLabel: "Rainha", correspondence: "Domínio interno · corporificação · cuidado" },
+  king: { label: "Rei", marseilleLabel: "Rei", correspondence: "Domínio externo · direção · responsabilidade" },
+};
+
+const PORTUGUESE_LENORMAND_THEMES: Record<string, string> = {
+  "01-rider": "Notícias · chegada · movimento",
+  "02-clover": "Pequena sorte · oportunidade · brevidade",
+  "03-ship": "Jornada · distância · comércio",
+  "04-house": "Lar · segurança · limites",
+  "05-tree": "Saúde · raízes · crescimento lento",
+  "06-clouds": "Confusão · incerteza · condições mutáveis",
+  "07-snake": "Complexidade · estratégia · desejo",
+  "08-coffin": "Fechamento · quietude · fim",
+  "09-bouquet": "Presente · beleza · apreciação",
+  "10-scythe": "Corte · decisão · mudança súbita",
+  "11-whip": "Repetição · conflito · intensidade",
+  "12-birds": "Conversa · nervosismo · troca",
+  "13-child": "Começo · pequenez · inocência",
+  "14-fox": "Cautela · trabalho · interesse próprio",
+  "15-bear": "Poder · proteção · recursos",
+  "16-stars": "Orientação · esperança · padrão",
+  "17-stork": "Mudança · movimento · melhora",
+  "18-dog": "Lealdade · amizade · apoio",
+  "19-tower": "Instituição · distância · solidão",
+  "20-garden": "Vida pública · encontro · comunidade",
+  "21-mountain": "Obstáculo · atraso · resistência",
+  "22-crossroads": "Escolha · alternativas · divergência",
+  "23-mice": "Erosão · preocupação · perda gradual",
+  "24-heart": "Amor · desejo · sinceridade",
+  "25-ring": "Compromisso · contrato · ciclo",
+  "26-book": "Conhecimento · estudo · segredo",
+  "27-letter": "Mensagem · documento · detalhe",
+  "28-man": "Pessoa · identidade · ponto de vista",
+  "29-woman": "Pessoa · identidade · ponto de vista",
+  "30-lily": "Maturidade · paz · sensualidade",
+  "31-sun": "Sucesso · vitalidade · visibilidade",
+  "32-moon": "Emoção · reconhecimento · ciclos",
+  "33-key": "Solução · certeza · acesso",
+  "34-fish": "Recursos · fluxo · comércio",
+  "35-anchor": "Estabilidade · trabalho · persistência",
+  "36-cross": "Fardo · fé · necessidade",
+};
+
+const PORTUGUESE_SOURCE_METADATA: Record<
+  string,
+  { label: string; locator?: string }
+> = {
+  [WAITE_SOURCE.href]: {
+    label: "A. E. Waite · The Pictorial Key to the Tarot",
+    locator: "Texto de 1910; Partes II–III",
+  },
+  [BOOK_T_SOURCE.href]: {
+    label: "Atribuições da Golden Dawn · The Equinox",
+    locator: "Vol. I, n.º VIII, 1912",
+  },
+  [POLLACK_SOURCE.href]: {
+    label: "Rachel Pollack · Seventy-Eight Degrees of Wisdom",
+    locator: "Página da editora; método pictórico e psicológico",
+  },
+  [DODAL_SOURCE.href]: {
+    label: "Tarô de Jean Dodal · Biblioteca Nacional da França",
+    locator: "Lyon, c. 1701–1715",
+  },
+  [DODAL_SCAN_SOURCE.href]: {
+    label: "Tarô de Jean Dodal · reprodução Gallica",
+    locator: "Artefato completo de 78 cartas",
+  },
+  [PAPUS_SOURCE.href]: {
+    label: "Papus · Le Tarot des Bohémiens",
+    locator: "Sistema ocultista francês posterior, 1889",
+  },
+  [STRALSUND_SOURCE.href]: {
+    label: "Lenormand de Stralsund · Fundação Etteilla",
+    locator: "Reprodução do baralho completo, c. 1890",
+  },
+  [GAME_OF_HOPE_SOURCE.href]: {
+    label: "Das Spiel der Hoffnung · Museu Britânico",
+    locator: "Precursor histórico de 36 cartas, c. 1800",
+  },
+};
+
+function getPortugueseName(definition: CardDefinition): string {
+  return definition.displayNames?.["pt-BR"] ?? definition.name;
+}
+
+function localizeSources(
+  sources: CardReading["sources"]
+): CardReading["sources"] {
+  return sources.map((source) => {
+    const translation = PORTUGUESE_SOURCE_METADATA[source.href];
+
+    return translation
+      ? { ...source, ...translation }
+      : source;
+  });
+}
+
+function localizeAstrology(value: string): string {
+  const [name, ...symbol] = value.split(" ");
+  const names: Record<string, string> = {
+    Air: "Ar",
+    Aquarius: "Aquário",
+    Aries: "Áries",
+    Cancer: "Câncer",
+    Capricorn: "Capricórnio",
+    Earth: "Terra",
+    Fire: "Fogo",
+    Gemini: "Gêmeos",
+    Jupiter: "Júpiter",
+    Leo: "Leão",
+    Libra: "Libra",
+    Mars: "Marte",
+    Mercury: "Mercúrio",
+    Moon: "Lua",
+    Pisces: "Peixes",
+    Sagittarius: "Sagitário",
+    Saturn: "Saturno",
+    Scorpio: "Escorpião",
+    Sun: "Sol",
+    Taurus: "Touro",
+    Venus: "Vênus",
+    Virgo: "Virgem",
+    Water: "Água",
+  };
+
+  return [names[name] ?? name, ...symbol].join(" ");
+}
+
+function getPortuguesePollackPerspective(majorKey?: MajorKey): NonNullable<CardReading["perspective"]> {
+  if (majorKey === "fool") {
+    return {
+      label: "Perspectiva de Rachel Pollack",
+      text: "Uma leitura psicológica orientada pela imagem pode encontrar o Louco como o eu no limiar: aberto à experiência, ainda não fixado e convidado a se descobrir pela jornada. Esta é uma síntese original, não uma citação.",
+    };
+  }
+
+  return {
+    label: "Perspectiva de Rachel Pollack",
+    text: "Uma leitura psicológica orientada pela imagem pergunta o que está se tornando consciente na cena. Use a carta como convite à autodescoberta, não como previsão fixa; esta é uma nota metodológica geral, não uma paráfrase carta a carta.",
+  };
+}
+
+function getPortugueseMajorReading(
+  cardSetId: "rider-waite-smith" | "tarot-de-marseille",
   definition: CardDefinition
 ): CardReading | undefined {
+  const majorKey =
+    cardSetId === "rider-waite-smith"
+      ? RWS_MAJOR_KEYS[definition.id]
+      : MARSEILLE_MAJOR_KEYS[definition.id];
+
+  if (!majorKey) {
+    return undefined;
+  }
+
+  const reading = MAJOR_READINGS[majorKey];
+  const name = getPortugueseName(definition);
+
+  if (cardSetId === "rider-waite-smith") {
+    return {
+      summary: `Nesta imagem da Rider–Waite–Smith, ${name} concentra ${PORTUGUESE_MAJOR_THEMES[majorKey].toLocaleLowerCase("pt-BR")}. A cena oferece uma pergunta aberta sobre como essas forças se movem na situação presente.`,
+      correspondences: [
+        { label: "Arquétipo", value: PORTUGUESE_MAJOR_THEMES[majorKey] },
+        { label: "Astrologia", value: localizeAstrology(reading.goldenDawn) },
+        { label: "Caminho hebraico", value: reading.hebrew },
+      ],
+      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE]),
+      traditionNote:
+        "A imagem é contextualizada pelo texto de Waite; astrologia e letras hebraicas são correspondências identificadas como Golden Dawn.",
+      perspective: getPortuguesePollackPerspective(majorKey),
+    };
+  }
+
+  return {
+    summary: `Nesta lâmina de Jean Dodal, ${name} põe em primeiro plano ${PORTUGUESE_MAJOR_THEMES[majorKey].toLocaleLowerCase("pt-BR")}. A composição histórica permite observar como o símbolo organiza a pergunta antes de acrescentar qualquer sistema posterior.`,
+    correspondences: [
+      { label: "Arquétipo", value: PORTUGUESE_MAJOR_THEMES[majorKey] },
+      { label: "Sequência", value: name },
+      { label: "Lente ocultista", value: "Tarô francês posterior · 1889" },
+    ],
+    sources: localizeSources([DODAL_SOURCE, PAPUS_SOURCE]),
+    traditionNote:
+      "Dodal não deixou um guia esotérico carta a carta. O registro do objeto fundamenta a imagem; Papus é uma lente ocultista francesa claramente posterior.",
+  };
+}
+
+function getPortugueseMinorReading(
+  cardSetId: "rider-waite-smith" | "tarot-de-marseille",
+  definition: CardDefinition
+): CardReading | undefined {
+  const suit = definition.suit;
+  const rank = definition.rank;
+
+  if (!suit || !rank) {
+    return undefined;
+  }
+
+  const suitReading = PORTUGUESE_SUIT_READINGS[suit];
+  const rankReading = PORTUGUESE_RANKS[rank];
+
+  if (!rankReading) {
+    return undefined;
+  }
+
+  const name = getPortugueseName(definition);
+  const rankLabel =
+    cardSetId === "tarot-de-marseille"
+      ? rankReading.marseilleLabel
+      : rankReading.label;
+
+  if (cardSetId === "rider-waite-smith") {
+    return {
+      summary: `Na Rider–Waite–Smith, ${name} une ${suitReading.domain} a ${rankReading.correspondence.toLocaleLowerCase("pt-BR")}. A cena pode ser usada como uma pergunta sobre onde essa dinâmica já está visível na vida cotidiana.`,
+      correspondences: [
+        { label: "Elemento", value: suitReading.element },
+        { label: "Número ou figura", value: rankReading.correspondence },
+        { label: "Domínio do naipe", value: suitReading.domain },
+      ],
+      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE]),
+      traditionNote:
+        "A imagem de Smith e o texto de Waite fundamentam a carta; a síntese elemental e numérica é apresentada como uma estrutura editorial de leitura esotérica.",
+      perspective: getPortuguesePollackPerspective(),
+    };
+  }
+
+  return {
+    summary: `No ${rankLabel} de ${suitReading.label} de Dodal, o número ou a figura da corte organiza o naipe sem uma cena totalmente ilustrada. Como lente comparativa posterior, a carta une ${suitReading.domain} a ${rankReading.correspondence.toLocaleLowerCase("pt-BR")}.`,
+    correspondences: [
+      { label: "Elemento", value: suitReading.element },
+      { label: "Número ou figura", value: rankReading.correspondence },
+      { label: "Domínio do naipe", value: suitReading.domain },
+    ],
+    sources: localizeSources([DODAL_SCAN_SOURCE, PAPUS_SOURCE]),
+    traditionNote:
+      "A reprodução da BnF fundamenta a imagem do ás, número ou corte de Dodal; a camada interpretativa é posterior e não é apresentada como original ao baralho de c. 1701–1715.",
+  };
+}
+
+const PORTUGUESE_PLAYING_CARD_RANKS: Record<string, string> = {
+  Ace: "Ás",
+  King: "Rei",
+  Queen: "Rainha",
+  Jack: "Valete",
+  Ten: "Dez",
+  Nine: "Nove",
+  Eight: "Oito",
+  Seven: "Sete",
+  Six: "Seis",
+};
+
+const PORTUGUESE_PLAYING_CARD_SUITS: Record<string, string> = {
+  Diamonds: "Ouros",
+  Hearts: "Copas",
+  Clubs: "Paus",
+  Spades: "Espadas",
+};
+
+function localizePlayingCard(value: string): string {
+  const [rank, suit] = value.split(" of ");
+
+  return `${PORTUGUESE_PLAYING_CARD_RANKS[rank] ?? rank} de ${PORTUGUESE_PLAYING_CARD_SUITS[suit] ?? suit}`;
+}
+
+function getPortugueseLenormandReading(
+  definition: CardDefinition
+): CardReading | undefined {
+  const reading = LENORMAND_READINGS[definition.id];
+  const themes = PORTUGUESE_LENORMAND_THEMES[definition.id];
+
+  if (!reading || !themes) {
+    return undefined;
+  }
+
+  const name = getPortugueseName(definition);
+
+  return {
+    summary: `No Petit Lenormand, ${name} orienta a leitura por ${themes.toLocaleLowerCase("pt-BR")}. A imagem ganha precisão no contexto, especialmente em combinação com as cartas vizinhas e a pergunta formulada.`,
+    correspondences: [
+      { label: "Carta do baralho comum", value: localizePlayingCard(reading.playingCard) },
+      { label: "Temas editoriais", value: themes },
+      { label: "Sistema", value: `Petit Lenormand · Carta ${definition.order + 1}` },
+    ],
+    sources: localizeSources([STRALSUND_SOURCE, GAME_OF_HOPE_SOURCE]),
+    traditionNote:
+      "As fontes do baralho e do museu estabelecem imagem, número, inserto e história. Os temas carta a carta são uma leitura editorial concisa, não um texto canônico do baralho de 1890.",
+  };
+}
+
+export function getCardReading(
+  cardSetId: string,
+  definition: CardDefinition,
+  locale: AppLocale = "en"
+): CardReading | undefined {
+  if (locale === "pt-BR") {
+    if (cardSetId === "classic-lenormand") {
+      return getPortugueseLenormandReading(definition);
+    }
+
+    if (cardSetId === "rider-waite-smith" || cardSetId === "tarot-de-marseille") {
+      return definition.arcana === "major"
+        ? getPortugueseMajorReading(cardSetId, definition)
+        : getPortugueseMinorReading(cardSetId, definition);
+    }
+
+    return undefined;
+  }
+
   if (cardSetId === "classic-lenormand") {
     return getLenormandReading(definition);
   }

--- a/src/data/card-sets.ts
+++ b/src/data/card-sets.ts
@@ -5,6 +5,7 @@ import type {
   CardSetDefinition,
   TarotSuit,
 } from "@/types";
+import type { AppLocale } from "@/i18n/locale";
 
 const getCroppedAspectRatio = (
   sourceAspectRatio: number,
@@ -14,17 +15,17 @@ const getCroppedAspectRatio = (
   ((1 - crop.left - crop.right) / (1 - crop.top - crop.bottom));
 
 const marseilleArtworkCrop = {
-  left: 24 / 792,
-  right: 24 / 792,
+  left: 40 / 792,
+  right: 40 / 792,
   top: 44 / 1464,
-  bottom: 26 / 1464,
+  bottom: 40 / 1464,
 } satisfies CardArtworkCrop;
 
 const lenormandArtworkCrop = {
-  left: 48 / 918,
-  right: 33 / 918,
-  top: 49 / 1494,
-  bottom: 49 / 1494,
+  left: 64 / 918,
+  right: 60 / 918,
+  top: 70 / 1494,
+  bottom: 70 / 1494,
 } satisfies CardArtworkCrop;
 
 const artwork = (filename: string): CardArtwork => {
@@ -74,6 +75,31 @@ const majorArcana = [
   ["21-the-world.png", "The World"],
 ] as const;
 
+const riderWaitePortugueseMajorNames: Record<string, string> = {
+  "0-the-fool": "O Louco",
+  "1-the-magician": "O Mago",
+  "2-the-high-priestess": "A Sacerdotisa",
+  "3-the-empress": "A Imperatriz",
+  "4-the-emperor": "O Imperador",
+  "5-the-hierophant": "O Hierofante",
+  "6-the-lovers": "Os Enamorados",
+  "7-the-chariot": "O Carro",
+  "8-strength": "A Força",
+  "9-the-hermit": "O Eremita",
+  "10-wheel-of-fortune": "A Roda da Fortuna",
+  "11-justice": "A Justiça",
+  "12-the-hanged-man": "O Enforcado",
+  "13-death": "A Morte",
+  "14-temperance": "A Temperança",
+  "15-the-devil": "O Diabo",
+  "16-the-tower": "A Torre",
+  "17-the-star": "A Estrela",
+  "18-the-moon": "A Lua",
+  "19-the-sun": "O Sol",
+  "20-judgement": "O Julgamento",
+  "21-the-world": "O Mundo",
+};
+
 const minorRanks = [
   ["1", "Ace"],
   ["2", "Two"],
@@ -98,10 +124,37 @@ const suits: Array<{ id: TarotSuit; label: string }> = [
   { id: "wands", label: "Wands" },
 ];
 
+const portugueseMinorRanks: Record<string, string> = {
+  "1": "Ás",
+  "2": "Dois",
+  "3": "Três",
+  "4": "Quatro",
+  "5": "Cinco",
+  "6": "Seis",
+  "7": "Sete",
+  "8": "Oito",
+  "9": "Nove",
+  "10": "Dez",
+  page: "Pajem",
+  knight: "Cavaleiro",
+  queen: "Rainha",
+  king: "Rei",
+};
+
+const portugueseTarotSuits: Record<TarotSuit, string> = {
+  cups: "Copas",
+  pentacles: "Ouros",
+  swords: "Espadas",
+  wands: "Paus",
+};
+
 const riderWaiteSmithCards: CardDefinition[] = [
   ...majorArcana.map(([filename, name], order) => ({
     id: filename.replace(/\.png$/i, ""),
     name,
+    displayNames: {
+      "pt-BR": riderWaitePortugueseMajorNames[filename.replace(/\.png$/i, "")],
+    },
     order,
     image: artwork(filename),
     arcana: "major" as const,
@@ -114,6 +167,9 @@ const riderWaiteSmithCards: CardDefinition[] = [
       return {
         id: filename.replace(/\.png$/i, ""),
         name: `${rankLabel} of ${suitLabel}`,
+        displayNames: {
+          "pt-BR": `${portugueseMinorRanks[rank]} de ${portugueseTarotSuits[suit]}`,
+        },
         order: majorArcana.length + suitIndex * minorRanks.length + rankIndex,
         image: artwork(filename),
         arcana: "minor" as const,
@@ -130,6 +186,11 @@ export const riderWaiteSmith: CardSetDefinition = {
   label: "Rider–Waite–Smith Tarot",
   shortLabel: "Rider–Waite–Smith",
   description: "A complete 78-card deck for open-ended readings and spreads.",
+  displayLabels: { "pt-BR": "Tarô Rider–Waite–Smith" },
+  displayShortLabels: { "pt-BR": "Rider–Waite–Smith" },
+  displayDescriptions: {
+    "pt-BR": "Um baralho completo de 78 cartas para tiragens e leituras abertas.",
+  },
   cardAspectRatio: 1017 / 1776,
   back: artwork("back.png"),
   cards: riderWaiteSmithCards,
@@ -160,6 +221,31 @@ const marseilleMajorArcana = [
   ["21-le-monde", "Le Monde"],
 ] as const;
 
+const marseillePortugueseMajorNames: Record<string, string> = {
+  "00-le-mat": "O Louco",
+  "01-le-bateleur": "O Mago",
+  "02-la-papesse": "A Papisa",
+  "03-l-imperatrice": "A Imperatriz",
+  "04-l-empereur": "O Imperador",
+  "05-le-pape": "O Papa",
+  "06-l-amoureux": "Os Enamorados",
+  "07-le-chariot": "O Carro",
+  "08-la-justice": "A Justiça",
+  "09-l-ermite": "O Eremita",
+  "10-la-roue-de-fortune": "A Roda da Fortuna",
+  "11-la-force": "A Força",
+  "12-le-pendu": "O Enforcado",
+  "13-arcane-xiii": "Arcano XIII",
+  "14-temperance": "A Temperança",
+  "15-le-diable": "O Diabo",
+  "16-la-maison-dieu": "A Casa de Deus",
+  "17-l-etoile": "A Estrela",
+  "18-la-lune": "A Lua",
+  "19-le-soleil": "O Sol",
+  "20-le-jugement": "O Julgamento",
+  "21-le-monde": "O Mundo",
+};
+
 const marseilleRanks = [
   ["1", "As"],
   ["2", "Deux"],
@@ -188,10 +274,16 @@ const marseilleSuits: Array<{
   { id: "wands", filename: "wands", label: "Bâtons" },
 ];
 
+const portugueseMarseilleRanks: Record<string, string> = {
+  ...portugueseMinorRanks,
+  page: "Valete",
+};
+
 const tarotDeMarseilleCards: CardDefinition[] = [
   ...marseilleMajorArcana.map(([filename, name], order) => ({
     id: filename,
     name,
+    displayNames: { "pt-BR": marseillePortugueseMajorNames[filename] },
     order,
     image: marseilleArtwork(filename),
     arcana: "major" as const,
@@ -204,6 +296,9 @@ const tarotDeMarseilleCards: CardDefinition[] = [
       return {
         id: cardFilename,
         name: `${rankLabel} de ${label}`,
+        displayNames: {
+          "pt-BR": `${portugueseMarseilleRanks[rank]} de ${portugueseTarotSuits[suit]}`,
+        },
         order:
           marseilleMajorArcana.length +
           suitIndex * marseilleRanks.length +
@@ -224,6 +319,11 @@ export const tarotDeMarseille: CardSetDefinition = {
   shortLabel: "Tarot de Marseille",
   description:
     "Jean Dodal's complete 78-card Tarot de Marseille, printed in Lyon circa 1701–1715.",
+  displayLabels: { "pt-BR": "Tarô de Marselha · Jean Dodal" },
+  displayShortLabels: { "pt-BR": "Tarô de Marselha" },
+  displayDescriptions: {
+    "pt-BR": "O Tarô de Marselha completo de Jean Dodal, impresso em Lyon por volta de 1701–1715.",
+  },
   cardAspectRatio: getCroppedAspectRatio(33 / 61, marseilleArtworkCrop),
   artworkCrop: marseilleArtworkCrop,
   back: marseilleArtwork("back"),
@@ -269,6 +369,45 @@ const classicLenormandCards = [
   ["36-cross", "Cross"],
 ] as const;
 
+const lenormandPortugueseNames: Record<string, string> = {
+  "01-rider": "Cavaleiro",
+  "02-clover": "Trevo",
+  "03-ship": "Navio",
+  "04-house": "Casa",
+  "05-tree": "Árvore",
+  "06-clouds": "Nuvens",
+  "07-snake": "Cobra",
+  "08-coffin": "Caixão",
+  "09-bouquet": "Buquê",
+  "10-scythe": "Foice",
+  "11-whip": "Chicote",
+  "12-birds": "Pássaros",
+  "13-child": "Criança",
+  "14-fox": "Raposa",
+  "15-bear": "Urso",
+  "16-stars": "Estrelas",
+  "17-stork": "Cegonha",
+  "18-dog": "Cão",
+  "19-tower": "Torre",
+  "20-garden": "Jardim",
+  "21-mountain": "Montanha",
+  "22-crossroads": "Encruzilhada",
+  "23-mice": "Ratos",
+  "24-heart": "Coração",
+  "25-ring": "Anel",
+  "26-book": "Livro",
+  "27-letter": "Carta",
+  "28-man": "Homem",
+  "29-woman": "Mulher",
+  "30-lily": "Lírios",
+  "31-sun": "Sol",
+  "32-moon": "Lua",
+  "33-key": "Chave",
+  "34-fish": "Peixes",
+  "35-anchor": "Âncora",
+  "36-cross": "Cruz",
+};
+
 export const classicLenormand: CardSetDefinition = {
   id: "classic-lenormand",
   kind: "lenormand",
@@ -276,12 +415,18 @@ export const classicLenormand: CardSetDefinition = {
   shortLabel: "Stralsund Lenormand",
   description:
     "A complete 36-card Stralsund deck from Spielkartenfabrik Altenburg, circa 1890.",
+  displayLabels: { "pt-BR": "Lenormand de Stralsund" },
+  displayShortLabels: { "pt-BR": "Lenormand de Stralsund" },
+  displayDescriptions: {
+    "pt-BR": "Um Lenormand completo de 36 cartas da Spielkartenfabrik Altenburg, por volta de 1890.",
+  },
   cardAspectRatio: getCroppedAspectRatio(51 / 83, lenormandArtworkCrop),
   artworkCrop: lenormandArtworkCrop,
   back: lenormandArtwork("back"),
   cards: classicLenormandCards.map(([id, name], order) => ({
     id,
     name,
+    displayNames: { "pt-BR": lenormandPortugueseNames[id] },
     order,
     image: lenormandArtwork(id),
   })),
@@ -305,4 +450,32 @@ export function getCardSet(cardSetId: string): CardSetDefinition {
   }
 
   return cardSet;
+}
+
+export function getCardDisplayName(
+  definition: CardDefinition,
+  locale: AppLocale
+): string {
+  return definition.displayNames?.[locale] ?? definition.name;
+}
+
+export function getCardSetDisplayLabel(
+  cardSet: CardSetDefinition,
+  locale: AppLocale
+): string {
+  return cardSet.displayLabels?.[locale] ?? cardSet.label;
+}
+
+export function getCardSetDisplayShortLabel(
+  cardSet: CardSetDefinition,
+  locale: AppLocale
+): string {
+  return cardSet.displayShortLabels?.[locale] ?? cardSet.shortLabel;
+}
+
+export function getCardSetDisplayDescription(
+  cardSet: CardSetDefinition,
+  locale: AppLocale
+): string {
+  return cardSet.displayDescriptions?.[locale] ?? cardSet.description;
 }

--- a/src/data/card-sets.ts
+++ b/src/data/card-sets.ts
@@ -1,9 +1,31 @@
 import type {
   CardArtwork,
+  CardArtworkCrop,
   CardDefinition,
   CardSetDefinition,
   TarotSuit,
 } from "@/types";
+
+const getCroppedAspectRatio = (
+  sourceAspectRatio: number,
+  crop: CardArtworkCrop
+) =>
+  sourceAspectRatio *
+  ((1 - crop.left - crop.right) / (1 - crop.top - crop.bottom));
+
+const marseilleArtworkCrop = {
+  left: 24 / 792,
+  right: 24 / 792,
+  top: 44 / 1464,
+  bottom: 26 / 1464,
+} satisfies CardArtworkCrop;
+
+const lenormandArtworkCrop = {
+  left: 48 / 918,
+  right: 33 / 918,
+  top: 49 / 1494,
+  bottom: 49 / 1494,
+} satisfies CardArtworkCrop;
 
 const artwork = (filename: string): CardArtwork => {
   const optimizedFilename = filename.replace(/\.png$/i, ".webp");
@@ -202,7 +224,8 @@ export const tarotDeMarseille: CardSetDefinition = {
   shortLabel: "Tarot de Marseille",
   description:
     "Jean Dodal's complete 78-card Tarot de Marseille, printed in Lyon circa 1701–1715.",
-  cardAspectRatio: 33 / 61,
+  cardAspectRatio: getCroppedAspectRatio(33 / 61, marseilleArtworkCrop),
+  artworkCrop: marseilleArtworkCrop,
   back: marseilleArtwork("back"),
   cards: tarotDeMarseilleCards,
 };
@@ -253,7 +276,8 @@ export const classicLenormand: CardSetDefinition = {
   shortLabel: "Stralsund Lenormand",
   description:
     "A complete 36-card Stralsund deck from Spielkartenfabrik Altenburg, circa 1890.",
-  cardAspectRatio: 51 / 83,
+  cardAspectRatio: getCroppedAspectRatio(51 / 83, lenormandArtworkCrop),
+  artworkCrop: lenormandArtworkCrop,
   back: lenormandArtwork("back"),
   cards: classicLenormandCards.map(([id, name], order) => ({
     id,

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -1,0 +1,51 @@
+export const APP_LOCALES = ["en", "pt-BR"] as const;
+
+export type AppLocale = (typeof APP_LOCALES)[number];
+
+const LOCALE_STORAGE_KEY = "tarot-table-locale";
+
+export function isAppLocale(value: string | null): value is AppLocale {
+  return value === "en" || value === "pt-BR";
+}
+
+export function getBrowserLocale(
+  languages: readonly string[] = []
+): AppLocale {
+  for (const language of languages) {
+    const normalizedLanguage = language.toLowerCase();
+
+    if (normalizedLanguage.startsWith("pt")) {
+      return "pt-BR";
+    }
+
+    if (normalizedLanguage.startsWith("en")) {
+      return "en";
+    }
+  }
+
+  return "en";
+}
+
+export function getInitialLocale(): AppLocale {
+  if (typeof window === "undefined") {
+    return "en";
+  }
+
+  const savedLocale = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+
+  if (isAppLocale(savedLocale)) {
+    return savedLocale;
+  }
+
+  return getBrowserLocale(
+    navigator.languages?.length ? navigator.languages : [navigator.language]
+  );
+}
+
+export function persistLocale(locale: AppLocale) {
+  window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+}
+
+export function applyDocumentLocale(locale: AppLocale) {
+  document.documentElement.lang = locale;
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,4 +1,5 @@
 import type { AppLocale } from "./locale";
+import type { CardSpreadId } from "@/lib/tarot-spreads";
 
 type CardCategory = "lenormand" | "major" | "minor";
 
@@ -35,11 +36,14 @@ type Messages = {
   layouts: Readonly<Record<"fan" | "grid" | "stack" | "sort", [string, string]>>;
   moveDeck: [string, string];
   undo: [string, string];
-  shuffle: string;
-  shuffleActions: string;
-  deckSession: string;
-  newShuffle: string;
-  restartWithAll: (count: number) => string;
+  redo: [string, string];
+  resetTable: string;
+  resetTableDescription: (count: number) => string;
+  tarotCollection: string;
+  tarotCollectionActions: string;
+  tarotCollections: Readonly<
+    Record<"all" | "major" | "minor" | "court", [string, string]>
+  >;
   cardSounds: string;
   cardSoundsOn: string;
   cardSoundsOff: string;
@@ -71,15 +75,15 @@ type Messages = {
   reverse: string;
   sendBack: string;
   bringForward: string;
+  moveUp: string;
+  moveDown: string;
   symbolism: (title: string) => string;
   symbolismTitle: string;
   openingNotes: string;
   sources: string;
   emptyDeck: string;
   liveStatus: (deck: Count, table: Count) => string;
-  spreadLabels: Readonly<
-    Record<"one-card" | "three-card" | "horseshoe" | "celtic-cross", [string, string]>
-  >;
+  spreadLabels: Readonly<Record<CardSpreadId, [string, string]>>;
 };
 
 const cardNoun = (count: number) => (count === 1 ? "card" : "cards");
@@ -93,7 +97,7 @@ const messages: Record<AppLocale, Messages> = {
     localeShortLabel: "EN",
     loadingTable: "Opening the table…",
     tableDescription:
-      "Interactive card table. Drag the top card to draw it, drag table cards to arrange them, use the card controls to flip, rotate, or change layers, and use Arrange to move the whole deck without keyboard modifiers.",
+      "Interactive card table. Drag the top card to draw it and drag table cards to arrange them. Scroll the table background to zoom, hold Space while dragging to pan, use I and K to change the selected card layer, and J and L to rotate it.",
     tableActions: "Table actions",
     deckTrigger: (deckLabel, deck) =>
       `Choose deck. ${deckLabel}, ${deck.count} ${deck.noun} remaining`,
@@ -108,9 +112,9 @@ const messages: Record<AppLocale, Messages> = {
     cancelDeckMove: "Cancel deck move mode",
     movingDeck: "Moving deck",
     cancel: "Cancel",
-    chooseSpread: "Choose a tarot spread",
+    chooseSpread: "Choose a spread",
     spreads: "Spreads",
-    popularSpreads: "Popular tarot spreads",
+    popularSpreads: "Popular spreads",
     chooseASpread: "Choose a spread",
     arrangeAndUndo: "Arrange cards and undo",
     arrange: "Arrange",
@@ -123,11 +127,17 @@ const messages: Record<AppLocale, Messages> = {
     },
     moveDeck: ["Move deck", "Then drag the pile"],
     undo: ["Undo", "Last table move"],
-    shuffle: "Shuffle",
-    shuffleActions: "Shuffle actions",
-    deckSession: "Deck session",
-    newShuffle: "New shuffle",
-    restartWithAll: (count) => `Restart with all ${count} cards`,
+    redo: ["Redo", "Reapply last table move"],
+    resetTable: "Reset table",
+    resetTableDescription: (count) => `Return all ${count} cards to the deck`,
+    tarotCollection: "Tarot collection",
+    tarotCollectionActions: "Tarot collection actions",
+    tarotCollections: {
+      all: ["All cards", "78 cards"],
+      major: ["Major Arcana", "22 cards"],
+      minor: ["Minor Arcana", "56 cards"],
+      court: ["Court cards", "16 cards"],
+    },
     cardSounds: "Card sounds",
     cardSoundsOn: "Card sounds on",
     cardSoundsOff: "Card sounds off",
@@ -169,11 +179,13 @@ const messages: Record<AppLocale, Messages> = {
     reverse: "Reverse",
     sendBack: "Send back",
     bringForward: "Bring forward",
+    moveUp: "Move up",
+    moveDown: "Move down",
     symbolism: (title) => `Symbolism and correspondences for ${title}`,
     symbolismTitle: "Symbolism & correspondences",
     openingNotes: "Opening the card notes…",
     sources: "Sources",
-    emptyDeck: "The deck is empty. Start a new shuffle to begin again.",
+    emptyDeck: "The deck is empty. Reset the table to begin again.",
     liveStatus: (deck, table) =>
       `${deck.count} ${deck.noun} ${deck.count === 1 ? "remains" : "remain"} in the deck. ${tableStatus(table)}`,
     spreadLabels: {
@@ -181,6 +193,10 @@ const messages: Record<AppLocale, Messages> = {
       "three-card": ["Past · Present · Future", "3 cards"],
       horseshoe: ["Horseshoe", "7 cards"],
       "celtic-cross": ["Celtic Cross", "10 cards"],
+      "lenormand-three-card": ["Three-card line", "3 cards"],
+      "lenormand-five-card": ["Five-card line", "5 cards"],
+      "lenormand-portrait": ["Portrait", "9 cards"],
+      "lenormand-grand-tableau": ["Grand Tableau", "36 cards"],
     },
   },
   "pt-BR": {
@@ -188,7 +204,7 @@ const messages: Record<AppLocale, Messages> = {
     localeShortLabel: "PT",
     loadingTable: "Abrindo a mesa…",
     tableDescription:
-      "Mesa de cartas interativa. Arraste a carta do topo para tirá-la, arraste as cartas na mesa para organizá-las, use os controles da carta para virar, girar ou mudar camadas, e use Organizar para mover o baralho inteiro sem modificadores de teclado.",
+      "Mesa de cartas interativa. Arraste a carta do topo para tirá-la e arraste as cartas na mesa para organizá-las. Role sobre o fundo da mesa para dar zoom, mantenha Espaço pressionado enquanto arrasta para mover a visão, use I e K para mudar a camada da carta selecionada e J e L para girá-la.",
     tableActions: "Ações da mesa",
     deckTrigger: (deckLabel, deck) =>
       `Escolher baralho. ${deckLabel}, restam ${deck.count} ${deck.noun}`,
@@ -203,9 +219,9 @@ const messages: Record<AppLocale, Messages> = {
     cancelDeckMove: "Cancelar modo de mover baralho",
     movingDeck: "Movendo baralho",
     cancel: "Cancelar",
-    chooseSpread: "Escolher uma abertura de tarot",
+    chooseSpread: "Escolher uma abertura",
     spreads: "Aberturas",
-    popularSpreads: "Aberturas de tarot populares",
+    popularSpreads: "Aberturas populares",
     chooseASpread: "Escolha uma abertura",
     arrangeAndUndo: "Organizar cartas e desfazer",
     arrange: "Organizar",
@@ -218,11 +234,17 @@ const messages: Record<AppLocale, Messages> = {
     },
     moveDeck: ["Mover baralho", "Arraste a pilha"],
     undo: ["Desfazer", "Último movimento"],
-    shuffle: "Embaralhar",
-    shuffleActions: "Ações de embaralhar",
-    deckSession: "Sessão do baralho",
-    newShuffle: "Novo embaralhamento",
-    restartWithAll: (count) => `Recomeçar com todas as ${count} cartas`,
+    redo: ["Refazer", "Reaplicar o último movimento"],
+    resetTable: "Redefinir mesa",
+    resetTableDescription: (count) => `Devolver todas as ${count} cartas ao baralho`,
+    tarotCollection: "Coleção de tarot",
+    tarotCollectionActions: "Ações da coleção de tarot",
+    tarotCollections: {
+      all: ["Todas as cartas", "78 cartas"],
+      major: ["Arcanos Maiores", "22 cartas"],
+      minor: ["Arcanos Menores", "56 cartas"],
+      court: ["Cartas da corte", "16 cartas"],
+    },
     cardSounds: "Sons das cartas",
     cardSoundsOn: "Sons das cartas ativados",
     cardSoundsOff: "Sons das cartas desativados",
@@ -264,11 +286,13 @@ const messages: Record<AppLocale, Messages> = {
     reverse: "Inverter",
     sendBack: "Enviar para trás",
     bringForward: "Trazer para frente",
+    moveUp: "Mover para cima",
+    moveDown: "Mover para baixo",
     symbolism: (title) => `Simbolismo e correspondências de ${title}`,
     symbolismTitle: "Simbolismo e correspondências",
     openingNotes: "Abrindo as notas da carta…",
     sources: "Fontes",
-    emptyDeck: "O baralho está vazio. Inicie um novo embaralhamento para recomeçar.",
+    emptyDeck: "O baralho está vazio. Redefina a mesa para recomeçar.",
     liveStatus: (deck, table) =>
       `Restam ${deck.count} ${deck.noun} no baralho. ${table.count} ${table.noun} ${table.count === 1 ? "está" : "estão"} na mesa.`,
     spreadLabels: {
@@ -276,6 +300,10 @@ const messages: Record<AppLocale, Messages> = {
       "three-card": ["Passado · Presente · Futuro", "3 cartas"],
       horseshoe: ["Ferradura", "7 cartas"],
       "celtic-cross": ["Cruz Celta", "10 cartas"],
+      "lenormand-three-card": ["Linha de três cartas", "3 cartas"],
+      "lenormand-five-card": ["Linha de cinco cartas", "5 cartas"],
+      "lenormand-portrait": ["Retrato", "9 cartas"],
+      "lenormand-grand-tableau": ["Grande Tableau", "36 cartas"],
     },
   },
 };

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,0 +1,293 @@
+import type { AppLocale } from "./locale";
+
+type CardCategory = "lenormand" | "major" | "minor";
+
+type Count = {
+  count: number;
+  noun: string;
+};
+
+type Messages = {
+  localeLabel: string;
+  localeShortLabel: string;
+  loadingTable: string;
+  tableDescription: string;
+  tableActions: string;
+  deckTrigger: (deckLabel: string, deck: Count) => string;
+  chooseDeck: string;
+  deck: string;
+  cardsInDeck: (deck: Count) => string;
+  tableZoom: (percent: number) => string;
+  zoom: string;
+  zoomOut: string;
+  resetZoom: string;
+  zoomIn: string;
+  cancelDeckMove: string;
+  movingDeck: string;
+  cancel: string;
+  chooseSpread: string;
+  spreads: string;
+  popularSpreads: string;
+  chooseASpread: string;
+  arrangeAndUndo: string;
+  arrange: string;
+  tableActionsTitle: string;
+  layouts: Readonly<Record<"fan" | "grid" | "stack" | "sort", [string, string]>>;
+  moveDeck: [string, string];
+  undo: [string, string];
+  shuffle: string;
+  shuffleActions: string;
+  deckSession: string;
+  newShuffle: string;
+  restartWithAll: (count: number) => string;
+  cardSounds: string;
+  cardSoundsOn: string;
+  cardSoundsOff: string;
+  language: string;
+  chooseLanguage: string;
+  languageOptions: string;
+  card: string;
+  selectedCardControls: (title: string, isOpen: boolean) => string;
+  selectCardControls: string;
+  selectedCard: string;
+  collapseCardControls: string;
+  browseTableCards: string;
+  selectDrawnCard: string;
+  cardNumber: (number: number) => string;
+  faceDownCard: string;
+  faceDownCardNumber: (number: number) => string;
+  selectedHint: (args: {
+    category: CardCategory;
+    layer: number;
+    total: number;
+    rotation: number;
+    isReversed: boolean;
+  }) => string;
+  faceDownHint: (layer: number, total: number) => string;
+  noSelectionHint: string;
+  flip: string;
+  turnLeft: string;
+  turnRight: string;
+  reverse: string;
+  sendBack: string;
+  bringForward: string;
+  symbolism: (title: string) => string;
+  symbolismTitle: string;
+  openingNotes: string;
+  sources: string;
+  emptyDeck: string;
+  liveStatus: (deck: Count, table: Count) => string;
+  spreadLabels: Readonly<
+    Record<"one-card" | "three-card" | "horseshoe" | "celtic-cross", [string, string]>
+  >;
+};
+
+const cardNoun = (count: number) => (count === 1 ? "card" : "cards");
+
+const tableStatus = ({ count, noun }: Count) =>
+  `${count} ${noun} ${count === 1 ? "is" : "are"} on the table.`;
+
+const messages: Record<AppLocale, Messages> = {
+  en: {
+    localeLabel: "English",
+    localeShortLabel: "EN",
+    loadingTable: "Opening the table…",
+    tableDescription:
+      "Interactive card table. Drag the top card to draw it, drag table cards to arrange them, use the card controls to flip, rotate, or change layers, and use Arrange to move the whole deck without keyboard modifiers.",
+    tableActions: "Table actions",
+    deckTrigger: (deckLabel, deck) =>
+      `Choose deck. ${deckLabel}, ${deck.count} ${deck.noun} remaining`,
+    chooseDeck: "Choose deck",
+    deck: "Deck",
+    cardsInDeck: (deck) => `${deck.count} ${deck.noun} in the deck`,
+    tableZoom: (percent) => `Table zoom, ${percent} percent`,
+    zoom: "Zoom",
+    zoomOut: "Zoom out",
+    resetZoom: "Reset table zoom",
+    zoomIn: "Zoom in",
+    cancelDeckMove: "Cancel deck move mode",
+    movingDeck: "Moving deck",
+    cancel: "Cancel",
+    chooseSpread: "Choose a tarot spread",
+    spreads: "Spreads",
+    popularSpreads: "Popular tarot spreads",
+    chooseASpread: "Choose a spread",
+    arrangeAndUndo: "Arrange cards and undo",
+    arrange: "Arrange",
+    tableActionsTitle: "Table actions",
+    layouts: {
+      fan: ["Fan", "Open arc"],
+      grid: ["Grid", "Even rows"],
+      stack: ["Stack", "Single pile"],
+      sort: ["Sort", "Deck order"],
+    },
+    moveDeck: ["Move deck", "Then drag the pile"],
+    undo: ["Undo", "Last table move"],
+    shuffle: "Shuffle",
+    shuffleActions: "Shuffle actions",
+    deckSession: "Deck session",
+    newShuffle: "New shuffle",
+    restartWithAll: (count) => `Restart with all ${count} cards`,
+    cardSounds: "Card sounds",
+    cardSoundsOn: "Card sounds on",
+    cardSoundsOff: "Card sounds off",
+    language: "Language",
+    chooseLanguage: "Choose language",
+    languageOptions: "Language options",
+    card: "Card",
+    selectedCardControls: (title, isOpen) =>
+      `${isOpen ? "Close" : "Open"} selected card controls for ${title}`,
+    selectCardControls: "Select a card to use card controls",
+    selectedCard: "Selected card",
+    collapseCardControls: "Collapse selected card controls",
+    browseTableCards: "Browse cards on the table",
+    selectDrawnCard: "Select a drawn card",
+    cardNumber: (number) => `Card ${number}`,
+    faceDownCard: "Face-down card",
+    faceDownCardNumber: (number) => `Face-down card ${number}`,
+    selectedHint: ({ category, layer, total, rotation, isReversed }) => {
+      const orientation = isReversed
+        ? "Reversed · "
+        : rotation > 0.8
+          ? `Rotation ${Math.round(rotation)}° · `
+          : "";
+      const categoryLabel =
+        category === "lenormand"
+          ? "Lenormand"
+          : category === "major"
+            ? "Major Arcana"
+            : "Minor Arcana";
+
+      return `${orientation}${categoryLabel} · Layer ${layer} of ${total}`;
+    },
+    faceDownHint: (layer, total) =>
+      `Face down · Layer ${layer} of ${total}. Use the layer controls to restack.`,
+    noSelectionHint: "Draw a card or tap one on the table.",
+    flip: "Flip",
+    turnLeft: "Turn −15°",
+    turnRight: "Turn +15°",
+    reverse: "Reverse",
+    sendBack: "Send back",
+    bringForward: "Bring forward",
+    symbolism: (title) => `Symbolism and correspondences for ${title}`,
+    symbolismTitle: "Symbolism & correspondences",
+    openingNotes: "Opening the card notes…",
+    sources: "Sources",
+    emptyDeck: "The deck is empty. Start a new shuffle to begin again.",
+    liveStatus: (deck, table) =>
+      `${deck.count} ${deck.noun} ${deck.count === 1 ? "remains" : "remain"} in the deck. ${tableStatus(table)}`,
+    spreadLabels: {
+      "one-card": ["One card", "1 card"],
+      "three-card": ["Past · Present · Future", "3 cards"],
+      horseshoe: ["Horseshoe", "7 cards"],
+      "celtic-cross": ["Celtic Cross", "10 cards"],
+    },
+  },
+  "pt-BR": {
+    localeLabel: "Português (Brasil)",
+    localeShortLabel: "PT",
+    loadingTable: "Abrindo a mesa…",
+    tableDescription:
+      "Mesa de cartas interativa. Arraste a carta do topo para tirá-la, arraste as cartas na mesa para organizá-las, use os controles da carta para virar, girar ou mudar camadas, e use Organizar para mover o baralho inteiro sem modificadores de teclado.",
+    tableActions: "Ações da mesa",
+    deckTrigger: (deckLabel, deck) =>
+      `Escolher baralho. ${deckLabel}, restam ${deck.count} ${deck.noun}`,
+    chooseDeck: "Escolher baralho",
+    deck: "Baralho",
+    cardsInDeck: (deck) => `${deck.count} ${deck.noun} no baralho`,
+    tableZoom: (percent) => `Zoom da mesa, ${percent} por cento`,
+    zoom: "Zoom",
+    zoomOut: "Diminuir zoom",
+    resetZoom: "Redefinir zoom da mesa",
+    zoomIn: "Aumentar zoom",
+    cancelDeckMove: "Cancelar modo de mover baralho",
+    movingDeck: "Movendo baralho",
+    cancel: "Cancelar",
+    chooseSpread: "Escolher uma abertura de tarot",
+    spreads: "Aberturas",
+    popularSpreads: "Aberturas de tarot populares",
+    chooseASpread: "Escolha uma abertura",
+    arrangeAndUndo: "Organizar cartas e desfazer",
+    arrange: "Organizar",
+    tableActionsTitle: "Ações da mesa",
+    layouts: {
+      fan: ["Leque", "Arco aberto"],
+      grid: ["Grade", "Linhas regulares"],
+      stack: ["Pilha", "Uma só pilha"],
+      sort: ["Ordenar", "Ordem do baralho"],
+    },
+    moveDeck: ["Mover baralho", "Arraste a pilha"],
+    undo: ["Desfazer", "Último movimento"],
+    shuffle: "Embaralhar",
+    shuffleActions: "Ações de embaralhar",
+    deckSession: "Sessão do baralho",
+    newShuffle: "Novo embaralhamento",
+    restartWithAll: (count) => `Recomeçar com todas as ${count} cartas`,
+    cardSounds: "Sons das cartas",
+    cardSoundsOn: "Sons das cartas ativados",
+    cardSoundsOff: "Sons das cartas desativados",
+    language: "Idioma",
+    chooseLanguage: "Escolher idioma",
+    languageOptions: "Opções de idioma",
+    card: "Carta",
+    selectedCardControls: (title, isOpen) =>
+      `${isOpen ? "Fechar" : "Abrir"} controles da carta selecionada: ${title}`,
+    selectCardControls: "Selecione uma carta para usar os controles",
+    selectedCard: "Carta selecionada",
+    collapseCardControls: "Recolher controles da carta selecionada",
+    browseTableCards: "Explorar cartas na mesa",
+    selectDrawnCard: "Selecione uma carta tirada",
+    cardNumber: (number) => `Carta ${number}`,
+    faceDownCard: "Carta virada para baixo",
+    faceDownCardNumber: (number) => `Carta virada para baixo ${number}`,
+    selectedHint: ({ category, layer, total, rotation, isReversed }) => {
+      const orientation = isReversed
+        ? "Invertida · "
+        : rotation > 0.8
+          ? `Rotação ${Math.round(rotation)}° · `
+          : "";
+      const categoryLabel =
+        category === "lenormand"
+          ? "Lenormand"
+          : category === "major"
+            ? "Arcanos Maiores"
+            : "Arcanos Menores";
+
+      return `${orientation}${categoryLabel} · Camada ${layer} de ${total}`;
+    },
+    faceDownHint: (layer, total) =>
+      `Virada para baixo · Camada ${layer} de ${total}. Use os controles de camada para reorganizar.`,
+    noSelectionHint: "Tire uma carta ou toque em uma carta na mesa.",
+    flip: "Virar",
+    turnLeft: "Girar −15°",
+    turnRight: "Girar +15°",
+    reverse: "Inverter",
+    sendBack: "Enviar para trás",
+    bringForward: "Trazer para frente",
+    symbolism: (title) => `Simbolismo e correspondências de ${title}`,
+    symbolismTitle: "Simbolismo e correspondências",
+    openingNotes: "Abrindo as notas da carta…",
+    sources: "Fontes",
+    emptyDeck: "O baralho está vazio. Inicie um novo embaralhamento para recomeçar.",
+    liveStatus: (deck, table) =>
+      `Restam ${deck.count} ${deck.noun} no baralho. ${table.count} ${table.noun} ${table.count === 1 ? "está" : "estão"} na mesa.`,
+    spreadLabels: {
+      "one-card": ["Uma carta", "1 carta"],
+      "three-card": ["Passado · Presente · Futuro", "3 cartas"],
+      horseshoe: ["Ferradura", "7 cartas"],
+      "celtic-cross": ["Cruz Celta", "10 cartas"],
+    },
+  },
+};
+
+export function getMessages(locale: AppLocale): Messages {
+  return messages[locale];
+}
+
+export function getCardCount(locale: AppLocale, count: number): Count {
+  if (locale === "pt-BR") {
+    return { count, noun: count === 1 ? "carta" : "cartas" };
+  }
+
+  return { count, noun: cardNoun(count) };
+}

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -266,7 +266,7 @@ export function tarotSessionReducer(
       return session;
     }
 
-    return { ...session, selectedCardId: action.cardId, redo: [] };
+    return { ...session, selectedCardId: action.cardId };
   }
 
   if (action.type === "undo") {

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -8,7 +8,7 @@ import type {
   TarotSession,
 } from "@/types";
 import { TABLE_POINT_LIMIT } from "@/types";
-import type { TarotSpread } from "@/lib/tarot-spreads";
+import type { CardSpread } from "@/lib/tarot-spreads";
 
 const HISTORY_LIMIT = 24;
 
@@ -40,6 +40,14 @@ function cloneDeckPosition(position: TablePoint | null): TablePoint | null {
   return position ? ([...position] as TablePoint) : null;
 }
 
+function cloneSnapshots(snapshots: TableSnapshot[]): TableSnapshot[] {
+  return snapshots.map((entry) => ({
+    cards: cloneCards(entry.cards),
+    deckPosition: cloneDeckPosition(entry.deckPosition),
+    selectedCardId: entry.selectedCardId,
+  }));
+}
+
 function snapshot(session: TarotSession): TableSnapshot {
   return {
     cards: cloneCards(session.cards),
@@ -60,6 +68,7 @@ function commit(
     deckPosition: cloneDeckPosition(deckPosition),
     selectedCardId,
     history: [...session.history, snapshot(session)].slice(-HISTORY_LIMIT),
+    redo: [],
   };
 }
 
@@ -89,6 +98,7 @@ export function createTarotSession(cardSet: CardSetDefinition): TarotSession {
     deckPosition: null,
     selectedCardId: null,
     history: [],
+    redo: [],
   };
 }
 
@@ -213,7 +223,7 @@ export type TarotSessionAction =
   | { type: "nudge"; cardId: string; delta: TablePoint }
   | {
       type: "deal-spread";
-      spread: TarotSpread;
+      spread: CardSpread;
       deckPosition?: TablePoint;
     }
   | {
@@ -223,7 +233,18 @@ export type TarotSessionAction =
         Pick<TableCard, "position" | "rotation" | "zIndex">
       >;
     }
+  | {
+      type: "show-collection";
+      cardIds: string[];
+      deckPosition?: TablePoint;
+      placements: Map<
+        string,
+        Pick<TableCard, "position" | "rotation" | "zIndex">
+      >;
+    }
   | { type: "undo" }
+  | { type: "redo" }
+  | { type: "reset-table"; cardSet: CardSetDefinition }
   | { type: "new-shuffle"; cardSet: CardSetDefinition };
 
 export function tarotSessionReducer(
@@ -235,16 +256,17 @@ export function tarotSessionReducer(
       ...action.session,
       cards: cloneCards(action.session.cards),
       deckPosition: cloneDeckPosition(action.session.deckPosition),
-      history: action.session.history.map((entry) => ({
-        cards: cloneCards(entry.cards),
-        deckPosition: cloneDeckPosition(entry.deckPosition),
-        selectedCardId: entry.selectedCardId,
-      })),
+      history: cloneSnapshots(action.session.history),
+      redo: cloneSnapshots(action.session.redo ?? []),
     };
   }
 
   if (action.type === "select") {
-    return { ...session, selectedCardId: action.cardId };
+    if (session.selectedCardId === action.cardId) {
+      return session;
+    }
+
+    return { ...session, selectedCardId: action.cardId, redo: [] };
   }
 
   if (action.type === "undo") {
@@ -260,6 +282,38 @@ export function tarotSessionReducer(
       deckPosition: cloneDeckPosition(previous.deckPosition),
       selectedCardId: previous.selectedCardId,
       history: session.history.slice(0, -1),
+      redo: [...session.redo, snapshot(session)].slice(-HISTORY_LIMIT),
+    };
+  }
+
+  if (action.type === "redo") {
+    const next = session.redo[session.redo.length - 1];
+
+    if (!next) {
+      return session;
+    }
+
+    return {
+      ...session,
+      cards: cloneCards(next.cards),
+      deckPosition: cloneDeckPosition(next.deckPosition),
+      selectedCardId: next.selectedCardId,
+      history: [...session.history, snapshot(session)].slice(-HISTORY_LIMIT),
+      redo: session.redo.slice(0, -1),
+    };
+  }
+
+  if (action.type === "reset-table") {
+    if (action.cardSet.id !== session.cardSetId) {
+      return session;
+    }
+
+    const resetSession = createTarotSession(action.cardSet);
+
+    return {
+      ...resetSession,
+      history: [...session.history, snapshot(session)].slice(-HISTORY_LIMIT),
+      redo: [],
     };
   }
 
@@ -349,6 +403,76 @@ export function tarotSessionReducer(
         rotation: placement.slot.rotation,
         zIndex: zIndexBase + placement.index,
         faceUp: false,
+      };
+    });
+
+    return commit(
+      session,
+      cards,
+      null,
+      action.deckPosition ?? session.deckPosition
+    );
+  }
+
+  if (action.type === "show-collection") {
+    const requestedIds = new Set(action.cardIds);
+    const includedCards = session.cards.filter(
+      (candidate) =>
+        requestedIds.has(candidate.id) || requestedIds.has(candidate.cardId)
+    );
+    const missingPlacement = includedCards.some(
+      (candidate) =>
+        !action.placements.has(candidate.id) &&
+        !action.placements.has(candidate.cardId)
+    );
+
+    if (
+      (action.cardIds.length > 0 && includedCards.length === 0) ||
+      missingPlacement
+    ) {
+      return session;
+    }
+
+    const includedCardIds = new Set(includedCards.map((card) => card.id));
+    const deckZIndexByCardId = new Map(
+      session.cards
+        .filter((candidate) => !includedCardIds.has(candidate.id))
+        .sort(
+          (first, second) =>
+            first.zIndex - second.zIndex || first.id.localeCompare(second.id)
+        )
+        .map((candidate, index) => [candidate.id, index])
+    );
+    const cards = session.cards.map((candidate) => {
+      if (!includedCardIds.has(candidate.id)) {
+        return {
+          ...candidate,
+          zone: "deck" as const,
+          position: [0, 0] as TablePoint,
+          rotation: 0,
+          zIndex: deckZIndexByCardId.get(candidate.id) ?? candidate.zIndex,
+          faceUp: false,
+        };
+      }
+
+      const placement =
+        action.placements.get(candidate.id) ??
+        action.placements.get(candidate.cardId);
+
+      if (!placement) {
+        return candidate;
+      }
+
+      return {
+        ...candidate,
+        zone: "table" as const,
+        position: [
+          clampTablePoint(placement.position[0]),
+          clampTablePoint(placement.position[1]),
+        ] as TablePoint,
+        rotation: placement.rotation,
+        zIndex: placement.zIndex,
+        faceUp: true,
       };
     });
 

--- a/src/lib/tarot-spreads.ts
+++ b/src/lib/tarot-spreads.ts
@@ -127,7 +127,10 @@ function getSpreadBounds(cardBounds: SceneBounds[]) {
 
 function getZoomForBounds(bounds: SceneBounds, layout: SceneTableLayout) {
   const horizontalPadding = layout.cardWidth * 0.16;
-  const verticalPadding = layout.cardHeight * 0.3;
+  // Leave enough breathing room for the auto-hiding dock even while it is
+  // visible; otherwise the lowest card can technically fit the canvas while
+  // still reading as clipped behind the controls.
+  const verticalPadding = layout.cardHeight * 0.46;
   const requiredHalfWidth =
     Math.max(Math.abs(bounds.left), Math.abs(bounds.right)) +
     horizontalPadding;

--- a/src/lib/tarot-spreads.ts
+++ b/src/lib/tarot-spreads.ts
@@ -11,11 +11,35 @@ export type TarotSpreadSlot = {
   rotation: number;
 };
 
-export type TarotSpread = {
-  id: "one-card" | "three-card" | "horseshoe" | "celtic-cross";
+export type TarotSpreadId =
+  | "one-card"
+  | "three-card"
+  | "horseshoe"
+  | "celtic-cross";
+
+export type LenormandSpreadId =
+  | "lenormand-three-card"
+  | "lenormand-five-card"
+  | "lenormand-portrait"
+  | "lenormand-grand-tableau";
+
+export type CardSpreadId = TarotSpreadId | LenormandSpreadId;
+
+export type CardSpread = {
+  id: CardSpreadId;
   label: string;
   shortLabel: string;
   slots: TarotSpreadSlot[];
+};
+
+/** A spread whose positions suit the taller tarot card format. */
+export type TarotSpread = CardSpread & {
+  id: TarotSpreadId;
+};
+
+/** A spread whose positions suit the compact, 36-card Lenormand tableau. */
+export type LenormandSpread = CardSpread & {
+  id: LenormandSpreadId;
 };
 
 export type SpreadPresentation = {
@@ -82,7 +106,7 @@ export function getRotatedCardBounds(
 }
 
 function getSpreadCardBounds(
-  spread: TarotSpread,
+  spread: CardSpread,
   layout: SceneTableLayout
 ) {
   return spread.slots.map((slot) => {
@@ -129,7 +153,7 @@ function getZoomForBounds(bounds: SceneBounds, layout: SceneTableLayout) {
  * returned deck position and the UI can animate to the returned zoom.
  */
 export function getSpreadPresentation(
-  spread: TarotSpread,
+  spread: CardSpread,
   layout: SceneTableLayout
 ): SpreadPresentation {
   if (spread.slots.length === 0) {
@@ -219,9 +243,9 @@ export const popularTarotSpreads: TarotSpread[] = [
     label: "Past · Present · Future",
     shortLabel: "3 cards",
     slots: [
-      { position: [-0.8, -0.05], rotation: -6 },
+      { position: [-0.52, -0.04], rotation: -5 },
       { position: [0, 0.03], rotation: 0 },
-      { position: [0.8, -0.05], rotation: 6 },
+      { position: [0.52, -0.04], rotation: 5 },
     ],
   },
   {
@@ -229,13 +253,13 @@ export const popularTarotSpreads: TarotSpread[] = [
     label: "Horseshoe",
     shortLabel: "7 cards",
     slots: [
-      { position: [-1.55, -1.05], rotation: -16 },
-      { position: [-1.35, 0.25], rotation: -11 },
-      { position: [-0.75, 1.35], rotation: -6 },
-      { position: [0, 1.8], rotation: 0 },
-      { position: [0.75, 1.35], rotation: 6 },
-      { position: [1.35, 0.25], rotation: 11 },
-      { position: [1.55, -1.05], rotation: 16 },
+      { position: [-1.08, -0.85], rotation: -14 },
+      { position: [-0.98, 0.32], rotation: -10 },
+      { position: [-0.5, 1.15], rotation: -5 },
+      { position: [0, 1.47], rotation: 0 },
+      { position: [0.5, 1.15], rotation: 5 },
+      { position: [0.98, 0.32], rotation: 10 },
+      { position: [1.08, -0.85], rotation: 14 },
     ],
   },
   {
@@ -243,16 +267,79 @@ export const popularTarotSpreads: TarotSpread[] = [
     label: "Celtic Cross",
     shortLabel: "10 cards",
     slots: [
-      { position: [-1.55, 0], rotation: 0 },
-      { position: [-1.55, 0], rotation: 90 },
-      { position: [-1.55, 1.55], rotation: 0 },
-      { position: [-1.55, -1.55], rotation: 0 },
-      { position: [-2.4, 0], rotation: 0 },
-      { position: [-0.7, 0], rotation: 0 },
-      { position: [1.75, -2.25], rotation: 0 },
-      { position: [1.75, -0.75], rotation: 0 },
-      { position: [1.75, 0.75], rotation: 0 },
-      { position: [1.75, 2.25], rotation: 0 },
+      { position: [-0.58, 0], rotation: 0 },
+      { position: [-0.58, 0], rotation: 90 },
+      { position: [-0.58, 1.28], rotation: 0 },
+      { position: [-0.58, -1.28], rotation: 0 },
+      { position: [-1.14, 0], rotation: 0 },
+      { position: [-0.02, 0], rotation: 0 },
+      { position: [0.98, -1.84], rotation: 0 },
+      { position: [0.98, -0.61], rotation: 0 },
+      { position: [0.98, 0.61], rotation: 0 },
+      { position: [0.98, 1.84], rotation: 0 },
     ],
   },
 ];
+
+export const popularLenormandSpreads: LenormandSpread[] = [
+  {
+    id: "lenormand-three-card",
+    label: "Three-card line",
+    shortLabel: "3 cards",
+    slots: [
+      { position: [-0.5, 0], rotation: 0 },
+      { position: [0, 0], rotation: 0 },
+      { position: [0.5, 0], rotation: 0 },
+    ],
+  },
+  {
+    id: "lenormand-five-card",
+    label: "Five-card line",
+    shortLabel: "5 cards",
+    slots: [
+      { position: [-1, 0], rotation: 0 },
+      { position: [-0.5, 0], rotation: 0 },
+      { position: [0, 0], rotation: 0 },
+      { position: [0.5, 0], rotation: 0 },
+      { position: [1, 0], rotation: 0 },
+    ],
+  },
+  {
+    id: "lenormand-portrait",
+    label: "Portrait",
+    shortLabel: "9 cards",
+    slots: [
+      { position: [-0.55, 1.5], rotation: 0 },
+      { position: [0, 1.5], rotation: 0 },
+      { position: [0.55, 1.5], rotation: 0 },
+      { position: [-0.55, 0], rotation: 0 },
+      { position: [0, 0], rotation: 0 },
+      { position: [0.55, 0], rotation: 0 },
+      { position: [-0.55, -1.5], rotation: 0 },
+      { position: [0, -1.5], rotation: 0 },
+      { position: [0.55, -1.5], rotation: 0 },
+    ],
+  },
+  {
+    id: "lenormand-grand-tableau",
+    label: "Grand Tableau",
+    shortLabel: "36 cards",
+    slots: [2.4, 0.8, -0.8, -2.4].flatMap((y) =>
+      [-2.0, -1.5, -1.0, -0.5, 0, 0.5, 1.0, 1.5, 2.0].map((x) => ({
+        position: [x, y] as TablePoint,
+        rotation: 0,
+      }))
+    ),
+  },
+];
+
+/**
+ * Returns spread choices appropriate to the active card system. Keeping the
+ * selection here means future card sets can opt into their own vocabulary and
+ * geometry without changing the presentation code.
+ */
+export function getPopularSpreads(cardSetId: string): CardSpread[] {
+  return cardSetId === "classic-lenormand"
+    ? popularLenormandSpreads
+    : popularTarotSpreads;
+}

--- a/src/lib/tarot-spreads.ts
+++ b/src/lib/tarot-spreads.ts
@@ -1,4 +1,4 @@
-import type { TablePoint } from "@/types";
+import type { CardSetKind, TablePoint } from "@/types";
 import {
   MAX_VIEW_ZOOM,
   MIN_VIEW_ZOOM,
@@ -309,22 +309,22 @@ export const popularLenormandSpreads: LenormandSpread[] = [
     label: "Portrait",
     shortLabel: "9 cards",
     slots: [
-      { position: [-0.55, 1.5], rotation: 0 },
-      { position: [0, 1.5], rotation: 0 },
-      { position: [0.55, 1.5], rotation: 0 },
+      { position: [-0.55, 0.94], rotation: 0 },
+      { position: [0, 0.94], rotation: 0 },
+      { position: [0.55, 0.94], rotation: 0 },
       { position: [-0.55, 0], rotation: 0 },
       { position: [0, 0], rotation: 0 },
       { position: [0.55, 0], rotation: 0 },
-      { position: [-0.55, -1.5], rotation: 0 },
-      { position: [0, -1.5], rotation: 0 },
-      { position: [0.55, -1.5], rotation: 0 },
+      { position: [-0.55, -0.94], rotation: 0 },
+      { position: [0, -0.94], rotation: 0 },
+      { position: [0.55, -0.94], rotation: 0 },
     ],
   },
   {
     id: "lenormand-grand-tableau",
     label: "Grand Tableau",
     shortLabel: "36 cards",
-    slots: [2.4, 0.8, -0.8, -2.4].flatMap((y) =>
+    slots: [1.41, 0.47, -0.47, -1.41].flatMap((y) =>
       [-2.0, -1.5, -1.0, -0.5, 0, 0.5, 1.0, 1.5, 2.0].map((x) => ({
         position: [x, y] as TablePoint,
         rotation: 0,
@@ -338,8 +338,8 @@ export const popularLenormandSpreads: LenormandSpread[] = [
  * selection here means future card sets can opt into their own vocabulary and
  * geometry without changing the presentation code.
  */
-export function getPopularSpreads(cardSetId: string): CardSpread[] {
-  return cardSetId === "classic-lenormand"
+export function getPopularSpreads(cardSetKind: CardSetKind): CardSpread[] {
+  return cardSetKind === "lenormand"
     ? popularLenormandSpreads
     : popularTarotSpreads;
 }

--- a/src/lib/tarot-workspace.ts
+++ b/src/lib/tarot-workspace.ts
@@ -106,6 +106,7 @@ function restoreSession(
       : null,
     selectedCardId: session.selectedCardId,
     history: [],
+    redo: [],
   };
 }
 
@@ -157,6 +158,7 @@ export function saveTarotWorkspace(workspace: TarotWorkspace): void {
       session: {
         ...workspace.session,
         history: [],
+        redo: [],
       },
       viewZoom: workspace.viewZoom,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export type TarotSession = {
   deckPosition: TablePoint | null;
   selectedCardId: string | null;
   history: TableSnapshot[];
+  redo: TableSnapshot[];
 };
 
 export type TableLayout = "fan" | "grid" | "stack" | "sort";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { AppLocale } from "@/i18n/locale";
+
 export type CardSetKind = "tarot" | "lenormand";
 
 export type TarotSuit = "cups" | "pentacles" | "swords" | "wands";
@@ -21,7 +23,10 @@ export type CardArtworkCrop = {
 
 export type CardDefinition = {
   id: string;
+  /** Stable archival title used by the deck data and saved sessions. */
   name: string;
+  /** Viewer-facing title keyed by the application's supported locales. */
+  displayNames?: Partial<Record<AppLocale, string>>;
   order: number;
   image: CardArtwork;
   arcana?: "major" | "minor";
@@ -35,6 +40,10 @@ export type CardSetDefinition = {
   label: string;
   shortLabel: string;
   description: string;
+  /** Localized viewer-facing metadata; ids and archival labels stay stable. */
+  displayLabels?: Partial<Record<AppLocale, string>>;
+  displayShortLabels?: Partial<Record<AppLocale, string>>;
+  displayDescriptions?: Partial<Record<AppLocale, string>>;
   cardAspectRatio: number;
   artworkCrop?: CardArtworkCrop;
   back: CardArtwork;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ export type CardArtwork = {
   source: string;
 };
 
+export type CardArtworkCrop = {
+  /** Fraction of the source texture hidden from each edge. */
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
 export type CardDefinition = {
   id: string;
   name: string;
@@ -28,6 +36,7 @@ export type CardSetDefinition = {
   shortLabel: string;
   description: string;
   cardAspectRatio: number;
+  artworkCrop?: CardArtworkCrop;
   back: CardArtwork;
   cards: CardDefinition[];
 };


### PR DESCRIPTION
## Why

The historic Marseille and Lenormand scans needed to feel like physical cards on the same table as Rider–Waite–Smith. The table also needed a complete bilingual experience and familiar, dependable navigation for arranging a full reading.

## What changed

- Crop archival outer edges without altering source artwork, preserve each deck ratio, and add complete English and Brazilian Portuguese deck, card, reading, and control copy.
- Add attributed, copyright-safe card guidance, randomized gently drifting astrological marks, and a more dimensional stacked deck.
- Add I/K layer shortcuts, J/L rotation shortcuts, Cmd/Ctrl+Z undo, Cmd/Ctrl+Shift+Z redo, background-wheel zoom, and Space-drag table panning with clean hover handoff.
- Replace Shuffle with Reset table, improve the deck and Table actions popovers, and keep reset/history operations animated and reversible.
- Add full, Major Arcana, Minor Arcana, and Court card galleries for Tarot plus Three-card line, Five-card line, Portrait, and Grand Tableau layouts for Lenormand.
- Tighten spread spacing, animate zoom-to-fit above the dock, and keep the full interaction set usable at desktop and 320px mobile widths.