### PR TITLE
Keep the deck clear of and beneath arranged cards

### DIFF
--- a/scripts/validate-card-readings.mjs
+++ b/scripts/validate-card-readings.mjs
@@ -34,8 +34,6 @@ const { getCardReading } = loadTypeScriptModule(
 );
 const failures = [];
 const locales = ["en", "pt-BR"];
-const pollackSource =
-  "https://redwheelweiser.com/book/seventy-eight-degrees-of-wisdom-9781578636655/";
 const englishAstrologyNames =
   /^(Air|Aquarius|Aries|Cancer|Capricorn|Earth|Fire|Gemini|Jupiter|Leo|Mars|Mercury|Moon|Pisces|Sagittarius|Saturn|Scorpio|Sun|Taurus|Venus|Virgo|Water)\b/;
 
@@ -96,19 +94,7 @@ for (const cardSet of cardSets) {
         failures.push(`${cardKey} has invalid sources`);
       }
 
-      const hasPollack = reading?.sources.some(
-        (source) => source.href === pollackSource
-      );
-
       if (cardSet.id === "rider-waite-smith") {
-        if (
-          !hasPollack ||
-          !reading?.perspective?.label ||
-          !reading.perspective.text
-        ) {
-          failures.push(`${cardKey} is missing the Rachel Pollack methodology lens`);
-        }
-
         const astrology = reading?.correspondences.find(
           ({ label }) => label === "Astrologia"
         )?.value;
@@ -116,8 +102,6 @@ for (const cardSet of cardSets) {
         if (locale === "pt-BR" && astrology && englishAstrologyNames.test(astrology)) {
           failures.push(`${cardKey} has untranslated astrology metadata`);
         }
-      } else if (hasPollack || reading?.perspective) {
-        failures.push(`${cardKey} incorrectly includes the Rachel Pollack lens`);
       }
     }
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -885,24 +885,6 @@ button {
   font-size: 0.74rem;
 }
 
