### PR TITLE
Make overlapping tarot cards feel physical

### DIFF
--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -13,9 +13,11 @@ import {
   useState,
 } from "react";
 import {
+  Euler,
   ExtrudeGeometry,
   Group,
   LinearFilter,
+  Matrix4,
   MathUtils,
   Mesh,
   Plane,
@@ -50,10 +52,13 @@ const MAX_RELEASE_GLIDE = 0.32;
 const MIN_THROW_SPEED = 0.7;
 const MAX_THROW_ROTATION = 11;
 const FLIP_DURATION_SECONDS = 0.52;
-const FLIP_LIFT = 0.14;
+const FLIP_SURFACE_CLEARANCE = 0.0005;
 const DRAG_SCALE = 1.035;
 
 export const CARD_THICKNESS = 0.018;
+const CARD_FACE_PLANE_OFFSET = 0.002;
+const CARD_VISIBLE_HALF_DEPTH =
+  CARD_THICKNESS / 2 + CARD_FACE_PLANE_OFFSET;
 const CARD_CORNER_RADIUS = 0.16;
 const CARD_BEVEL_SIZE = 0.006;
 const CARD_BEVEL_THICKNESS = 0.003;
@@ -279,7 +284,7 @@ function CardFaceLayers({
       <CardArtwork
         url={artworkUrl}
         crop={artworkCrop}
-        position={[0, 0, direction * (CARD_THICKNESS / 2 + 0.002)]}
+        position={[0, 0, direction * CARD_VISIBLE_HALF_DEPTH]}
         rotation={rotation}
         width={artworkWidth}
         height={artworkHeight}
@@ -442,6 +447,10 @@ export const CardMesh = memo(function CardMesh({
   const groupRef = useRef<Group>(null);
   const flipRef = useRef<Group>(null);
   const slabRef = useRef<Mesh>(null);
+  const parentRotationRef = useRef(new Euler());
+  const parentRotationMatrixRef = useRef(new Matrix4());
+  const flipRotationMatrixRef = useRef(new Matrix4());
+  const combinedRotationMatrixRef = useRef(new Matrix4());
   const dragRef = useRef<DragState | null>(null);
   const flipAnimationRef = useRef<FlipAnimation | null>(null);
   const pendingPositionRef = useRef<[number, number] | null>(null);
@@ -995,20 +1004,78 @@ export const CardMesh = memo(function CardMesh({
       slab.castShadow = !flipIsActive;
     }
 
-    const flipLift =
-      reducedMotion || !flipIsActive
-        ? 0
-        : Math.abs(Math.sin(flippingCard.rotation.y)) * FLIP_LIFT;
-    const zTarget =
-      drag?.moved && drag.mode !== "move-deck"
-        ? draggingZ + flipLift
-        : restingZ + (drag?.mode === "move-deck" ? 0.006 : 0) + flipLift;
     const positionXTarget = moving
       ? drag.target.x
       : pendingPosition?.[0] ?? targetPositionX;
     const positionYTarget = moving
       ? drag.target.y
       : pendingPosition?.[1] ?? targetPositionY;
+    const positionLambda = moving
+      ? DRAG_FOLLOW_LAMBDA
+      : POSITION_SETTLE_LAMBDA;
+    const nextTiltX = reducedMotion
+      ? 0
+      : MathUtils.damp(group.rotation.x, tiltXTarget, 14, delta);
+    const nextTiltY = reducedMotion
+      ? 0
+      : MathUtils.damp(group.rotation.y, tiltYTarget, 14, delta);
+    const nextRotation = reducedMotion
+      ? rotationTarget
+      : MathUtils.damp(group.rotation.z, rotationTarget, 14, delta);
+    const nextX = reducedMotion
+      ? positionXTarget
+      : MathUtils.damp(
+          group.position.x,
+          positionXTarget,
+          positionLambda,
+          delta
+        );
+    const nextY = reducedMotion
+      ? positionYTarget
+      : MathUtils.damp(
+          group.position.y,
+          positionYTarget,
+          positionLambda,
+          delta
+        );
+    const nextScale = reducedMotion
+      ? scaleTarget
+      : MathUtils.damp(group.scale.x, scaleTarget, 17, delta);
+    let flipLift = 0;
+
+    if (flipIsActive) {
+      const parentRotation = parentRotationRef.current.set(
+        nextTiltX,
+        nextTiltY,
+        nextRotation,
+        group.rotation.order
+      );
+      const combinedRotation = combinedRotationMatrixRef.current.multiplyMatrices(
+        parentRotationMatrixRef.current.makeRotationFromEuler(parentRotation),
+        flipRotationMatrixRef.current.makeRotationFromEuler(
+          flippingCard.rotation
+        )
+      );
+      const rotationElements = combinedRotation.elements;
+      const projectedHalfDepth =
+        nextScale *
+        (Math.abs(rotationElements[2]) * (cardWidth / 2) +
+          Math.abs(rotationElements[6]) * (cardHeight / 2) +
+          Math.abs(rotationElements[10]) * CARD_VISIBLE_HALF_DEPTH);
+
+      // Keep the lowest visible corner on or above the surface throughout the
+      // turn. A fixed cosmetic lift lets most of a wide card pass through the
+      // table when the card approaches edge-on.
+      flipLift =
+        Math.max(0, projectedHalfDepth - CARD_VISIBLE_HALF_DEPTH) +
+        FLIP_SURFACE_CLEARANCE;
+    }
+
+    const zBase =
+      drag?.moved && drag.mode !== "move-deck"
+        ? draggingZ
+        : restingZ + (drag?.mode === "move-deck" ? 0.006 : 0);
+    const zTarget = zBase + flipLift;
 
     if (reducedMotion) {
       group.rotation.x = 0;
@@ -1024,36 +1091,12 @@ export const CardMesh = memo(function CardMesh({
       return;
     }
 
-    const nextTiltX = MathUtils.damp(group.rotation.x, tiltXTarget, 14, delta);
-    const nextTiltY = MathUtils.damp(group.rotation.y, tiltYTarget, 14, delta);
-    const nextRotation = MathUtils.damp(
-      group.rotation.z,
-      rotationTarget,
-      14,
-      delta
-    );
-    const positionLambda = moving
-      ? DRAG_FOLLOW_LAMBDA
-      : POSITION_SETTLE_LAMBDA;
-    const nextX = MathUtils.damp(
-      group.position.x,
-      positionXTarget,
-      positionLambda,
-      delta
-    );
-    const nextY = MathUtils.damp(
-      group.position.y,
-      positionYTarget,
-      positionLambda,
-      delta
-    );
-    const nextZ = MathUtils.damp(group.position.z, zTarget, 18, delta);
-    const nextScale = MathUtils.damp(
-      group.scale.x,
-      scaleTarget,
-      17,
-      delta
-    );
+    const nextZ = flipIsActive
+      ? Math.max(
+          MathUtils.damp(group.position.z, zTarget, 18, delta),
+          zTarget
+        )
+      : MathUtils.damp(group.position.z, zTarget, 18, delta);
 
     const needsAnotherFrame =
       flipIsActive ||

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -36,6 +36,7 @@ import type {
 } from "@/types";
 import type { CardSoundPlayer } from "@/lib/card-sounds";
 import type { SceneTableLayout } from "./table-layout";
+import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
 import { TAROT_SCENE_PALETTE } from "./theme";
 
 const DRAG_PLANE = new Plane(new Vector3(0, 0, 1), 0);
@@ -52,8 +53,10 @@ const FLIP_DURATION_SECONDS = 0.52;
 const FLIP_LIFT = 0.14;
 const DRAG_SCALE = 1.035;
 
-export const CARD_THICKNESS = 0.075;
+export const CARD_THICKNESS = 0.018;
 const CARD_CORNER_RADIUS = 0.16;
+const CARD_BEVEL_SIZE = 0.006;
+const CARD_BEVEL_THICKNESS = 0.003;
 
 type PointerCaptureTarget = Mesh & {
   setPointerCapture?: (pointerId: number) => void;
@@ -194,6 +197,7 @@ export function CardArtwork({
   width,
   height,
   renderOrder = 3,
+  paperSeed = 0,
 }: {
   url: string;
   crop?: CardArtworkCrop;
@@ -202,6 +206,7 @@ export function CardArtwork({
   width: number;
   height: number;
   renderOrder?: number;
+  paperSeed?: number;
 }) {
   const texture = useTextureForCard(url);
   const geometry = useMemo(() => {
@@ -233,15 +238,14 @@ export function CardArtwork({
       position={position}
       rotation={rotation}
       renderOrder={renderOrder}
+      receiveShadow
     >
-      <meshStandardMaterial
+      <CardPaperMaterial
         map={texture}
         color="#fffdf7"
-        roughness={0.92}
-        metalness={0}
+        roughness={0.9}
+        paperSeed={paperSeed}
         toneMapped={false}
-        depthTest={false}
-        depthWrite={false}
       />
     </mesh>
   );
@@ -253,12 +257,14 @@ function CardFaceLayers({
   cardWidth,
   cardHeight,
   reverse = false,
+  paperSeed,
 }: {
   artworkUrl: string;
   artworkCrop?: CardArtworkCrop;
   cardWidth: number;
   cardHeight: number;
   reverse?: boolean;
+  paperSeed: number;
 }) {
   const direction = reverse ? -1 : 1;
   const rotation: [number, number, number] | undefined = reverse
@@ -278,6 +284,7 @@ function CardFaceLayers({
         width={artworkWidth}
         height={artworkHeight}
         renderOrder={1}
+        paperSeed={paperSeed}
       />
     </Suspense>
   );
@@ -323,14 +330,18 @@ function createCardSlabGeometry(width: number, height: number) {
     -halfHeight
   );
 
+  const faceDepth = CARD_THICKNESS - CARD_BEVEL_THICKNESS * 2;
   const geometry = new ExtrudeGeometry(shape, {
-    bevelEnabled: false,
+    bevelEnabled: true,
+    bevelSegments: 2,
+    bevelSize: CARD_BEVEL_SIZE,
+    bevelThickness: CARD_BEVEL_THICKNESS,
     curveSegments: 8,
-    depth: CARD_THICKNESS,
+    depth: faceDepth,
     steps: 1,
   });
 
-  geometry.translate(0, 0, -CARD_THICKNESS / 2);
+  geometry.translate(0, 0, -faceDepth / 2);
   geometry.computeVertexNormals();
   return geometry;
 }
@@ -462,6 +473,7 @@ export const CardMesh = memo(function CardMesh({
     [cardHeight, cardWidth]
   );
   const frontTexture = definition.image.preview;
+  const paperSeed = useMemo(() => getPaperSeed(card.id), [card.id]);
 
   useEffect(() => () => slabGeometry.dispose(), [slabGeometry]);
 
@@ -1298,12 +1310,10 @@ export const CardMesh = memo(function CardMesh({
           receiveShadow
           renderOrder={0}
         >
-          <meshStandardMaterial
+          <CardPaperMaterial
             color={TAROT_SCENE_PALETTE.cardPaper}
-            roughness={0.96}
-            metalness={0}
-            depthTest={false}
-            depthWrite={false}
+            roughness={0.94}
+            paperSeed={paperSeed}
           />
         </mesh>
         {hasRevealed && (
@@ -1312,6 +1322,7 @@ export const CardMesh = memo(function CardMesh({
             artworkCrop={cardSet.artworkCrop}
             cardWidth={cardWidth}
             cardHeight={cardHeight}
+            paperSeed={paperSeed}
           />
         )}
         <CardFaceLayers
@@ -1319,6 +1330,7 @@ export const CardMesh = memo(function CardMesh({
           artworkCrop={cardSet.artworkCrop}
           cardWidth={cardWidth}
           cardHeight={cardHeight}
+          paperSeed={paperSeed + 0.417}
           reverse
         />
       </group>

--- a/src/components/tarot-studio/CardPaperMaterial.tsx
+++ b/src/components/tarot-studio/CardPaperMaterial.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { memo, useEffect, useMemo } from "react";
+import {
+  MeshStandardMaterial,
+  type ColorRepresentation,
+  type Texture,
+} from "three";
+
+type CardPaperMaterialProps = {
+  color: ColorRepresentation;
+  map?: Texture;
+  roughness?: number;
+  paperSeed?: number;
+  albedoVariation?: number;
+  roughnessVariation?: number;
+  toneMapped?: boolean;
+};
+
+const PAPER_VERTEX_DECLARATION = /* glsl */ `
+#include <common>
+varying vec3 vPaperPosition;
+`;
+
+const PAPER_VERTEX_POSITION = /* glsl */ `
+#include <begin_vertex>
+vPaperPosition = position;
+`;
+
+const PAPER_FRAGMENT_DECLARATION = /* glsl */ `
+#include <common>
+uniform float uPaperSeed;
+uniform float uPaperAlbedoVariation;
+uniform float uPaperRoughnessVariation;
+varying vec3 vPaperPosition;
+
+float paperHash(vec2 point) {
+  return fract(
+    sin(dot(point, vec2(127.1, 311.7)) + uPaperSeed * 19.19) *
+    43758.5453123
+  );
+}
+
+float paperNoise(vec2 point) {
+  vec2 cell = floor(point);
+  vec2 offset = fract(point);
+  vec2 blend = offset * offset * (3.0 - 2.0 * offset);
+
+  return mix(
+    mix(paperHash(cell), paperHash(cell + vec2(1.0, 0.0)), blend.x),
+    mix(
+      paperHash(cell + vec2(0.0, 1.0)),
+      paperHash(cell + vec2(1.0, 1.0)),
+      blend.x
+    ),
+    blend.y
+  );
+}
+`;
+
+const PAPER_FRAGMENT_COLOR = /* glsl */ `
+#include <map_fragment>
+vec2 paperPoint = vPaperPosition.xy + vec2(
+  uPaperSeed * 0.071,
+  uPaperSeed * 0.113
+);
+float paperCloud = paperNoise(paperPoint * vec2(15.0, 11.0));
+float paperFiber = paperNoise(paperPoint * vec2(8.0, 92.0));
+float paperGrain =
+  (paperCloud - 0.5) * 0.62 +
+  (paperFiber - 0.5) * 0.38;
+diffuseColor.rgb *= 1.0 + paperGrain * uPaperAlbedoVariation;
+`;
+
+const PAPER_FRAGMENT_ROUGHNESS = /* glsl */ `
+#include <roughnessmap_fragment>
+roughnessFactor = clamp(
+  roughnessFactor + paperGrain * uPaperRoughnessVariation,
+  0.72,
+  1.0
+);
+`;
+
+export function getPaperSeed(value: string): number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0) / 4294967295;
+}
+
+export const CardPaperMaterial = memo(function CardPaperMaterial({
+  color,
+  map,
+  roughness = 0.92,
+  paperSeed = 0,
+  albedoVariation = 0.035,
+  roughnessVariation = 0.12,
+  toneMapped = true,
+}: CardPaperMaterialProps) {
+  const material = useMemo(() => {
+    const nextMaterial = new MeshStandardMaterial({
+      color,
+      map,
+      metalness: 0,
+      roughness,
+      toneMapped,
+    });
+
+    nextMaterial.name = "tarot-card-paper";
+    nextMaterial.onBeforeCompile = (shader) => {
+      shader.uniforms.uPaperSeed = { value: paperSeed };
+      shader.uniforms.uPaperAlbedoVariation = {
+        value: albedoVariation,
+      };
+      shader.uniforms.uPaperRoughnessVariation = {
+        value: roughnessVariation,
+      };
+      shader.vertexShader = shader.vertexShader
+        .replace("#include <common>", PAPER_VERTEX_DECLARATION)
+        .replace("#include <begin_vertex>", PAPER_VERTEX_POSITION);
+      shader.fragmentShader = shader.fragmentShader
+        .replace("#include <common>", PAPER_FRAGMENT_DECLARATION)
+        .replace("#include <map_fragment>", PAPER_FRAGMENT_COLOR)
+        .replace(
+          "#include <roughnessmap_fragment>",
+          PAPER_FRAGMENT_ROUGHNESS
+        );
+    };
+    nextMaterial.customProgramCacheKey = () => "tarot-card-paper-v1";
+
+    return nextMaterial;
+  }, [
+    albedoVariation,
+    color,
+    map,
+    paperSeed,
+    roughness,
+    roughnessVariation,
+    toneMapped,
+  ]);
+
+  useEffect(() => () => material.dispose(), [material]);
+
+  return <primitive object={material} attach="material" />;
+});

--- a/src/components/tarot-studio/CardPaperMaterial.tsx
+++ b/src/components/tarot-studio/CardPaperMaterial.tsx
@@ -104,10 +104,10 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   const material = useMemo(() => {
     const nextMaterial = new MeshStandardMaterial({
       color,
-      map,
       metalness: 0,
       roughness,
       toneMapped,
+      ...(map ? { map } : {}),
     });
 
     nextMaterial.name = "tarot-card-paper";

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -44,6 +44,8 @@ import { TAROT_SCENE_PALETTE } from "./theme";
 
 const BASE_CAMERA_ZOOM = 75;
 const TABLE_SURFACE_Z = -0.16;
+const CARD_SURFACE_CLEARANCE = 0.002;
+const DECK_MAT_SURFACE_Z = TABLE_SURFACE_Z + 0.003;
 const TABLE_CARD_CONTACT_GAP = 0.002;
 const DECK_STACK_RENDER_ORDER = 10;
 const DECK_CARD_RENDER_ORDER = 20;
@@ -458,10 +460,11 @@ function getDeckMetrics(count: number) {
       : 0;
   const layerThickness = 0.018;
   const layerStep = 0.019;
-  const firstCenter = TABLE_SURFACE_Z + 0.008 + layerThickness / 2;
+  const firstCenter =
+    DECK_MAT_SURFACE_Z + CARD_SURFACE_CLEARANCE + layerThickness / 2;
   const topSurface = layerCount
     ? firstCenter + (layerCount - 1) * layerStep + layerThickness / 2
-    : TABLE_SURFACE_Z + 0.007;
+    : DECK_MAT_SURFACE_Z;
 
   return {
     firstCenter,
@@ -469,7 +472,8 @@ function getDeckMetrics(count: number) {
     layerStep,
     layerThickness,
     topSurface,
-    topCardCenter: topSurface + CARD_THICKNESS / 2 + 0.006,
+    topCardCenter:
+      topSurface + CARD_THICKNESS / 2 + CARD_SURFACE_CLEARANCE,
   };
 }
 
@@ -510,7 +514,7 @@ function DeckMat({ width, height }: { width: number; height: number }) {
       ),
     [matHeight, matWidth]
   );
-  const surfaceZ = TABLE_SURFACE_Z + 0.003;
+  const surfaceZ = DECK_MAT_SURFACE_Z;
 
   return (
     <group renderOrder={0}>
@@ -900,7 +904,7 @@ function TarotTable({
     tableCards.map((card, index) => [card.id, index])
   );
   const baseTableCardZ =
-    TABLE_SURFACE_Z + CARD_THICKNESS / 2 + 0.008;
+    TABLE_SURFACE_Z + CARD_THICKNESS / 2 + CARD_SURFACE_CLEARANCE;
   const tableCardRestingHeights = useMemo(
     () =>
       getTableCardRestingHeights({

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -28,11 +28,12 @@ import type {
 } from "@/types";
 import {
   getRemainingDeckCount,
-  getTableCards,
   getTopDeckCard,
 } from "@/lib/tarot-session";
 import type { CardSoundPlayer } from "@/lib/card-sounds";
 import { CardArtwork, CARD_THICKNESS, CardMesh } from "./CardMesh";
+import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
+import { getTableCardRestingHeights } from "./card-stacking";
 import {
   createSceneTableLayout,
   MIN_VIEW_ZOOM,
@@ -43,7 +44,7 @@ import { TAROT_SCENE_PALETTE } from "./theme";
 
 const BASE_CAMERA_ZOOM = 75;
 const TABLE_SURFACE_Z = -0.16;
-const TABLE_CARD_GAP = 0.0015;
+const TABLE_CARD_CONTACT_GAP = 0.002;
 const DECK_STACK_RENDER_ORDER = 10;
 const DECK_CARD_RENDER_ORDER = 20;
 const TABLE_CARD_RENDER_ORDER = 100;
@@ -669,15 +670,17 @@ function DeckStack({
               metrics.firstCenter + index * metrics.layerStep,
             ]}
             renderOrder={index}
+            castShadow
+            receiveShadow
           >
-            <meshStandardMaterial
+            <CardPaperMaterial
               color={
                 index % 2
                   ? TAROT_SCENE_PALETTE.cardPaper
                   : TAROT_SCENE_PALETTE.cardPaperShadow
               }
               roughness={index % 2 ? 0.88 : 0.84}
-              metalness={0}
+              paperSeed={getPaperSeed(`${backUrl}:${index}`)}
             />
           </RoundedBox>
         );
@@ -693,6 +696,7 @@ function DeckStack({
             width={width - frameInset}
             height={height - frameInset}
             renderOrder={metrics.layerCount + 1}
+            paperSeed={getPaperSeed(`${backUrl}:passive`)}
           />
         </Suspense>
       )}
@@ -866,7 +870,13 @@ function TarotTable({
         }),
     [definitions, session.cards]
   );
-  const tableCards = getTableCards(session);
+  const tableCards = useMemo(
+    () =>
+      session.cards
+        .filter((card) => card.zone === "table")
+        .sort((first, second) => first.zIndex - second.zIndex),
+    [session.cards]
+  );
   const topDeckCard = getTopDeckCard(session);
   const deckCount = getRemainingDeckCount(session);
   const resolvedDeckPosition =
@@ -891,9 +901,20 @@ function TarotTable({
   );
   const baseTableCardZ =
     TABLE_SURFACE_Z + CARD_THICKNESS / 2 + 0.008;
-  const highestTableCardZ =
-    baseTableCardZ +
-    Math.max(0, tableCards.length - 1) * TABLE_CARD_GAP;
+  const tableCardRestingHeights = useMemo(
+    () =>
+      getTableCardRestingHeights({
+        cards: tableCards,
+        layout,
+        baseHeight: baseTableCardZ,
+        layerStep: CARD_THICKNESS + TABLE_CARD_CONTACT_GAP,
+      }),
+    [baseTableCardZ, layout, tableCards]
+  );
+  const highestTableCardZ = Math.max(
+    baseTableCardZ,
+    ...Array.from(tableCardRestingHeights.values())
+  );
   const draggingZ =
     Math.max(deckMetrics.topCardCenter, highestTableCardZ) +
     CARD_THICKNESS +
@@ -910,7 +931,7 @@ function TarotTable({
 
   return (
     <>
-      <ambientLight intensity={0.7} />
+      <ambientLight intensity={0.48} />
       <directionalLight
         castShadow
         position={[-4, 7, 8]}
@@ -963,7 +984,7 @@ function TarotTable({
         const restingZ =
           card.zone === "deck"
             ? deckMetrics.topCardCenter
-            : baseTableCardZ + tableIndex * TABLE_CARD_GAP;
+            : tableCardRestingHeights.get(card.id) ?? baseTableCardZ;
         const renderOrder =
           card.zone === "deck"
             ? DECK_CARD_RENDER_ORDER

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -934,7 +934,7 @@ function TarotTable({
       <ambientLight intensity={0.48} />
       <directionalLight
         castShadow
-        position={[-4, 7, 8]}
+        position={[-3, 4.5, 12]}
         intensity={2.45}
         color={TAROT_SCENE_PALETTE.keyLight}
         shadow-mapSize-width={1024}

--- a/src/components/tarot-studio/card-stacking.ts
+++ b/src/components/tarot-studio/card-stacking.ts
@@ -1,0 +1,105 @@
+import type { TableCard } from "@/types";
+import type { SceneTableLayout } from "./table-layout";
+
+type Axis = [number, number];
+
+type RotatedCard = {
+  center: [number, number];
+  axes: [Axis, Axis];
+};
+
+function dot(first: Axis, second: Axis): number {
+  return first[0] * second[0] + first[1] * second[1];
+}
+
+function createRotatedCard(
+  card: TableCard,
+  layout: SceneTableLayout
+): RotatedCard {
+  const radians = (card.rotation * Math.PI) / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+
+  return {
+    center: layout.toWorld(card.position),
+    axes: [
+      [cosine, sine],
+      [-sine, cosine],
+    ],
+  };
+}
+
+function projectionRadius(
+  card: RotatedCard,
+  axis: Axis,
+  halfWidth: number,
+  halfHeight: number
+): number {
+  return (
+    halfWidth * Math.abs(dot(card.axes[0], axis)) +
+    halfHeight * Math.abs(dot(card.axes[1], axis))
+  );
+}
+
+function cardsOverlap(
+  first: RotatedCard,
+  second: RotatedCard,
+  halfWidth: number,
+  halfHeight: number
+): boolean {
+  const centerDelta: Axis = [
+    second.center[0] - first.center[0],
+    second.center[1] - first.center[1],
+  ];
+
+  return [...first.axes, ...second.axes].every((axis) => {
+    const centerDistance = Math.abs(dot(centerDelta, axis));
+    const combinedRadius =
+      projectionRadius(first, axis, halfWidth, halfHeight) +
+      projectionRadius(second, axis, halfWidth, halfHeight);
+
+    return centerDistance < combinedRadius - 0.001;
+  });
+}
+
+export function getTableCardRestingHeights({
+  cards,
+  layout,
+  baseHeight,
+  layerStep,
+}: {
+  cards: TableCard[];
+  layout: SceneTableLayout;
+  baseHeight: number;
+  layerStep: number;
+}): Map<string, number> {
+  const restingHeights = new Map<string, number>();
+  const footprints = cards.map((card) => createRotatedCard(card, layout));
+  const halfWidth = layout.cardWidth / 2;
+  const halfHeight = layout.cardHeight / 2;
+
+  cards.forEach((card, index) => {
+    let restingHeight = baseHeight;
+
+    for (let lowerIndex = 0; lowerIndex < index; lowerIndex += 1) {
+      if (
+        cardsOverlap(
+          footprints[index],
+          footprints[lowerIndex],
+          halfWidth,
+          halfHeight
+        )
+      ) {
+        restingHeight = Math.max(
+          restingHeight,
+          (restingHeights.get(cards[lowerIndex].id) ?? baseHeight) +
+            layerStep
+        );
+      }
+    }
+
+    restingHeights.set(card.id, restingHeight);
+  });
+
+  return restingHeights;
+}

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -147,9 +147,16 @@ export function createLayout(
       : cards;
 
   if (layout === "stack") {
+    const stackIntervals = Math.max(1, orderedCards.length - 1);
+    const horizontalStep = Math.min(0.008, 0.08 / stackIntervals);
+    const verticalStep = Math.min(0.01, 0.1 / stackIntervals);
+
     orderedCards.forEach((card, index) => {
       placements.set(card.id, {
-        position: [0.3 + index * 0.008, index * 0.01],
+        position: [
+          0.3 + index * horizontalStep,
+          index * verticalStep,
+        ],
         rotation: alignedRotation(card),
         zIndex: index + 1,
       });


### PR DESCRIPTION
Cards previously relied on painter order while their physical slabs intersected, so small piles looked like flat cutouts and could not produce convincing contact shadows.

This experiment gives only genuinely overlapping cards physical stack height, lets visible paper faces receive shadows, and adds a shared static shader for restrained fiber and roughness variation. The shader stays opaque and non-animated so artwork remains crisp and the earlier border flicker does not return.

Cards and deck layers now sit within a 0.002-unit surface clearance, leaving enough room to avoid z-fighting while keeping contact shadows grounded.

Flip height now follows the card's rotated physical bounds, so its lowest edge clears the mat and any cards underneath for the entire turn instead of clipping through the table.

Dense stack arrangements cap their cumulative registration and use a more overhead key light, keeping a full 78-card pile readable as a deck instead of a long staircase.

## Why

Scattered cards should read as layered physical cardstock without changing the table controls or turning the experience into a glossy 3D demo.