-.tarot-card-perspective {
-  margin-top: 0.72rem;
-  padding-top: 0.72rem;
-  border-top: 1px solid rgba(234, 212, 155, 0.12);
-}
-
-.tarot-card-perspective > span {
-  color: var(--faint-ink);
-  font-family: var(--font-mono);
-  font-size: 0.625rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.tarot-card-perspective p {
-  margin: 0.3rem 0 0;
-}
-
 @media (min-width: 768px) and (hover: hover) and (pointer: fine) {
   .tarot-toolbar[data-dock-state="hidden"] {
     opacity: 0;

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -866,10 +866,10 @@ export const CardMesh = memo(function CardMesh({
             glideY *= glideScale;
           }
 
-          const nextPoint = layout.toPoint(
-            releaseX + glideX,
-            releaseY + glideY
-          );
+          const nextPoint =
+            drag.mode === "move-deck"
+              ? layout.toDeckPoint(releaseX + glideX, releaseY + glideY)
+              : layout.toPoint(releaseX + glideX, releaseY + glideY);
           const nextWorldPosition = layout.toWorld(nextPoint);
 
           if (drag.mode === "move-deck") {

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -203,6 +203,7 @@ export function CardArtwork({
   height,
   renderOrder = 3,
   paperSeed = 0,
+  depthTest = true,
   depthWrite = true,
 }: {
   url: string;
@@ -213,6 +214,7 @@ export function CardArtwork({
   height: number;
   renderOrder?: number;
   paperSeed?: number;
+  depthTest?: boolean;
   depthWrite?: boolean;
 }) {
   const texture = useTextureForCard(url);
@@ -253,6 +255,7 @@ export function CardArtwork({
         roughness={0.9}
         paperSeed={paperSeed}
         toneMapped={false}
+        depthTest={depthTest}
         depthWrite={depthWrite}
       />
     </mesh>
@@ -266,6 +269,7 @@ function CardFaceLayers({
   cardHeight,
   reverse = false,
   paperSeed,
+  depthTest = true,
   depthWrite = true,
 }: {
   artworkUrl: string;
@@ -274,6 +278,7 @@ function CardFaceLayers({
   cardHeight: number;
   reverse?: boolean;
   paperSeed: number;
+  depthTest?: boolean;
   depthWrite?: boolean;
 }) {
   const direction = reverse ? -1 : 1;
@@ -295,6 +300,7 @@ function CardFaceLayers({
         height={artworkHeight}
         renderOrder={1}
         paperSeed={paperSeed}
+        depthTest={depthTest}
         depthWrite={depthWrite}
       />
     </Suspense>
@@ -1007,7 +1013,7 @@ export const CardMesh = memo(function CardMesh({
     // them out of the shadow pass prevents another card's shadow from reading
     // as transparency, while the slab still gives placed cards a stable shadow.
     if (slab) {
-      slab.castShadow = card.zone !== "deck" && !flipIsActive;
+      slab.castShadow = !flipIsActive;
     }
 
     const positionXTarget = moving
@@ -1355,7 +1361,7 @@ export const CardMesh = memo(function CardMesh({
         <mesh
           ref={slabRef}
           geometry={slabGeometry}
-          castShadow={card.zone !== "deck"}
+          castShadow
           receiveShadow
           renderOrder={0}
         >
@@ -1363,7 +1369,7 @@ export const CardMesh = memo(function CardMesh({
             color={TAROT_SCENE_PALETTE.cardPaper}
             roughness={0.94}
             paperSeed={paperSeed}
-            depthWrite={card.zone !== "deck"}
+            depthTest={card.zone !== "deck"}
           />
         </mesh>
         {hasRevealed && (
@@ -1373,7 +1379,7 @@ export const CardMesh = memo(function CardMesh({
             cardWidth={cardWidth}
             cardHeight={cardHeight}
             paperSeed={paperSeed}
-            depthWrite={card.zone !== "deck"}
+            depthTest={card.zone !== "deck"}
           />
         )}
         <CardFaceLayers
@@ -1382,7 +1388,7 @@ export const CardMesh = memo(function CardMesh({
           cardWidth={cardWidth}
           cardHeight={cardHeight}
           paperSeed={paperSeed + 0.417}
-          depthWrite={card.zone !== "deck"}
+          depthTest={card.zone !== "deck"}
           reverse
         />
       </group>

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -203,6 +203,7 @@ export function CardArtwork({
   height,
   renderOrder = 3,
   paperSeed = 0,
+  depthWrite = true,
 }: {
   url: string;
   crop?: CardArtworkCrop;
@@ -212,6 +213,7 @@ export function CardArtwork({
   height: number;
   renderOrder?: number;
   paperSeed?: number;
+  depthWrite?: boolean;
 }) {
   const texture = useTextureForCard(url);
   const geometry = useMemo(() => {
@@ -251,6 +253,7 @@ export function CardArtwork({
         roughness={0.9}
         paperSeed={paperSeed}
         toneMapped={false}
+        depthWrite={depthWrite}
       />
     </mesh>
   );
@@ -263,6 +266,7 @@ function CardFaceLayers({
   cardHeight,
   reverse = false,
   paperSeed,
+  depthWrite = true,
 }: {
   artworkUrl: string;
   artworkCrop?: CardArtworkCrop;
@@ -270,6 +274,7 @@ function CardFaceLayers({
   cardHeight: number;
   reverse?: boolean;
   paperSeed: number;
+  depthWrite?: boolean;
 }) {
   const direction = reverse ? -1 : 1;
   const rotation: [number, number, number] | undefined = reverse
@@ -290,6 +295,7 @@ function CardFaceLayers({
         height={artworkHeight}
         renderOrder={1}
         paperSeed={paperSeed}
+        depthWrite={depthWrite}
       />
     </Suspense>
   );
@@ -1357,6 +1363,7 @@ export const CardMesh = memo(function CardMesh({
             color={TAROT_SCENE_PALETTE.cardPaper}
             roughness={0.94}
             paperSeed={paperSeed}
+            depthWrite={card.zone !== "deck"}
           />
         </mesh>
         {hasRevealed && (
@@ -1366,6 +1373,7 @@ export const CardMesh = memo(function CardMesh({
             cardWidth={cardWidth}
             cardHeight={cardHeight}
             paperSeed={paperSeed}
+            depthWrite={card.zone !== "deck"}
           />
         )}
         <CardFaceLayers
@@ -1374,6 +1382,7 @@ export const CardMesh = memo(function CardMesh({
           cardWidth={cardWidth}
           cardHeight={cardHeight}
           paperSeed={paperSeed + 0.417}
+          depthWrite={card.zone !== "deck"}
           reverse
         />
       </group>

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -1007,7 +1007,7 @@ export const CardMesh = memo(function CardMesh({
     // them out of the shadow pass prevents another card's shadow from reading
     // as transparency, while the slab still gives placed cards a stable shadow.
     if (slab) {
-      slab.castShadow = !flipIsActive;
+      slab.castShadow = card.zone !== "deck" && !flipIsActive;
     }
 
     const positionXTarget = moving
@@ -1355,7 +1355,7 @@ export const CardMesh = memo(function CardMesh({
         <mesh
           ref={slabRef}
           geometry={slabGeometry}
-          castShadow
+          castShadow={card.zone !== "deck"}
           receiveShadow
           renderOrder={0}
         >

--- a/src/components/tarot-studio/CardPaperMaterial.tsx
+++ b/src/components/tarot-studio/CardPaperMaterial.tsx
@@ -15,6 +15,7 @@ type CardPaperMaterialProps = {
   albedoVariation?: number;
   roughnessVariation?: number;
   toneMapped?: boolean;
+  depthTest?: boolean;
   depthWrite?: boolean;
 };
 
@@ -101,6 +102,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   albedoVariation = 0.035,
   roughnessVariation = 0.12,
   toneMapped = true,
+  depthTest = true,
   depthWrite = true,
 }: CardPaperMaterialProps) {
   const material = useMemo(() => {
@@ -109,6 +111,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
       metalness: 0,
       roughness,
       toneMapped,
+      depthTest,
       depthWrite,
       ...(map ? { map } : {}),
     });
@@ -139,6 +142,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   }, [
     albedoVariation,
     color,
+    depthTest,
     depthWrite,
     map,
     paperSeed,

--- a/src/components/tarot-studio/CardPaperMaterial.tsx
+++ b/src/components/tarot-studio/CardPaperMaterial.tsx
@@ -15,6 +15,7 @@ type CardPaperMaterialProps = {
   albedoVariation?: number;
   roughnessVariation?: number;
   toneMapped?: boolean;
+  depthWrite?: boolean;
 };
 
 const PAPER_VERTEX_DECLARATION = /* glsl */ `
@@ -100,6 +101,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   albedoVariation = 0.035,
   roughnessVariation = 0.12,
   toneMapped = true,
+  depthWrite = true,
 }: CardPaperMaterialProps) {
   const material = useMemo(() => {
     const nextMaterial = new MeshStandardMaterial({
@@ -107,6 +109,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
       metalness: 0,
       roughness,
       toneMapped,
+      depthWrite,
       ...(map ? { map } : {}),
     });
 
@@ -136,6 +139,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   }, [
     albedoVariation,
     color,
+    depthWrite,
     map,
     paperSeed,
     roughness,

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -687,6 +687,7 @@ function DeckStack({
               }
               roughness={index % 2 ? 0.88 : 0.84}
               paperSeed={getPaperSeed(`${backUrl}:${index}`)}
+              depthWrite={false}
             />
           </RoundedBox>
         );
@@ -703,6 +704,7 @@ function DeckStack({
             height={height - frameInset}
             renderOrder={metrics.layerCount + 1}
             paperSeed={getPaperSeed(`${backUrl}:passive`)}
+            depthWrite={false}
           />
         </Suspense>
       )}

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -676,7 +676,7 @@ function DeckStack({
               metrics.firstCenter + index * metrics.layerStep,
             ]}
             renderOrder={index}
-            castShadow
+            castShadow={false}
             receiveShadow
           >
             <CardPaperMaterial

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -26,6 +26,7 @@ import type {
   TablePoint,
   TarotSession,
 } from "@/types";
+import { getCardStackOffset } from "@/lib/card-stack-layout";
 import {
   getRemainingDeckCount,
   getTopDeckCard,
@@ -51,25 +52,12 @@ const TABLE_SURFACE_Z = -0.16;
 const CARD_SURFACE_CLEARANCE = 0.002;
 const DECK_MAT_SURFACE_Z = TABLE_SURFACE_Z + 0.003;
 const TABLE_CARD_CONTACT_GAP = 0.002;
-const DECK_STACK_RENDER_ORDER = 10;
-const DECK_CARD_RENDER_ORDER = 20;
+const DECK_STACK_RENDER_ORDER = 1_000;
+const DECK_CARD_RENDER_ORDER = 2_000;
 const TABLE_CARD_RENDER_ORDER = 100;
 const CARD_RENDER_ORDER_STEP = 10;
 const DRAG_RENDER_ORDER = 10_000;
-const DECK_LAYER_REGISTRATION = [
-  [-0.009, 0.005],
-  [0.006, 0.003],
-  [-0.005, -0.006],
-  [0.009, -0.002],
-  [-0.007, 0.002],
-  [0.004, -0.006],
-  [-0.002, 0.006],
-  [0.007, -0.004],
-  [-0.006, -0.001],
-  [0.003, 0.005],
-  [-0.004, -0.004],
-  [0.005, 0.001],
-] as const;
+const MAX_DECK_VISUAL_LAYERS = 12;
 const CELESTIAL_MARKS = [
   [-0.38, 0.31, 0.018],
   [-0.29, 0.18, 0.011],
@@ -90,6 +78,10 @@ const ASTROLOGICAL_KINDS = [
   "sun",
   "mars",
   "mercury",
+  "jupiter",
+  "saturn",
+  "uranus",
+  "neptune",
 ] as const;
 
 function createRoundedRectangleShape(
@@ -197,34 +189,68 @@ type DriftingAstrologicalMark = {
   speed: number;
   driftX: number;
   driftY: number;
+  opacity: number;
 };
 
 function createDriftingAstrologicalMarks(): DriftingAstrologicalMark[] {
-  const markCount = 4 + Math.floor(Math.random() * 3);
-
-  return Array.from({ length: markCount }, (_, index) => {
+  const createGrid = ({
+    columns,
+    rows,
+    extentX,
+    extentY,
+    minimumScale,
+    scaleVariation,
+  }: {
+    columns: number;
+    rows: number;
+    extentX: number;
+    extentY: number;
+    minimumScale: number;
+    scaleVariation: number;
+  }) => Array.from({ length: columns * rows }, (_, index) => {
     const kind =
       ASTROLOGICAL_KINDS[
         Math.floor(Math.random() * ASTROLOGICAL_KINDS.length)
       ];
-    const angle =
-      (index / markCount) * Math.PI * 2 +
-      (Math.random() - 0.5) * 0.68;
-    const radiusX = 0.32 + Math.random() * 0.1;
-    const radiusY = 0.27 + Math.random() * 0.1;
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const normalizedX =
+      (column + 0.5 + (Math.random() - 0.5) * 0.62) / columns;
+    const normalizedY =
+      (row + 0.5 + (Math.random() - 0.5) * 0.62) / rows;
 
     return {
       kind,
-      x: Math.cos(angle) * radiusX,
-      y: Math.sin(angle) * radiusY,
-      scale: 0.18 + Math.random() * 0.09,
-      rotation: (Math.random() - 0.5) * 0.5,
+      x: (normalizedX - 0.5) * 2 * extentX,
+      y: (normalizedY - 0.5) * 2 * extentY,
+      scale: minimumScale + Math.random() * scaleVariation,
+      rotation: (Math.random() - 0.5) * 0.72,
       phase: Math.random() * Math.PI * 2,
-      speed: 0.045 + Math.random() * 0.035,
-      driftX: 0.025 + Math.random() * 0.035,
-      driftY: 0.02 + Math.random() * 0.03,
+      speed: 0.035 + Math.random() * 0.04,
+      driftX: 0.004 + Math.random() * 0.007,
+      driftY: 0.004 + Math.random() * 0.007,
+      opacity: 0.1 + Math.random() * 0.08,
     };
   });
+
+  return [
+    ...createGrid({
+      columns: 5,
+      rows: 4,
+      extentX: 0.14,
+      extentY: 0.14,
+      minimumScale: 0.16,
+      scaleVariation: 0.08,
+    }),
+    ...createGrid({
+      columns: 7,
+      rows: 4,
+      extentX: 0.47,
+      extentY: 0.46,
+      minimumScale: 0.18,
+      scaleVariation: 0.12,
+    }),
+  ];
 }
 
 function AstrologicalMark({
@@ -232,12 +258,14 @@ function AstrologicalMark({
   position,
   rotation,
   scale,
+  opacity,
   markRef,
 }: {
   kind: AstrologicalMarkKind;
   position: [number, number, number];
   rotation: number;
   scale: number;
+  opacity: number;
   markRef?: RefCallback<Group>;
 }) {
   const paths = useMemo(() => {
@@ -274,6 +302,73 @@ function AstrologicalMark({
             [number, number, number]
           >,
         ];
+      case "jupiter":
+        return [
+          [
+            [-0.82, 0.55, 0],
+            [-0.12, 0.55, 0],
+            [0.42, 1.08, 0],
+          ] as Array<[number, number, number]>,
+          [
+            [0.12, 1.02, 0],
+            [-0.5, 0.12, 0],
+            [0.38, -0.18, 0],
+            [0.38, -1.08, 0],
+          ] as Array<[number, number, number]>,
+          [[-0.14, -0.58, 0], [0.82, -0.58, 0]] as Array<
+            [number, number, number]
+          >,
+        ];
+      case "saturn":
+        return [
+          [
+            [-0.38, 1.1, 0],
+            [-0.38, -0.18, 0],
+            [0.18, -0.72, 0],
+            [0.62, -0.38, 0],
+          ] as Array<[number, number, number]>,
+          [[-0.86, 0.55, 0], [0.28, 0.55, 0]] as Array<
+            [number, number, number]
+          >,
+          createArcPoints(0.58, -Math.PI * 0.58, Math.PI * 0.38, 0.08),
+        ];
+      case "uranus":
+        return [
+          circle,
+          [[0, 1.2, 0], [0, -1.2, 0]] as Array<[number, number, number]>,
+          [
+            [-0.95, 0.72, 0],
+            [-0.48, 0.72, 0],
+            [-0.48, -0.72, 0],
+            [-0.95, -0.72, 0],
+          ] as Array<[number, number, number]>,
+          [
+            [0.95, 0.72, 0],
+            [0.48, 0.72, 0],
+            [0.48, -0.72, 0],
+            [0.95, -0.72, 0],
+          ] as Array<[number, number, number]>,
+        ];
+      case "neptune":
+        return [
+          [[0, 1.15, 0], [0, -1.18, 0]] as Array<[number, number, number]>,
+          [
+            [-0.88, 0.84, 0],
+            [-0.88, 0.28, 0],
+            [0, -0.12, 0],
+            [0.88, 0.28, 0],
+            [0.88, 0.84, 0],
+          ] as Array<[number, number, number]>,
+          [[-1.12, 0.64, 0], [-0.88, 0.9, 0], [-0.64, 0.64, 0]] as Array<
+            [number, number, number]
+          >,
+          [[0.64, 0.64, 0], [0.88, 0.9, 0], [1.12, 0.64, 0]] as Array<
+            [number, number, number]
+          >,
+          [[-0.48, -0.78, 0], [0.48, -0.78, 0]] as Array<
+            [number, number, number]
+          >,
+        ];
       case "sun":
       default:
         return [circle, createArcPoints(0.09, 0, Math.PI * 2)];
@@ -294,7 +389,7 @@ function AstrologicalMark({
           color={TAROT_SCENE_PALETTE.celestialGold}
           lineWidth={0.7}
           transparent
-          opacity={0.16}
+          opacity={opacity}
           depthWrite={false}
         />
       ))}
@@ -365,6 +460,7 @@ function DriftingAstrologicalField({
       position={[mark.x * width, mark.y * height, 0.001]}
       rotation={mark.rotation}
       scale={mark.scale}
+      opacity={mark.opacity}
       markRef={(group) => {
         markRefs.current[index] = group;
       }}
@@ -476,7 +572,7 @@ function getDeckMetrics(count: number) {
   const layerCount =
     count > 0
       ? Math.min(
-          DECK_LAYER_REGISTRATION.length,
+          MAX_DECK_VISUAL_LAYERS,
           Math.max(1, Math.ceil(count / 7))
         )
       : 0;
@@ -502,18 +598,15 @@ function getDeckMetrics(count: number) {
 function getDeckLayerOffset(
   index: number,
   layerCount: number,
-  width: number,
-  height: number
+  layout: SceneTableLayout
 ): TablePoint {
-  const registration =
-    DECK_LAYER_REGISTRATION[index % DECK_LAYER_REGISTRATION.length];
-  const depth =
-    layerCount <= 1 ? 0 : (layerCount - 1 - index) / (layerCount - 1);
+  const visualCount = layerCount + 1;
+  const [layerX, layerY] = getCardStackOffset(index, visualCount);
+  const [topX, topY] = getCardStackOffset(layerCount, visualCount);
+  const origin = layout.toWorld([0, 0]);
+  const layer = layout.toWorld([layerX - topX, layerY - topY]);
 
-  return [
-    (-depth * 0.014 + registration[0] * depth * 0.32) * width,
-    (-depth * 0.01 + registration[1] * depth * 0.32) * height,
-  ];
+  return [layer[0] - origin[0], layer[1] - origin[1]];
 }
 
 function DeckMat({ width, height }: { width: number; height: number }) {
@@ -584,6 +677,7 @@ function DeckStack({
   count,
   showMat,
   position,
+  layout,
   width,
   height,
   backUrl,
@@ -594,6 +688,7 @@ function DeckStack({
   count: number;
   showMat: boolean;
   position: TablePoint;
+  layout: SceneTableLayout;
   width: number;
   height: number;
   backUrl: string;
@@ -668,8 +763,7 @@ function DeckStack({
     ? getDeckLayerOffset(
         metrics.layerCount - 1,
         metrics.layerCount,
-        width,
-        height
+        layout
       )
     : [0, 0];
 
@@ -680,8 +774,7 @@ function DeckStack({
         const [offsetX, offsetY] = getDeckLayerOffset(
           index,
           metrics.layerCount,
-          width,
-          height
+          layout
         );
 
         return (
@@ -696,7 +789,7 @@ function DeckStack({
               metrics.firstCenter + index * metrics.layerStep,
             ]}
             renderOrder={index}
-            castShadow={false}
+            castShadow
             receiveShadow
           >
             <CardPaperMaterial
@@ -707,7 +800,7 @@ function DeckStack({
               }
               roughness={index % 2 ? 0.88 : 0.84}
               paperSeed={getPaperSeed(`${backUrl}:${index}`)}
-              depthWrite={false}
+              depthTest={false}
             />
           </RoundedBox>
         );
@@ -724,7 +817,7 @@ function DeckStack({
             height={height - frameInset}
             renderOrder={metrics.layerCount + 1}
             paperSeed={getPaperSeed(`${backUrl}:passive`)}
-            depthWrite={false}
+            depthTest={false}
           />
         </Suspense>
       )}
@@ -837,8 +930,8 @@ function TableSurface({
           </mesh>
         ))}
         <DriftingAstrologicalField
-          width={width}
-          height={height}
+          width={visibleWidth}
+          height={visibleHeight}
           reducedMotion={reducedMotion}
         />
       </group>
@@ -868,8 +961,6 @@ function TarotTable({
   const deckPreviewPositionRef = useRef<TablePoint | null>(null);
   const baseViewportWidth = size.width / BASE_CAMERA_ZOOM;
   const baseViewportHeight = size.height / BASE_CAMERA_ZOOM;
-  const shadowHalfWidth = (baseViewportWidth / MIN_VIEW_ZOOM) * 0.55;
-  const shadowHalfHeight = (baseViewportHeight / MIN_VIEW_ZOOM) * 0.55;
   const layout = useMemo(
     () =>
       createSceneTableLayout({
@@ -968,28 +1059,27 @@ function TarotTable({
         viewportBounds={layout.viewportBounds}
         targetZoom={viewZoom}
       />
-      <ambientLight intensity={0.48} />
-      <directionalLight
+      <ambientLight intensity={0.44} />
+      <pointLight
         castShadow
-        position={[-3, 4.5, 12]}
-        intensity={2.45}
+        position={[0, 0, 7.5]}
+        intensity={86}
+        distance={24}
+        decay={2}
         color={TAROT_SCENE_PALETTE.keyLight}
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
         shadow-bias={-0.00035}
         shadow-radius={8}
         shadow-normalBias={0.001}
-        shadow-camera-left={-shadowHalfWidth}
-        shadow-camera-right={shadowHalfWidth}
-        shadow-camera-top={shadowHalfHeight}
-        shadow-camera-bottom={-shadowHalfHeight}
-        shadow-camera-near={0.1}
-        shadow-camera-far={24}
+        shadow-camera-near={0.2}
+        shadow-camera-far={18}
       />
       <pointLight
-        position={[4, -2, 5]}
-        intensity={4.2}
-        distance={14}
+        position={[0, 0, 4.5]}
+        intensity={8}
+        distance={16}
+        decay={2}
         color={TAROT_SCENE_PALETTE.fillLight}
       />
       <TableSurface
@@ -1003,6 +1093,7 @@ function TarotTable({
         count={Math.max(0, deckCount - 1)}
         showMat={deckCount > 0}
         position={deckPosition}
+        layout={layout}
         width={layout.cardWidth}
         height={layout.cardHeight}
         backUrl={cardSet.back.preview}
@@ -1070,7 +1161,7 @@ export const TarotScene = memo(function TarotScene(props: TarotSceneProps) {
       className="tarot-canvas"
       orthographic
       shadows="soft"
-      dpr={[1, 1.5]}
+      dpr={[0.5, 1.5]}
       frameloop="demand"
       camera={{
         position: [0, 0, 10],

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -36,6 +36,8 @@ import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
 import { getTableCardRestingHeights } from "./card-stacking";
 import {
   createSceneTableLayout,
+  DECK_MAT_HEIGHT_PADDING,
+  DECK_MAT_WIDTH_PADDING,
   MIN_VIEW_ZOOM,
   type SceneBounds,
   type SceneTableLayout,
@@ -495,8 +497,8 @@ function getDeckLayerOffset(
 }
 
 function DeckMat({ width, height }: { width: number; height: number }) {
-  const matWidth = width + 0.58;
-  const matHeight = height + 0.64;
+  const matWidth = width + DECK_MAT_WIDTH_PADDING;
+  const matHeight = height + DECK_MAT_HEIGHT_PADDING;
   const shape = useMemo(
     () => createRoundedRectangleShape(matWidth, matHeight, 0.24),
     [matHeight, matWidth]
@@ -929,7 +931,7 @@ function TarotTable({
     deckPreloadUrls.forEach((url) => useTexture.preload(url));
   }, [cardSet.back.preview, deckPreloadUrls]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     onLayoutChange(layout);
   }, [layout, onLayoutChange]);
 

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -36,9 +36,11 @@ import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
 import { getTableCardRestingHeights } from "./card-stacking";
 import {
   createSceneTableLayout,
+  clampViewPan,
   DECK_MAT_HEIGHT_PADDING,
   DECK_MAT_WIDTH_PADDING,
   MIN_VIEW_ZOOM,
+  TABLE_SURFACE_OVERSCAN,
   type SceneBounds,
   type SceneTableLayout,
 } from "./table-layout";
@@ -434,20 +436,38 @@ function AnimatedCameraZoom({
   return null;
 }
 
-function CameraPan({ value }: { value?: TablePoint }) {
+function CameraPan({
+  value,
+  viewportBounds,
+  targetZoom,
+}: {
+  value?: TablePoint;
+  viewportBounds: SceneBounds;
+  targetZoom: number;
+}) {
   const camera = useThree((state) => state.camera) as OrthographicCamera;
   const invalidate = useThree((state) => state.invalidate);
-  const [x, y] = value ?? [0, 0];
 
   useEffect(() => {
+    invalidate();
+  }, [invalidate, targetZoom, value, viewportBounds]);
+
+  useFrame(() => {
+    const currentZoom = camera.zoom / BASE_CAMERA_ZOOM;
+    const safeZoom = Math.min(targetZoom, currentZoom);
+    const [x, y] = clampViewPan(
+      value ?? [0, 0],
+      viewportBounds,
+      safeZoom
+    );
+
     if (camera.position.x === x && camera.position.y === y) {
       return;
     }
 
     camera.position.set(x, y, camera.position.z);
     camera.updateMatrixWorld();
-    invalidate();
-  }, [camera, invalidate, x, y]);
+  });
 
   return null;
 }
@@ -725,8 +745,10 @@ function TableSurface({
   reducedMotion: boolean;
   onSelect: (cardId: string | null) => void;
 }) {
-  const visibleWidth = (width / MIN_VIEW_ZOOM) * 1.04;
-  const visibleHeight = (height / MIN_VIEW_ZOOM) * 1.04;
+  const visibleWidth =
+    (width / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN;
+  const visibleHeight =
+    (height / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN;
   const celestialRadius = Math.min(visibleWidth, visibleHeight) * 0.19;
   const dragOutline = useMemo(
     () => createRoundedRectanglePoints(dragBounds, 0.5, 10),
@@ -828,6 +850,8 @@ function TarotTable({
   cardSet,
   session,
   reducedMotion,
+  viewZoom,
+  viewPan,
   deckMoveMode,
   onSelect,
   onDraw,
@@ -939,6 +963,11 @@ function TarotTable({
 
   return (
     <>
+      <CameraPan
+        value={viewPan}
+        viewportBounds={layout.viewportBounds}
+        targetZoom={viewZoom}
+      />
       <ambientLight intensity={0.48} />
       <directionalLight
         castShadow
@@ -1059,7 +1088,6 @@ export const TarotScene = memo(function TarotScene(props: TarotSceneProps) {
         value={props.viewZoom}
         reducedMotion={props.reducedMotion}
       />
-      <CameraPan value={props.viewPan} />
       <TarotTable {...props} />
     </Canvas>
   );

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -2038,12 +2038,6 @@ export function TarotStudio() {
                           {selectedReading.traditionNote}
                         </p>
                       )}
-                      {selectedReading.perspective && (
-                        <div className="tarot-card-perspective">
-                          <span>{selectedReading.perspective.label}</span>
-                          <p>{selectedReading.perspective.text}</p>
-                        </div>
-                      )}
                       <div className="tarot-card-sources">
                         <span>{messages.sources}</span>
                         <ul>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -37,6 +37,10 @@ import {
   type CardSoundPlayOptions,
 } from "@/lib/card-sounds";
 import {
+  getArrangementPresentation,
+  type AutomaticCardPlacement,
+} from "@/lib/card-arrangement";
+import {
   createLayout,
   createTarotSession,
   getRemainingDeckCount,
@@ -70,11 +74,11 @@ const COURT_RANKS = new Set(["page", "knight", "queen", "king"]);
 
 type TarotCollectionId = "all" | "major" | "minor" | "court";
 
-const COLLECTION_ZOOM: Record<TarotCollectionId, number> = {
-  all: MIN_VIEW_ZOOM,
-  major: 0.48,
-  minor: 0.35,
-  court: 0.48,
+type ActiveAutomaticArrangement = {
+  adjustZoom: boolean;
+  deckPosition: TablePoint;
+  includeDeck: boolean;
+  placements: AutomaticCardPlacement[];
 };
 
 function getCollectionColumnCount(
@@ -124,6 +128,15 @@ function createCollectionPlacements(
       ] as const;
     })
   );
+}
+
+function copyAutomaticPlacements(
+  placements: Iterable<AutomaticCardPlacement>
+): AutomaticCardPlacement[] {
+  return Array.from(placements, (placement) => ({
+    position: [...placement.position] as TablePoint,
+    rotation: placement.rotation,
+  }));
 }
 
 const TarotScene = dynamic(
@@ -426,7 +439,7 @@ export function TarotStudio() {
   const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
-  const activeSpreadRef = useRef<CardSpread | null>(null);
+  const activeArrangementRef = useRef<ActiveAutomaticArrangement | null>(null);
   const spacePressedRef = useRef(false);
   const panGestureRef = useRef<{
     pointerId: number;
@@ -673,19 +686,51 @@ export function TarotStudio() {
   }, []);
 
   const arrangeCards = useCallback(
-    (layout: TableLayout) => {
-      if (tableCards.length === 0) {
+    (tableLayout: TableLayout) => {
+      const layout = sceneLayoutRef.current;
+
+      if (tableCards.length === 0 || !layout) {
         return;
       }
 
-      activeSpreadRef.current = null;
+      const placements = createLayout(
+        tableCards,
+        activeCardSet,
+        tableLayout
+      );
+      const automaticPlacements = copyAutomaticPlacements(
+        placements.values()
+      );
+      const includeDeck = deckCount > 0;
+      const presentation = getArrangementPresentation(
+        automaticPlacements,
+        layout,
+        {
+          includeDeck,
+          preferredDeckPosition: session.deckPosition,
+        }
+      );
+
+      activeArrangementRef.current = {
+        adjustZoom: false,
+        deckPosition: presentation.deckPosition,
+        includeDeck,
+        placements: automaticPlacements,
+      };
       playCardSound("arrange");
       dispatch({
         type: "layout",
-        placements: createLayout(tableCards, activeCardSet, layout),
+        deckPosition: presentation.deckPosition,
+        placements,
       });
     },
-    [activeCardSet, playCardSound, tableCards]
+    [
+      activeCardSet,
+      deckCount,
+      playCardSound,
+      session.deckPosition,
+      tableCards,
+    ]
   );
 
   const dealSpread = useCallback(
@@ -696,8 +741,17 @@ export function TarotStudio() {
         return;
       }
 
-      const presentation = getSpreadPresentation(spread, layout);
-      activeSpreadRef.current = spread;
+      const includeDeck = deckCount > spread.slots.length;
+      const presentation = getSpreadPresentation(spread, layout, {
+        includeDeck,
+        preferredDeckPosition: session.deckPosition,
+      });
+      activeArrangementRef.current = {
+        adjustZoom: true,
+        deckPosition: presentation.deckPosition,
+        includeDeck,
+        placements: copyAutomaticPlacements(spread.slots),
+      };
       setViewPan([0, 0]);
       setViewZoom(presentation.zoom);
       playCardSound("arrange");
@@ -708,7 +762,7 @@ export function TarotStudio() {
         deckPosition: presentation.deckPosition,
       });
     },
-    [playCardSound]
+    [deckCount, playCardSound, session.deckPosition]
   );
 
   const flipSelected = useCallback(() => {
@@ -720,7 +774,7 @@ export function TarotStudio() {
 
   const turnSelected = useCallback((degrees: number) => {
     if (selectedCard?.zone === "table") {
-      activeSpreadRef.current = null;
+      activeArrangementRef.current = null;
       playCardSound("rotate");
       dispatch({ type: "rotate", cardId: selectedCard.id, degrees });
     }
@@ -740,15 +794,30 @@ export function TarotStudio() {
     sceneLayoutRef.current = layout;
     setIsSceneLayoutReady(true);
 
-    const spread = activeSpreadRef.current;
+    const arrangement = activeArrangementRef.current;
 
-    if (spread) {
-      const presentation = getSpreadPresentation(spread, layout);
-      setViewZoom(presentation.zoom);
-      dispatch({
-        type: "sync-deck-position",
-        position: presentation.deckPosition,
-      });
+    if (arrangement) {
+      const presentation = getArrangementPresentation(
+        arrangement.placements,
+        layout,
+        {
+          includeDeck: arrangement.includeDeck,
+          preferredDeckPosition: arrangement.deckPosition,
+        }
+      );
+
+      arrangement.deckPosition = presentation.deckPosition;
+
+      if (arrangement.adjustZoom) {
+        setViewZoom(presentation.zoom);
+      }
+
+      if (arrangement.includeDeck) {
+        dispatch({
+          type: "sync-deck-position",
+          position: presentation.deckPosition,
+        });
+      }
     }
   }, []);
 
@@ -758,7 +827,7 @@ export function TarotStudio() {
 
   const handleDraw = useCallback(
     (cardId: string, position: TablePoint, rotation?: number) => {
-      activeSpreadRef.current = null;
+      activeArrangementRef.current = null;
       playCardSound("draw");
       dispatch({ type: "draw", cardId, position, rotation });
     },
@@ -766,7 +835,7 @@ export function TarotStudio() {
   );
 
   const handleMoveDeck = useCallback((position: TablePoint) => {
-    activeSpreadRef.current = null;
+    activeArrangementRef.current = null;
     setIsDeckMoveMode(false);
     playCardSound("drop");
     dispatch({ type: "move-deck", position });
@@ -774,7 +843,7 @@ export function TarotStudio() {
 
   const handleMove = useCallback(
     (cardId: string, position: TablePoint, rotation?: number) => {
-      activeSpreadRef.current = null;
+      activeArrangementRef.current = null;
       playCardSound("drop");
       dispatch({ type: "move", cardId, position, rotation });
     },
@@ -787,7 +856,7 @@ export function TarotStudio() {
   }, [playCardSound]);
 
   const handleRotate = useCallback((cardId: string, degrees: number) => {
-    activeSpreadRef.current = null;
+    activeArrangementRef.current = null;
     playCardSound("rotate");
     dispatch({ type: "rotate", cardId, degrees });
   }, [playCardSound]);
@@ -860,10 +929,7 @@ export function TarotStudio() {
       return;
     }
 
-    if (previous.cards.every((card) => card.zone === "deck")) {
-      activeSpreadRef.current = null;
-    }
-
+    activeArrangementRef.current = null;
     playCardSound("arrange");
     dispatch({ type: "undo" });
   }, [playCardSound, session.history]);
@@ -875,12 +941,13 @@ export function TarotStudio() {
       return;
     }
 
+    activeArrangementRef.current = null;
     playCardSound("arrange");
     dispatch({ type: "redo" });
   }, [playCardSound, session.redo]);
 
   const resetTable = useCallback(() => {
-    activeSpreadRef.current = null;
+    activeArrangementRef.current = null;
     setIsDeckMoveMode(false);
     setIsInspectorCollapsed(true);
     setViewPan([0, 0]);
@@ -922,20 +989,43 @@ export function TarotStudio() {
       );
       const layout = sceneLayoutRef.current;
 
-      activeSpreadRef.current = null;
+      if (!layout) {
+        return;
+      }
+
+      const placements = createCollectionPlacements(cardIds, collection);
+      const automaticPlacements = copyAutomaticPlacements(
+        placements.values()
+      );
+      const includeDeck = cardIds.length < activeCardSet.cards.length;
+      const presentation = getArrangementPresentation(
+        automaticPlacements,
+        layout,
+        {
+          includeDeck,
+          preferredDeckPosition: session.deckPosition,
+        }
+      );
+
+      activeArrangementRef.current = {
+        adjustZoom: true,
+        deckPosition: presentation.deckPosition,
+        includeDeck,
+        placements: automaticPlacements,
+      };
       setIsDeckMoveMode(false);
       setIsInspectorCollapsed(true);
       setViewPan([0, 0]);
-      setViewZoom(COLLECTION_ZOOM[collection]);
+      setViewZoom(presentation.zoom);
       playCardSound("arrange");
       dispatch({
         type: "show-collection",
         cardIds,
-        placements: createCollectionPlacements(cardIds, collection),
-        deckPosition: layout?.deckPositionCandidates[0]?.position,
+        placements,
+        deckPosition: presentation.deckPosition,
       });
     },
-    [activeCardSet, playCardSound]
+    [activeCardSet, playCardSound, session.deckPosition]
   );
 
   const adjustViewZoom = useCallback((delta: number) => {
@@ -1223,7 +1313,7 @@ export function TarotStudio() {
 
     if (nudge && selectedCard?.zone === "table") {
       event.preventDefault();
-      activeSpreadRef.current = null;
+      activeArrangementRef.current = null;
       playCardSound("move", { intensity: 0.6 });
       dispatch({
         type: "nudge",
@@ -1376,7 +1466,7 @@ export function TarotStudio() {
                 value={activeCardSetId}
                 onChange={(event) => {
                   const nextCardSet = getCardSet(event.target.value);
-                  activeSpreadRef.current = null;
+                  activeArrangementRef.current = null;
                   setIsDeckMoveMode(false);
                   setIsSceneLayoutReady(false);
                   setActiveCardSetId(nextCardSet.id);
@@ -1611,7 +1701,7 @@ export function TarotStudio() {
                       arrangeCards(layout);
                       closeArrangeMenu();
                     }}
-                    disabled={!tableCards.length}
+                    disabled={!tableCards.length || !isSceneLayoutReady}
                   >
                     <span>{label}</span>
                     <small>{hint}</small>
@@ -1678,6 +1768,7 @@ export function TarotStudio() {
                           showTarotCollection(collection);
                           closeArrangeMenu();
                         }}
+                        disabled={!isSceneLayoutReady}
                       >
                         <span>{messages.tarotCollections[collection][0]}</span>
                         <small>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/lib/tarot-workspace";
 import type { CardLayerDirection, TableLayout, TablePoint } from "@/types";
 import {
+  clampViewPan,
   MAX_VIEW_ZOOM,
   MIN_VIEW_ZOOM,
   type SceneTableLayout,
@@ -439,6 +440,7 @@ export function TarotStudio() {
   const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
+  const viewZoomRef = useRef(1);
   const activeArrangementRef = useRef<ActiveAutomaticArrangement | null>(null);
   const spacePressedRef = useRef(false);
   const panGestureRef = useRef<{
@@ -484,6 +486,28 @@ export function TarotStudio() {
   );
   const [isReadingLoading, setIsReadingLoading] = useState(false);
   const [locale, setLocale] = useState<AppLocale>("en");
+
+  useEffect(() => {
+    viewZoomRef.current = viewZoom;
+    const layout = sceneLayoutRef.current;
+
+    if (!layout) {
+      return;
+    }
+
+    setViewPan((current) => {
+      const next = clampViewPan(
+        current,
+        layout.viewportBounds,
+        viewZoom
+      );
+
+      return next[0] === current[0] && next[1] === current[1]
+        ? current
+        : next;
+    });
+  }, [viewZoom]);
+
   const messages = getMessages(locale);
   const activeCardSet = useMemo(
     () => getCardSet(activeCardSetId),
@@ -793,6 +817,17 @@ export function TarotStudio() {
   const handleLayoutChange = useCallback((layout: SceneTableLayout) => {
     sceneLayoutRef.current = layout;
     setIsSceneLayoutReady(true);
+    setViewPan((current) => {
+      const next = clampViewPan(
+        current,
+        layout.viewportBounds,
+        viewZoomRef.current
+      );
+
+      return next[0] === current[0] && next[1] === current[1]
+        ? current
+        : next;
+    });
 
     const arrangement = activeArrangementRef.current;
 
@@ -1161,10 +1196,16 @@ export function TarotStudio() {
       const deltaX = event.clientX - gesture.startX;
       const deltaY = event.clientY - gesture.startY;
 
-      setViewPan([
-        gesture.startPan[0] - deltaX * unitsPerPixel,
-        gesture.startPan[1] + deltaY * unitsPerPixel,
-      ]);
+      setViewPan(
+        clampViewPan(
+          [
+            gesture.startPan[0] - deltaX * unitsPerPixel,
+            gesture.startPan[1] + deltaY * unitsPerPixel,
+          ],
+          layout.viewportBounds,
+          viewZoom
+        )
+      );
     },
     [viewZoom]
   );

--- a/src/components/tarot-studio/table-layout.ts
+++ b/src/components/tarot-studio/table-layout.ts
@@ -3,6 +3,7 @@ import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 
 export const MIN_VIEW_ZOOM = 0.3;
 export const MAX_VIEW_ZOOM = 1.35;
+export const TABLE_SURFACE_OVERSCAN = 1.04;
 export const DECK_MAT_WIDTH_PADDING = 0.58;
 export const DECK_MAT_HEIGHT_PADDING = 0.64;
 const CARD_SCALE_AT_100_PERCENT = 0.8;
@@ -48,6 +49,49 @@ export type DeckPositionCandidate = {
   position: TablePoint;
   worldPosition: [number, number];
 };
+
+export function getViewPanBounds(
+  viewportBounds: SceneBounds,
+  viewZoom: number
+): SceneBounds {
+  const zoom = clamp(
+    Number.isFinite(viewZoom) ? viewZoom : 1,
+    MIN_VIEW_ZOOM,
+    MAX_VIEW_ZOOM
+  );
+  const viewportWidth = viewportBounds.right - viewportBounds.left;
+  const viewportHeight = viewportBounds.top - viewportBounds.bottom;
+  const surfaceHalfWidth =
+    (viewportWidth / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN * 0.5;
+  const surfaceHalfHeight =
+    (viewportHeight / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN * 0.5;
+  const visibleHalfWidth = viewportWidth / zoom / 2;
+  const visibleHalfHeight = viewportHeight / zoom / 2;
+  const maximumX = Math.max(0, surfaceHalfWidth - visibleHalfWidth);
+  const maximumY = Math.max(0, surfaceHalfHeight - visibleHalfHeight);
+
+  return {
+    left: -maximumX,
+    right: maximumX,
+    top: maximumY,
+    bottom: -maximumY,
+  };
+}
+
+export function clampViewPan(
+  pan: TablePoint,
+  viewportBounds: SceneBounds,
+  viewZoom: number
+): TablePoint {
+  const bounds = getViewPanBounds(viewportBounds, viewZoom);
+  const x = Number.isFinite(pan[0]) ? pan[0] : 0;
+  const y = Number.isFinite(pan[1]) ? pan[1] : 0;
+
+  return [
+    clamp(x, bounds.left, bounds.right),
+    clamp(y, bounds.bottom, bounds.top),
+  ];
+}
 
 export function createSceneTableLayout({
   viewportWidth,

--- a/src/components/tarot-studio/table-layout.ts
+++ b/src/components/tarot-studio/table-layout.ts
@@ -1,8 +1,10 @@
 import type { TablePoint } from "@/types";
-import { TABLE_POINT_LIMIT } from "@/types";
+import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 
 export const MIN_VIEW_ZOOM = 0.3;
 export const MAX_VIEW_ZOOM = 1.35;
+export const DECK_MAT_WIDTH_PADDING = 0.58;
+export const DECK_MAT_HEIGHT_PADDING = 0.64;
 const CARD_SCALE_AT_100_PERCENT = 0.8;
 
 const clamp = (value: number, minimum: number, maximum: number) =>
@@ -23,6 +25,8 @@ export type SceneTableLayout = {
    */
   deckPositionCandidates: DeckPositionCandidate[];
   toPoint: (x: number, y: number) => TablePoint;
+  /** Converts a planner position using the deck's wider parking range. */
+  toDeckPoint: (x: number, y: number) => TablePoint;
   toWorld: (point: TablePoint) => [number, number];
 };
 
@@ -90,18 +94,28 @@ export function createSceneTableLayout({
   const halfHeight = Math.max((tableTop - tableBottom) / 2, cardHeight / 2);
   const deckSideInset = 0.12;
   const deckVerticalInset = isMobile ? 0.58 : 0.95;
-  const toPoint = (x: number, y: number): TablePoint => [
+  const deckWidth = cardWidth + DECK_MAT_WIDTH_PADDING;
+  const deckHeight = cardHeight + DECK_MAT_HEIGHT_PADDING;
+  const toLimitedPoint = (
+    x: number,
+    y: number,
+    limit: number
+  ): TablePoint => [
     clamp(
       (x - centerX) / halfWidth,
-      -TABLE_POINT_LIMIT,
-      TABLE_POINT_LIMIT
+      -limit,
+      limit
     ),
     clamp(
       (y - centerY) / halfHeight,
-      -TABLE_POINT_LIMIT,
-      TABLE_POINT_LIMIT
+      -limit,
+      limit
     ),
   ];
+  const toPoint = (x: number, y: number): TablePoint =>
+    toLimitedPoint(x, y, TABLE_POINT_LIMIT);
+  const toDeckPoint = (x: number, y: number): TablePoint =>
+    toLimitedPoint(x, y, DECK_POINT_LIMIT);
   const toWorld = ([x, y]: TablePoint): [number, number] => [
     centerX + x * halfWidth,
     centerY + y * halfHeight,
@@ -132,32 +146,32 @@ export function createSceneTableLayout({
   const deckPositionCandidates: DeckPositionCandidate[] = [
     createDeckCandidate(
       "top-left",
-      tableLeft + cardWidth / 2 + deckSideInset,
-      tableTop - cardHeight / 2 - deckVerticalInset
+      tableLeft + deckWidth / 2 + deckSideInset,
+      tableTop - deckHeight / 2 - deckVerticalInset
     ),
     createDeckCandidate(
       "top-right",
-      tableRight - cardWidth / 2 - deckSideInset,
-      tableTop - cardHeight / 2 - deckVerticalInset
+      tableRight - deckWidth / 2 - deckSideInset,
+      tableTop - deckHeight / 2 - deckVerticalInset
     ),
     createDeckCandidate(
       "bottom-left",
-      tableLeft + cardWidth / 2 + deckSideInset,
-      tableBottom + cardHeight / 2 + deckSideInset
+      tableLeft + deckWidth / 2 + deckSideInset,
+      tableBottom + deckHeight / 2 + deckSideInset
     ),
     createDeckCandidate(
       "bottom-right",
-      tableRight - cardWidth / 2 - deckSideInset,
-      tableBottom + cardHeight / 2 + deckSideInset
+      tableRight - deckWidth / 2 - deckSideInset,
+      tableBottom + deckHeight / 2 + deckSideInset
     ),
     createDeckCandidate(
       "left",
-      tableLeft + cardWidth / 2 + deckSideInset,
+      tableLeft + deckWidth / 2 + deckSideInset,
       centerY
     ),
     createDeckCandidate(
       "right",
-      tableRight - cardWidth / 2 - deckSideInset,
+      tableRight - deckWidth / 2 - deckSideInset,
       centerY
     ),
   ];
@@ -172,5 +186,6 @@ export function createSceneTableLayout({
     deckPositionCandidates,
     toWorld,
     toPoint,
+    toDeckPoint,
   };
 }

--- a/src/data/card-readings.ts
+++ b/src/data/card-readings.ts
@@ -13,10 +13,6 @@ export type CardReading = {
     locator?: string;
   }>;
   traditionNote?: string;
-  perspective?: {
-    label: string;
-    text: string;
-  };
 };
 
 const WAITE_SOURCE = {
@@ -29,12 +25,6 @@ const BOOK_T_SOURCE = {
   label: "Golden Dawn attributions · The Equinox",
   href: "https://www.100thmonkeypress.com/biblio/acrowley/books/equinox_1_8_1912/equinox_1_8_1912.htm",
   locator: "Vol. I, No. VIII, 1912",
-} as const;
-
-const POLLACK_SOURCE = {
-  label: "Rachel Pollack · Seventy-Eight Degrees of Wisdom",
-  href: "https://redwheelweiser.com/book/seventy-eight-degrees-of-wisdom-9781578636655/",
-  locator: "Publisher overview; picture-led psychological tarot method",
 } as const;
 
 const DODAL_SOURCE = {
@@ -746,19 +736,9 @@ function getMajorReading(
         { label: "Astrology", value: reading.goldenDawn },
         { label: "Hebrew path", value: reading.hebrew },
       ],
-      sources: [WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE],
+      sources: [WAITE_SOURCE, BOOK_T_SOURCE],
       traditionNote:
         "The image note follows Waite’s companion text; astrology and Hebrew letters are labeled Golden Dawn correspondences.",
-      perspective:
-        majorKey === "fool"
-          ? {
-              label: "Rachel Pollack lens",
-              text: "A picture-led psychological reading can meet the Fool as the self at the threshold: open to experience, not yet fixed, and invited to discover itself through the journey. This is an original synopsis, not a quotation.",
-            }
-          : {
-              label: "Rachel Pollack lens",
-              text: "A picture-led psychological reading asks what in this scene is becoming conscious. Use the card as a prompt for self-discovery rather than a fixed prediction; this is a general methodology note, not a card-by-card paraphrase.",
-            },
     };
   }
 
@@ -802,13 +782,9 @@ function getMinorReading(
         { label: "Number or role", value: rankReading.correspondence },
         { label: "Esoteric theme", value: theme },
       ],
-      sources: [WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE],
+      sources: [WAITE_SOURCE, BOOK_T_SOURCE],
       traditionNote:
         "Smith’s image and Waite’s companion text ground the card; the elemental and number synthesis is presented as an editorial esoteric reading framework.",
-      perspective: {
-        label: "Rachel Pollack lens",
-        text: "A picture-led psychological reading asks what in this scene is becoming conscious. Use the card as a prompt for self-discovery rather than a fixed prediction; this is a general methodology note, not a card-by-card paraphrase.",
-      },
     };
   }
 
@@ -840,8 +816,6 @@ function getLenormandReading(definition: CardDefinition): CardReading | undefine
       { label: "System", value: `Petit Lenormand · Card ${definition.order + 1}` },
     ],
     sources: [STRALSUND_SOURCE, GAME_OF_HOPE_SOURCE],
-    traditionNote:
-      "The linked deck and museum sources establish the image, number, inset, and history. Per-card themes are a concise editorial reading, not a canonical text from the 1890 deck.",
   };
 }
 
@@ -967,10 +941,6 @@ const PORTUGUESE_SOURCE_METADATA: Record<
     label: "Atribuições da Golden Dawn · The Equinox",
     locator: "Vol. I, n.º VIII, 1912",
   },
-  [POLLACK_SOURCE.href]: {
-    label: "Rachel Pollack · Seventy-Eight Degrees of Wisdom",
-    locator: "Página da editora; método pictórico e psicológico",
-  },
   [DODAL_SOURCE.href]: {
     label: "Tarô de Jean Dodal · Biblioteca Nacional da França",
     locator: "Lyon, c. 1701–1715",
@@ -1040,20 +1010,6 @@ function localizeAstrology(value: string): string {
   return [names[name] ?? name, ...symbol].join(" ");
 }
 
-function getPortuguesePollackPerspective(majorKey?: MajorKey): NonNullable<CardReading["perspective"]> {
-  if (majorKey === "fool") {
-    return {
-      label: "Perspectiva de Rachel Pollack",
-      text: "Uma leitura psicológica orientada pela imagem pode encontrar o Louco como o eu no limiar: aberto à experiência, ainda não fixado e convidado a se descobrir pela jornada. Esta é uma síntese original, não uma citação.",
-    };
-  }
-
-  return {
-    label: "Perspectiva de Rachel Pollack",
-    text: "Uma leitura psicológica orientada pela imagem pergunta o que está se tornando consciente na cena. Use a carta como convite à autodescoberta, não como previsão fixa; esta é uma nota metodológica geral, não uma paráfrase carta a carta.",
-  };
-}
-
 function getPortugueseMajorReading(
   cardSetId: "rider-waite-smith" | "tarot-de-marseille",
   definition: CardDefinition
@@ -1078,10 +1034,9 @@ function getPortugueseMajorReading(
         { label: "Astrologia", value: localizeAstrology(reading.goldenDawn) },
         { label: "Caminho hebraico", value: reading.hebrew },
       ],
-      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE]),
+      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE]),
       traditionNote:
         "A imagem é contextualizada pelo texto de Waite; astrologia e letras hebraicas são correspondências identificadas como Golden Dawn.",
-      perspective: getPortuguesePollackPerspective(majorKey),
     };
   }
 
@@ -1130,10 +1085,9 @@ function getPortugueseMinorReading(
         { label: "Número ou figura", value: rankReading.correspondence },
         { label: "Domínio do naipe", value: suitReading.domain },
       ],
-      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE]),
+      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE]),
       traditionNote:
         "A imagem de Smith e o texto de Waite fundamentam a carta; a síntese elemental e numérica é apresentada como uma estrutura editorial de leitura esotérica.",
-      perspective: getPortuguesePollackPerspective(),
     };
   }
 
@@ -1195,8 +1149,6 @@ function getPortugueseLenormandReading(
       { label: "Sistema", value: `Petit Lenormand · Carta ${definition.order + 1}` },
     ],
     sources: localizeSources([STRALSUND_SOURCE, GAME_OF_HOPE_SOURCE]),
-    traditionNote:
-      "As fontes do baralho e do museu estabelecem imagem, número, inserto e história. Os temas carta a carta são uma leitura editorial concisa, não um texto canônico do baralho de 1890.",
   };
 }
 

--- a/src/lib/card-arrangement.ts
+++ b/src/lib/card-arrangement.ts
@@ -1,0 +1,263 @@
+import type {
+  SceneBounds,
+  SceneTableLayout,
+} from "@/components/tarot-studio/table-layout";
+import {
+  DECK_MAT_HEIGHT_PADDING,
+  DECK_MAT_WIDTH_PADDING,
+  MAX_VIEW_ZOOM,
+  MIN_VIEW_ZOOM,
+} from "@/components/tarot-studio/table-layout";
+import type { TablePoint } from "@/types";
+
+export type AutomaticCardPlacement = {
+  position: TablePoint;
+  rotation: number;
+};
+
+export type ArrangementPresentation = {
+  deckPosition: TablePoint;
+  zoom: number;
+};
+
+type ArrangementPresentationOptions = {
+  includeDeck?: boolean;
+  preferredDeckPosition?: TablePoint | null;
+};
+
+type ScoredDeckCandidate = ArrangementPresentation & {
+  overlap: number;
+};
+
+const MEANINGFUL_ZOOM_GAIN = 0.04;
+const OVERLAP_EPSILON = 0.0001;
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+  Math.min(Math.max(value, minimum), maximum);
+
+const emptyBounds = (): SceneBounds => ({
+  left: Number.POSITIVE_INFINITY,
+  right: Number.NEGATIVE_INFINITY,
+  top: Number.NEGATIVE_INFINITY,
+  bottom: Number.POSITIVE_INFINITY,
+});
+
+const includeBounds = (bounds: SceneBounds, next: SceneBounds): SceneBounds => ({
+  left: Math.min(bounds.left, next.left),
+  right: Math.max(bounds.right, next.right),
+  top: Math.max(bounds.top, next.top),
+  bottom: Math.min(bounds.bottom, next.bottom),
+});
+
+const overlapArea = (first: SceneBounds, second: SceneBounds) =>
+  Math.max(
+    0,
+    Math.min(first.right, second.right) - Math.max(first.left, second.left)
+  ) *
+  Math.max(
+    0,
+    Math.min(first.top, second.top) - Math.max(first.bottom, second.bottom)
+  );
+
+function getCenteredBounds(
+  position: [number, number],
+  width: number,
+  height: number
+): SceneBounds {
+  return {
+    left: position[0] - width / 2,
+    right: position[0] + width / 2,
+    top: position[1] + height / 2,
+    bottom: position[1] - height / 2,
+  };
+}
+
+/** Returns the world-space axis-aligned bounds of a rotated card. */
+export function getRotatedCardBounds(
+  position: [number, number],
+  rotation: number,
+  cardWidth: number,
+  cardHeight: number
+): SceneBounds {
+  const radians = (rotation * Math.PI) / 180;
+  const cosine = Math.abs(Math.cos(radians));
+  const sine = Math.abs(Math.sin(radians));
+  const halfWidth = (cosine * cardWidth + sine * cardHeight) / 2;
+  const halfHeight = (sine * cardWidth + cosine * cardHeight) / 2;
+
+  return {
+    left: position[0] - halfWidth,
+    right: position[0] + halfWidth,
+    top: position[1] + halfHeight,
+    bottom: position[1] - halfHeight,
+  };
+}
+
+function getZoomForBounds(bounds: SceneBounds, layout: SceneTableLayout) {
+  const horizontalPadding = layout.cardWidth * 0.16;
+  // Keep the lowest card and deck mat clear of the auto-hiding dock even
+  // while the controls are visible.
+  const verticalPadding = layout.cardHeight * 0.46;
+  const requiredHalfWidth =
+    Math.max(Math.abs(bounds.left), Math.abs(bounds.right)) +
+    horizontalPadding;
+  const requiredHalfHeight =
+    Math.max(Math.abs(bounds.top), Math.abs(bounds.bottom)) +
+    verticalPadding;
+  const viewportHalfWidth =
+    (layout.viewportBounds.right - layout.viewportBounds.left) / 2;
+  const viewportHalfHeight =
+    (layout.viewportBounds.top - layout.viewportBounds.bottom) / 2;
+  const fittingZoom = Math.min(
+    viewportHalfWidth / Math.max(requiredHalfWidth, Number.EPSILON),
+    viewportHalfHeight / Math.max(requiredHalfHeight, Number.EPSILON)
+  );
+
+  return clamp(Math.min(1, fittingZoom), MIN_VIEW_ZOOM, MAX_VIEW_ZOOM);
+}
+
+function getPerimeterCandidates(
+  bounds: SceneBounds,
+  deckWidth: number,
+  deckHeight: number,
+  layout: SceneTableLayout
+): TablePoint[] {
+  const halfDeckWidth = deckWidth / 2;
+  const halfDeckHeight = deckHeight / 2;
+  const centerX = (bounds.left + bounds.right) / 2;
+  const centerY = (bounds.top + bounds.bottom) / 2;
+  const leftX = bounds.left - halfDeckWidth;
+  const rightX = bounds.right + halfDeckWidth;
+  const topY = bounds.top + halfDeckHeight;
+  const bottomY = bounds.bottom - halfDeckHeight;
+  const leftAlignedX = bounds.left + halfDeckWidth;
+  const rightAlignedX = bounds.right - halfDeckWidth;
+  const topAlignedY = bounds.top - halfDeckHeight;
+  const bottomAlignedY = bounds.bottom + halfDeckHeight;
+  const worldPositions: [number, number][] = [
+    [leftX, topAlignedY],
+    [leftX, centerY],
+    [leftX, bottomAlignedY],
+    [rightX, topAlignedY],
+    [rightX, centerY],
+    [rightX, bottomAlignedY],
+    [leftAlignedX, topY],
+    [centerX, topY],
+    [rightAlignedX, topY],
+    [leftAlignedX, bottomY],
+    [centerX, bottomY],
+    [rightAlignedX, bottomY],
+  ];
+
+  return worldPositions.map(([x, y]) => layout.toDeckPoint(x, y));
+}
+
+function deduplicatePoints(points: TablePoint[]): TablePoint[] {
+  const seen = new Set<string>();
+
+  return points.filter((point) => {
+    const key = `${point[0].toFixed(6)}:${point[1].toFixed(6)}`;
+
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Plans a deck position from the final automatic card footprints. The padded
+ * deck rectangle includes the whole mat and a visible gutter, so a zero-area
+ * result also means the rendered deck cannot touch a placed card.
+ */
+export function getArrangementPresentation(
+  placements: readonly AutomaticCardPlacement[],
+  layout: SceneTableLayout,
+  {
+    includeDeck = true,
+    preferredDeckPosition = null,
+  }: ArrangementPresentationOptions = {}
+): ArrangementPresentation {
+  const cardBounds = placements.map((placement) =>
+    getRotatedCardBounds(
+      layout.toWorld(placement.position),
+      placement.rotation,
+      layout.cardWidth,
+      layout.cardHeight
+    )
+  );
+  const arrangementBounds = cardBounds.reduce(includeBounds, emptyBounds());
+
+  if (cardBounds.length === 0) {
+    return {
+      deckPosition: [
+        ...(preferredDeckPosition ?? layout.defaultDeckPosition),
+      ] as TablePoint,
+      zoom: 1,
+    };
+  }
+
+  if (!includeDeck) {
+    return {
+      deckPosition: [
+        ...(preferredDeckPosition ?? layout.defaultDeckPosition),
+      ] as TablePoint,
+      zoom: getZoomForBounds(arrangementBounds, layout),
+    };
+  }
+
+  const deckGap = Math.max(
+    0.12,
+    Math.min(layout.cardWidth, layout.cardHeight) * 0.08
+  );
+  const paddedDeckWidth =
+    layout.cardWidth + DECK_MAT_WIDTH_PADDING + deckGap * 2;
+  const paddedDeckHeight =
+    layout.cardHeight + DECK_MAT_HEIGHT_PADDING + deckGap * 2;
+  const candidatePoints = deduplicatePoints([
+    ...(preferredDeckPosition
+      ? [[...preferredDeckPosition] as TablePoint]
+      : []),
+    ...layout.deckPositionCandidates.map(
+      (candidate) => [...candidate.position] as TablePoint
+    ),
+    ...getPerimeterCandidates(
+      arrangementBounds,
+      paddedDeckWidth,
+      paddedDeckHeight,
+      layout
+    ),
+  ]);
+  const candidates: ScoredDeckCandidate[] = candidatePoints.map((position) => {
+    const deckBounds = getCenteredBounds(
+      layout.toWorld(position),
+      paddedDeckWidth,
+      paddedDeckHeight
+    );
+    const combinedBounds = includeBounds(arrangementBounds, deckBounds);
+
+    return {
+      deckPosition: position,
+      zoom: getZoomForBounds(combinedBounds, layout),
+      overlap: cardBounds.reduce(
+        (total, bounds) => total + overlapArea(bounds, deckBounds),
+        0
+      ),
+    };
+  });
+  const clearCandidates = candidates.filter(
+    (candidate) => candidate.overlap <= OVERLAP_EPSILON
+  );
+  const eligibleCandidates =
+    clearCandidates.length > 0 ? clearCandidates : candidates;
+  const bestCandidate = eligibleCandidates.reduce((best, candidate) =>
+    candidate.zoom > best.zoom + MEANINGFUL_ZOOM_GAIN ? candidate : best
+  );
+
+  return {
+    deckPosition: [...bestCandidate.deckPosition] as TablePoint,
+    zoom: bestCandidate.zoom,
+  };
+}

--- a/src/lib/card-stack-layout.ts
+++ b/src/lib/card-stack-layout.ts
@@ -1,0 +1,14 @@
+import type { TablePoint } from "@/types";
+
+export function getCardStackOffset(
+  index: number,
+  count: number
+): TablePoint {
+  const finalIndex = Math.max(0, count - 1);
+  const safeIndex = Math.min(finalIndex, Math.max(0, index));
+  const intervals = Math.max(1, finalIndex);
+  const horizontalStep = Math.min(0.008, 0.08 / intervals);
+  const verticalStep = Math.min(0.01, 0.1 / intervals);
+
+  return [safeIndex * horizontalStep, safeIndex * verticalStep];
+}

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/types";
 import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 import type { CardSpread } from "@/lib/tarot-spreads";
+import { getCardStackOffset } from "@/lib/card-stack-layout";
 
 const HISTORY_LIMIT = 24;
 
@@ -149,16 +150,14 @@ export function createLayout(
       : cards;
 
   if (layout === "stack") {
-    const stackIntervals = Math.max(1, orderedCards.length - 1);
-    const horizontalStep = Math.min(0.008, 0.08 / stackIntervals);
-    const verticalStep = Math.min(0.01, 0.1 / stackIntervals);
-
     orderedCards.forEach((card, index) => {
+      const [offsetX, offsetY] = getCardStackOffset(
+        index,
+        orderedCards.length
+      );
+
       placements.set(card.id, {
-        position: [
-          0.3 + index * horizontalStep,
-          index * verticalStep,
-        ],
+        position: [0.3 + offsetX, offsetY],
         rotation: alignedRotation(card),
         zIndex: index + 1,
       });

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -7,13 +7,15 @@ import type {
   TableSnapshot,
   TarotSession,
 } from "@/types";
-import { TABLE_POINT_LIMIT } from "@/types";
+import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 import type { CardSpread } from "@/lib/tarot-spreads";
 
 const HISTORY_LIMIT = 24;
 
 const clampTablePoint = (value: number) =>
   Math.min(TABLE_POINT_LIMIT, Math.max(-TABLE_POINT_LIMIT, value));
+const clampDeckPoint = (value: number) =>
+  Math.min(DECK_POINT_LIMIT, Math.max(-DECK_POINT_LIMIT, value));
 
 function shuffle<T>(items: T[]): T[] {
   const shuffled = [...items];
@@ -235,6 +237,7 @@ export type TarotSessionAction =
     }
   | {
       type: "layout";
+      deckPosition?: TablePoint;
       placements: Map<
         string,
         Pick<TableCard, "position" | "rotation" | "zIndex">
@@ -330,8 +333,8 @@ export function tarotSessionReducer(
 
   if (action.type === "move-deck") {
     const deckPosition: TablePoint = [
-      clampTablePoint(action.position[0]),
-      clampTablePoint(action.position[1]),
+      clampDeckPoint(action.position[0]),
+      clampDeckPoint(action.position[1]),
     ];
 
     if (
@@ -347,8 +350,8 @@ export function tarotSessionReducer(
 
   if (action.type === "sync-deck-position") {
     const deckPosition: TablePoint = [
-      clampTablePoint(action.position[0]),
-      clampTablePoint(action.position[1]),
+      clampDeckPoint(action.position[0]),
+      clampDeckPoint(action.position[1]),
     ];
 
     if (
@@ -372,7 +375,12 @@ export function tarotSessionReducer(
       return placement ? { ...card, ...placement } : card;
     });
 
-    return commit(session, cards);
+    return commit(
+      session,
+      cards,
+      session.selectedCardId,
+      action.deckPosition ?? session.deckPosition
+    );
   }
 
   if (action.type === "deal-spread") {

--- a/src/lib/tarot-spreads.ts
+++ b/src/lib/tarot-spreads.ts
@@ -1,10 +1,9 @@
 import type { CardSetKind, TablePoint } from "@/types";
+import type { SceneTableLayout } from "@/components/tarot-studio/table-layout";
 import {
-  MAX_VIEW_ZOOM,
-  MIN_VIEW_ZOOM,
-  type SceneBounds,
-  type SceneTableLayout,
-} from "@/components/tarot-studio/table-layout";
+  getArrangementPresentation,
+  type ArrangementPresentation,
+} from "@/lib/card-arrangement";
 
 export type TarotSpreadSlot = {
   position: TablePoint;
@@ -42,196 +41,20 @@ export type LenormandSpread = CardSpread & {
   id: LenormandSpreadId;
 };
 
-export type SpreadPresentation = {
-  deckPosition: TablePoint;
-  zoom: number;
-};
-
-type SpreadCandidate = SpreadPresentation & {
-  overlap: number;
-};
-
-const MEANINGFUL_ZOOM_GAIN = 0.04;
-
-const clamp = (value: number, minimum: number, maximum: number) =>
-  Math.min(Math.max(value, minimum), maximum);
-
-const emptyBounds = (): SceneBounds => ({
-  left: Number.POSITIVE_INFINITY,
-  right: Number.NEGATIVE_INFINITY,
-  top: Number.NEGATIVE_INFINITY,
-  bottom: Number.POSITIVE_INFINITY,
-});
-
-const includeBounds = (bounds: SceneBounds, next: SceneBounds): SceneBounds => ({
-  left: Math.min(bounds.left, next.left),
-  right: Math.max(bounds.right, next.right),
-  top: Math.max(bounds.top, next.top),
-  bottom: Math.min(bounds.bottom, next.bottom),
-});
-
-const overlapArea = (first: SceneBounds, second: SceneBounds) =>
-  Math.max(
-    0,
-    Math.min(first.right, second.right) - Math.max(first.left, second.left)
-  ) *
-  Math.max(
-    0,
-    Math.min(first.top, second.top) - Math.max(first.bottom, second.bottom)
-  );
-
-/**
- * Returns the world-space axis-aligned bounds of a card after its table
- * rotation. It intentionally uses the final footprint, not an unrotated
- * approximation, so a fanned spread cannot be clipped at its corners.
- */
-export function getRotatedCardBounds(
-  position: [number, number],
-  rotation: number,
-  cardWidth: number,
-  cardHeight: number
-): SceneBounds {
-  const radians = (rotation * Math.PI) / 180;
-  const cosine = Math.abs(Math.cos(radians));
-  const sine = Math.abs(Math.sin(radians));
-  const halfWidth = (cosine * cardWidth + sine * cardHeight) / 2;
-  const halfHeight = (sine * cardWidth + cosine * cardHeight) / 2;
-
-  return {
-    left: position[0] - halfWidth,
-    right: position[0] + halfWidth,
-    top: position[1] + halfHeight,
-    bottom: position[1] - halfHeight,
-  };
-}
-
-function getSpreadCardBounds(
-  spread: CardSpread,
-  layout: SceneTableLayout
-) {
-  return spread.slots.map((slot) => {
-    const worldPosition = layout.toWorld(slot.position);
-
-    return getRotatedCardBounds(
-      worldPosition,
-      slot.rotation,
-      layout.cardWidth,
-      layout.cardHeight
-    );
-  });
-}
-
-function getSpreadBounds(cardBounds: SceneBounds[]) {
-  return cardBounds.reduce(includeBounds, emptyBounds());
-}
-
-function getZoomForBounds(bounds: SceneBounds, layout: SceneTableLayout) {
-  const horizontalPadding = layout.cardWidth * 0.16;
-  // Leave enough breathing room for the auto-hiding dock even while it is
-  // visible; otherwise the lowest card can technically fit the canvas while
-  // still reading as clipped behind the controls.
-  const verticalPadding = layout.cardHeight * 0.46;
-  const requiredHalfWidth =
-    Math.max(Math.abs(bounds.left), Math.abs(bounds.right)) +
-    horizontalPadding;
-  const requiredHalfHeight =
-    Math.max(Math.abs(bounds.top), Math.abs(bounds.bottom)) +
-    verticalPadding;
-  const viewportHalfWidth =
-    (layout.viewportBounds.right - layout.viewportBounds.left) / 2;
-  const viewportHalfHeight =
-    (layout.viewportBounds.top - layout.viewportBounds.bottom) / 2;
-  const fittingZoom = Math.min(
-    viewportHalfWidth / Math.max(requiredHalfWidth, Number.EPSILON),
-    viewportHalfHeight / Math.max(requiredHalfHeight, Number.EPSILON)
-  );
-
-  return clamp(Math.min(1, fittingZoom), MIN_VIEW_ZOOM, MAX_VIEW_ZOOM);
-}
-
 /**
  * Chooses an edge position for the deck and the view zoom needed to show a
- * dealt spread. Overlap is weighted first; among clear placements, the one
- * requiring the least zoom-out wins. It is pure so the session can apply the
- * returned deck position and the UI can animate to the returned zoom.
+ * dealt spread. The shared planner measures the full deck mat and leaves a
+ * visible gutter around every final rotated card.
  */
 export function getSpreadPresentation(
   spread: CardSpread,
-  layout: SceneTableLayout
-): SpreadPresentation {
-  if (spread.slots.length === 0) {
-    return {
-      deckPosition: [...layout.defaultDeckPosition] as TablePoint,
-      zoom: clamp(1, MIN_VIEW_ZOOM, MAX_VIEW_ZOOM),
-    };
-  }
-
-  const spreadCardBounds = getSpreadCardBounds(spread, layout);
-  const spreadBounds = getSpreadBounds(spreadCardBounds);
-  const spreadCenterX = (spreadBounds.left + spreadBounds.right) / 2;
-  const spreadCenterY = (spreadBounds.top + spreadBounds.bottom) / 2;
-  const spreadGap = Math.min(layout.cardWidth, layout.cardHeight) * 0.18;
-  const spreadEdgePositions: TablePoint[] = [
-    layout.toPoint(
-      spreadCenterX,
-      spreadBounds.top + layout.cardHeight / 2 + spreadGap
-    ),
-    layout.toPoint(
-      spreadBounds.left - layout.cardWidth / 2 - spreadGap,
-      spreadCenterY
-    ),
-    layout.toPoint(
-      spreadBounds.right + layout.cardWidth / 2 + spreadGap,
-      spreadCenterY
-    ),
-    layout.toPoint(
-      spreadCenterX,
-      spreadBounds.bottom - layout.cardHeight / 2 - spreadGap
-    ),
-  ];
-  const deckCandidates = [
-    ...spreadEdgePositions.map((position) => ({
-      position,
-      worldPosition: layout.toWorld(position),
-    })),
-    ...layout.deckPositionCandidates,
-  ];
-  const candidates: SpreadCandidate[] = deckCandidates.map(
-    (candidate) => {
-      const deckBounds = getRotatedCardBounds(
-        candidate.worldPosition,
-        0,
-        layout.cardWidth,
-        layout.cardHeight
-      );
-      const bounds = includeBounds(spreadBounds, deckBounds);
-
-      return {
-        deckPosition: candidate.position,
-        zoom: getZoomForBounds(bounds, layout),
-        overlap: spreadCardBounds.reduce(
-          (total, cardBounds) => total + overlapArea(cardBounds, deckBounds),
-          0
-        ),
-      };
-    }
-  );
-  const bestCandidate = candidates.reduce((best, candidate) => {
-    const overlapDifference = candidate.overlap - best.overlap;
-
-    if (Math.abs(overlapDifference) > 0.0001) {
-      return overlapDifference < 0 ? candidate : best;
-    }
-
-    return candidate.zoom > best.zoom + MEANINGFUL_ZOOM_GAIN
-      ? candidate
-      : best;
-  });
-
-  return {
-    deckPosition: [...bestCandidate.deckPosition] as TablePoint,
-    zoom: bestCandidate.zoom,
-  };
+  layout: SceneTableLayout,
+  options: {
+    includeDeck?: boolean;
+    preferredDeckPosition?: TablePoint | null;
+  } = {}
+): ArrangementPresentation {
+  return getArrangementPresentation(spread.slots, layout, options);
 }
 
 export const popularTarotSpreads: TarotSpread[] = [

--- a/src/lib/tarot-workspace.ts
+++ b/src/lib/tarot-workspace.ts
@@ -4,7 +4,7 @@ import type {
   TablePoint,
   TarotSession,
 } from "@/types";
-import { TABLE_POINT_LIMIT } from "@/types";
+import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 
 export const TAROT_WORKSPACE_STORAGE_KEY = "tarot-table:workspace:v1";
 
@@ -25,17 +25,25 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function isTablePoint(value: unknown): value is TablePoint {
+function isPointWithinLimit(
+  value: unknown,
+  limit: number
+): value is TablePoint {
   return (
     Array.isArray(value) &&
     value.length === 2 &&
     value.every(
       (coordinate) =>
-        isFiniteNumber(coordinate) &&
-        Math.abs(coordinate) <= TABLE_POINT_LIMIT
+        isFiniteNumber(coordinate) && Math.abs(coordinate) <= limit
     )
   );
 }
+
+const isTablePoint = (value: unknown): value is TablePoint =>
+  isPointWithinLimit(value, TABLE_POINT_LIMIT);
+
+const isDeckPoint = (value: unknown): value is TablePoint =>
+  isPointWithinLimit(value, DECK_POINT_LIMIT);
 
 function isTableCard(value: unknown, cardSet: CardSetDefinition): value is TableCard {
   if (!value || typeof value !== "object") {
@@ -75,7 +83,7 @@ function restoreSession(
     session.cards.length !== cardSet.cards.length ||
     !session.cards.every((card) => isTableCard(card, cardSet)) ||
     !(
-      session.deckPosition === null || isTablePoint(session.deckPosition)
+      session.deckPosition === null || isDeckPoint(session.deckPosition)
     ) ||
     !(
       session.selectedCardId === null ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export type TableZone = "deck" | "table";
 export type TablePoint = [number, number];
 
 export const TABLE_POINT_LIMIT = 2.6;
+export const DECK_POINT_LIMIT = 6.4;
 
 export type CardLayerDirection = "forward" | "backward";
 


### PR DESCRIPTION
Automatic arrangements could leave the deck at its previous or hard-coded position, letting the larger deck mat overlap the cards that had just been placed.

The table now plans from the final rotated card footprints and reserves the full deck mat plus a visible gutter. Fan, grid, stack, sort, Tarot and Lenormand spreads, and Tarot collections all use the same deterministic placement rule; responsive layout changes re-evaluate active arrangements without adding undo history. Manual card and deck moves remain under the user's control.

Dense layouts can use a wider deck-only parking range, and those planned positions remain valid when the saved table is reloaded. Dragging an automatically parked deck keeps that same range, so a small adjustment cannot snap it back into the cards.

The deck keeps its physical 3D height and depth testing, but deck-only surfaces no longer write depth or cast shadows over cards drawn later. Placed and dragged cards therefore stay visually above the deck even when the user overlaps them manually; drawn cards resume normal shadows as soon as they leave the deck.

Depends on: https://github.com/vtrpldn/tarot/pull/8

## Why

The deck should remain a distinct foundation for drawing cards, never cover the reading, and never obscure a card placed over it.
