### PR TITLE
Refine tarot table depth and navigation

### DIFF
--- a/scripts/validate-card-readings.mjs
+++ b/scripts/validate-card-readings.mjs
@@ -34,8 +34,6 @@ const { getCardReading } = loadTypeScriptModule(
 );
 const failures = [];
 const locales = ["en", "pt-BR"];
-const pollackSource =
-  "https://redwheelweiser.com/book/seventy-eight-degrees-of-wisdom-9781578636655/";
 const englishAstrologyNames =
   /^(Air|Aquarius|Aries|Cancer|Capricorn|Earth|Fire|Gemini|Jupiter|Leo|Mars|Mercury|Moon|Pisces|Sagittarius|Saturn|Scorpio|Sun|Taurus|Venus|Virgo|Water)\b/;
 
@@ -96,19 +94,7 @@ for (const cardSet of cardSets) {
         failures.push(`${cardKey} has invalid sources`);
       }
 
-      const hasPollack = reading?.sources.some(
-        (source) => source.href === pollackSource
-      );
-
       if (cardSet.id === "rider-waite-smith") {
-        if (
-          !hasPollack ||
-          !reading?.perspective?.label ||
-          !reading.perspective.text
-        ) {
-          failures.push(`${cardKey} is missing the Rachel Pollack methodology lens`);
-        }
-
         const astrology = reading?.correspondences.find(
           ({ label }) => label === "Astrologia"
         )?.value;
@@ -116,8 +102,6 @@ for (const cardSet of cardSets) {
         if (locale === "pt-BR" && astrology && englishAstrologyNames.test(astrology)) {
           failures.push(`${cardKey} has untranslated astrology metadata`);
         }
-      } else if (hasPollack || reading?.perspective) {
-        failures.push(`${cardKey} incorrectly includes the Rachel Pollack lens`);
       }
     }
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -885,24 +885,6 @@ button {
   font-size: 0.74rem;
 }
 
-.tarot-card-perspective {
-  margin-top: 0.72rem;
-  padding-top: 0.72rem;
-  border-top: 1px solid rgba(234, 212, 155, 0.12);
-}
-
-.tarot-card-perspective > span {
-  color: var(--faint-ink);
-  font-family: var(--font-mono);
-  font-size: 0.625rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.tarot-card-perspective p {
-  margin: 0.3rem 0 0;
-}
-
 @media (min-width: 768px) and (hover: hover) and (pointer: fine) {
   .tarot-toolbar[data-dock-state="hidden"] {
     opacity: 0;

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -203,6 +203,7 @@ export function CardArtwork({
   height,
   renderOrder = 3,
   paperSeed = 0,
+  depthTest = true,
   depthWrite = true,
 }: {
   url: string;
@@ -213,6 +214,7 @@ export function CardArtwork({
   height: number;
   renderOrder?: number;
   paperSeed?: number;
+  depthTest?: boolean;
   depthWrite?: boolean;
 }) {
   const texture = useTextureForCard(url);
@@ -253,6 +255,7 @@ export function CardArtwork({
         roughness={0.9}
         paperSeed={paperSeed}
         toneMapped={false}
+        depthTest={depthTest}
         depthWrite={depthWrite}
       />
     </mesh>
@@ -266,6 +269,7 @@ function CardFaceLayers({
   cardHeight,
   reverse = false,
   paperSeed,
+  depthTest = true,
   depthWrite = true,
 }: {
   artworkUrl: string;
@@ -274,6 +278,7 @@ function CardFaceLayers({
   cardHeight: number;
   reverse?: boolean;
   paperSeed: number;
+  depthTest?: boolean;
   depthWrite?: boolean;
 }) {
   const direction = reverse ? -1 : 1;
@@ -295,6 +300,7 @@ function CardFaceLayers({
         height={artworkHeight}
         renderOrder={1}
         paperSeed={paperSeed}
+        depthTest={depthTest}
         depthWrite={depthWrite}
       />
     </Suspense>
@@ -1007,7 +1013,7 @@ export const CardMesh = memo(function CardMesh({
     // them out of the shadow pass prevents another card's shadow from reading
     // as transparency, while the slab still gives placed cards a stable shadow.
     if (slab) {
-      slab.castShadow = card.zone !== "deck" && !flipIsActive;
+      slab.castShadow = !flipIsActive;
     }
 
     const positionXTarget = moving
@@ -1355,7 +1361,7 @@ export const CardMesh = memo(function CardMesh({
         <mesh
           ref={slabRef}
           geometry={slabGeometry}
-          castShadow={card.zone !== "deck"}
+          castShadow
           receiveShadow
           renderOrder={0}
         >
@@ -1363,7 +1369,7 @@ export const CardMesh = memo(function CardMesh({
             color={TAROT_SCENE_PALETTE.cardPaper}
             roughness={0.94}
             paperSeed={paperSeed}
-            depthWrite={card.zone !== "deck"}
+            depthTest={card.zone !== "deck"}
           />
         </mesh>
         {hasRevealed && (
@@ -1373,7 +1379,7 @@ export const CardMesh = memo(function CardMesh({
             cardWidth={cardWidth}
             cardHeight={cardHeight}
             paperSeed={paperSeed}
-            depthWrite={card.zone !== "deck"}
+            depthTest={card.zone !== "deck"}
           />
         )}
         <CardFaceLayers
@@ -1382,7 +1388,7 @@ export const CardMesh = memo(function CardMesh({
           cardWidth={cardWidth}
           cardHeight={cardHeight}
           paperSeed={paperSeed + 0.417}
-          depthWrite={card.zone !== "deck"}
+          depthTest={card.zone !== "deck"}
           reverse
         />
       </group>

--- a/src/components/tarot-studio/CardPaperMaterial.tsx
+++ b/src/components/tarot-studio/CardPaperMaterial.tsx
@@ -15,6 +15,7 @@ type CardPaperMaterialProps = {
   albedoVariation?: number;
   roughnessVariation?: number;
   toneMapped?: boolean;
+  depthTest?: boolean;
   depthWrite?: boolean;
 };
 
@@ -101,6 +102,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   albedoVariation = 0.035,
   roughnessVariation = 0.12,
   toneMapped = true,
+  depthTest = true,
   depthWrite = true,
 }: CardPaperMaterialProps) {
   const material = useMemo(() => {
@@ -109,6 +111,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
       metalness: 0,
       roughness,
       toneMapped,
+      depthTest,
       depthWrite,
       ...(map ? { map } : {}),
     });
@@ -139,6 +142,7 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   }, [
     albedoVariation,
     color,
+    depthTest,
     depthWrite,
     map,
     paperSeed,

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -26,6 +26,7 @@ import type {
   TablePoint,
   TarotSession,
 } from "@/types";
+import { getCardStackOffset } from "@/lib/card-stack-layout";
 import {
   getRemainingDeckCount,
   getTopDeckCard,
@@ -51,25 +52,12 @@ const TABLE_SURFACE_Z = -0.16;
 const CARD_SURFACE_CLEARANCE = 0.002;
 const DECK_MAT_SURFACE_Z = TABLE_SURFACE_Z + 0.003;
 const TABLE_CARD_CONTACT_GAP = 0.002;
-const DECK_STACK_RENDER_ORDER = 10;
-const DECK_CARD_RENDER_ORDER = 20;
+const DECK_STACK_RENDER_ORDER = 1_000;
+const DECK_CARD_RENDER_ORDER = 2_000;
 const TABLE_CARD_RENDER_ORDER = 100;
 const CARD_RENDER_ORDER_STEP = 10;
 const DRAG_RENDER_ORDER = 10_000;
-const DECK_LAYER_REGISTRATION = [
-  [-0.009, 0.005],
-  [0.006, 0.003],
-  [-0.005, -0.006],
-  [0.009, -0.002],
-  [-0.007, 0.002],
-  [0.004, -0.006],
-  [-0.002, 0.006],
-  [0.007, -0.004],
-  [-0.006, -0.001],
-  [0.003, 0.005],
-  [-0.004, -0.004],
-  [0.005, 0.001],
-] as const;
+const MAX_DECK_VISUAL_LAYERS = 12;
 const CELESTIAL_MARKS = [
   [-0.38, 0.31, 0.018],
   [-0.29, 0.18, 0.011],
@@ -90,6 +78,10 @@ const ASTROLOGICAL_KINDS = [
   "sun",
   "mars",
   "mercury",
+  "jupiter",
+  "saturn",
+  "uranus",
+  "neptune",
 ] as const;
 
 function createRoundedRectangleShape(
@@ -197,34 +189,68 @@ type DriftingAstrologicalMark = {
   speed: number;
   driftX: number;
   driftY: number;
+  opacity: number;
 };
 
 function createDriftingAstrologicalMarks(): DriftingAstrologicalMark[] {
-  const markCount = 4 + Math.floor(Math.random() * 3);
-
-  return Array.from({ length: markCount }, (_, index) => {
+  const createGrid = ({
+    columns,
+    rows,
+    extentX,
+    extentY,
+    minimumScale,
+    scaleVariation,
+  }: {
+    columns: number;
+    rows: number;
+    extentX: number;
+    extentY: number;
+    minimumScale: number;
+    scaleVariation: number;
+  }) => Array.from({ length: columns * rows }, (_, index) => {
     const kind =
       ASTROLOGICAL_KINDS[
         Math.floor(Math.random() * ASTROLOGICAL_KINDS.length)
       ];
-    const angle =
-      (index / markCount) * Math.PI * 2 +
-      (Math.random() - 0.5) * 0.68;
-    const radiusX = 0.32 + Math.random() * 0.1;
-    const radiusY = 0.27 + Math.random() * 0.1;
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const normalizedX =
+      (column + 0.5 + (Math.random() - 0.5) * 0.62) / columns;
+    const normalizedY =
+      (row + 0.5 + (Math.random() - 0.5) * 0.62) / rows;
 
     return {
       kind,
-      x: Math.cos(angle) * radiusX,
-      y: Math.sin(angle) * radiusY,
-      scale: 0.18 + Math.random() * 0.09,
-      rotation: (Math.random() - 0.5) * 0.5,
+      x: (normalizedX - 0.5) * 2 * extentX,
+      y: (normalizedY - 0.5) * 2 * extentY,
+      scale: minimumScale + Math.random() * scaleVariation,
+      rotation: (Math.random() - 0.5) * 0.72,
       phase: Math.random() * Math.PI * 2,
-      speed: 0.045 + Math.random() * 0.035,
-      driftX: 0.025 + Math.random() * 0.035,
-      driftY: 0.02 + Math.random() * 0.03,
+      speed: 0.035 + Math.random() * 0.04,
+      driftX: 0.004 + Math.random() * 0.007,
+      driftY: 0.004 + Math.random() * 0.007,
+      opacity: 0.1 + Math.random() * 0.08,
     };
   });
+
+  return [
+    ...createGrid({
+      columns: 5,
+      rows: 4,
+      extentX: 0.14,
+      extentY: 0.14,
+      minimumScale: 0.16,
+      scaleVariation: 0.08,
+    }),
+    ...createGrid({
+      columns: 7,
+      rows: 4,
+      extentX: 0.47,
+      extentY: 0.46,
+      minimumScale: 0.18,
+      scaleVariation: 0.12,
+    }),
+  ];
 }
 
 function AstrologicalMark({
@@ -232,12 +258,14 @@ function AstrologicalMark({
   position,
   rotation,
   scale,
+  opacity,
   markRef,
 }: {
   kind: AstrologicalMarkKind;
   position: [number, number, number];
   rotation: number;
   scale: number;
+  opacity: number;
   markRef?: RefCallback<Group>;
 }) {
   const paths = useMemo(() => {
@@ -274,6 +302,73 @@ function AstrologicalMark({
             [number, number, number]
           >,
         ];
+      case "jupiter":
+        return [
+          [
+            [-0.82, 0.55, 0],
+            [-0.12, 0.55, 0],
+            [0.42, 1.08, 0],
+          ] as Array<[number, number, number]>,
+          [
+            [0.12, 1.02, 0],
+            [-0.5, 0.12, 0],
+            [0.38, -0.18, 0],
+            [0.38, -1.08, 0],
+          ] as Array<[number, number, number]>,
+          [[-0.14, -0.58, 0], [0.82, -0.58, 0]] as Array<
+            [number, number, number]
+          >,
+        ];
+      case "saturn":
+        return [
+          [
+            [-0.38, 1.1, 0],
+            [-0.38, -0.18, 0],
+            [0.18, -0.72, 0],
+            [0.62, -0.38, 0],
+          ] as Array<[number, number, number]>,
+          [[-0.86, 0.55, 0], [0.28, 0.55, 0]] as Array<
+            [number, number, number]
+          >,
+          createArcPoints(0.58, -Math.PI * 0.58, Math.PI * 0.38, 0.08),
+        ];
+      case "uranus":
+        return [
+          circle,
+          [[0, 1.2, 0], [0, -1.2, 0]] as Array<[number, number, number]>,
+          [
+            [-0.95, 0.72, 0],
+            [-0.48, 0.72, 0],
+            [-0.48, -0.72, 0],
+            [-0.95, -0.72, 0],
+          ] as Array<[number, number, number]>,
+          [
+            [0.95, 0.72, 0],
+            [0.48, 0.72, 0],
+            [0.48, -0.72, 0],
+            [0.95, -0.72, 0],
+          ] as Array<[number, number, number]>,
+        ];
+      case "neptune":
+        return [
+          [[0, 1.15, 0], [0, -1.18, 0]] as Array<[number, number, number]>,
+          [
+            [-0.88, 0.84, 0],
+            [-0.88, 0.28, 0],
+            [0, -0.12, 0],
+            [0.88, 0.28, 0],
+            [0.88, 0.84, 0],
+          ] as Array<[number, number, number]>,
+          [[-1.12, 0.64, 0], [-0.88, 0.9, 0], [-0.64, 0.64, 0]] as Array<
+            [number, number, number]
+          >,
+          [[0.64, 0.64, 0], [0.88, 0.9, 0], [1.12, 0.64, 0]] as Array<
+            [number, number, number]
+          >,
+          [[-0.48, -0.78, 0], [0.48, -0.78, 0]] as Array<
+            [number, number, number]
+          >,
+        ];
       case "sun":
       default:
         return [circle, createArcPoints(0.09, 0, Math.PI * 2)];
@@ -294,7 +389,7 @@ function AstrologicalMark({
           color={TAROT_SCENE_PALETTE.celestialGold}
           lineWidth={0.7}
           transparent
-          opacity={0.16}
+          opacity={opacity}
           depthWrite={false}
         />
       ))}
@@ -365,6 +460,7 @@ function DriftingAstrologicalField({
       position={[mark.x * width, mark.y * height, 0.001]}
       rotation={mark.rotation}
       scale={mark.scale}
+      opacity={mark.opacity}
       markRef={(group) => {
         markRefs.current[index] = group;
       }}
@@ -476,7 +572,7 @@ function getDeckMetrics(count: number) {
   const layerCount =
     count > 0
       ? Math.min(
-          DECK_LAYER_REGISTRATION.length,
+          MAX_DECK_VISUAL_LAYERS,
           Math.max(1, Math.ceil(count / 7))
         )
       : 0;
@@ -502,18 +598,15 @@ function getDeckMetrics(count: number) {
 function getDeckLayerOffset(
   index: number,
   layerCount: number,
-  width: number,
-  height: number
+  layout: SceneTableLayout
 ): TablePoint {
-  const registration =
-    DECK_LAYER_REGISTRATION[index % DECK_LAYER_REGISTRATION.length];
-  const depth =
-    layerCount <= 1 ? 0 : (layerCount - 1 - index) / (layerCount - 1);
+  const visualCount = layerCount + 1;
+  const [layerX, layerY] = getCardStackOffset(index, visualCount);
+  const [topX, topY] = getCardStackOffset(layerCount, visualCount);
+  const origin = layout.toWorld([0, 0]);
+  const layer = layout.toWorld([layerX - topX, layerY - topY]);
 
-  return [
-    (-depth * 0.014 + registration[0] * depth * 0.32) * width,
-    (-depth * 0.01 + registration[1] * depth * 0.32) * height,
-  ];
+  return [layer[0] - origin[0], layer[1] - origin[1]];
 }
 
 function DeckMat({ width, height }: { width: number; height: number }) {
@@ -584,6 +677,7 @@ function DeckStack({
   count,
   showMat,
   position,
+  layout,
   width,
   height,
   backUrl,
@@ -594,6 +688,7 @@ function DeckStack({
   count: number;
   showMat: boolean;
   position: TablePoint;
+  layout: SceneTableLayout;
   width: number;
   height: number;
   backUrl: string;
@@ -668,8 +763,7 @@ function DeckStack({
     ? getDeckLayerOffset(
         metrics.layerCount - 1,
         metrics.layerCount,
-        width,
-        height
+        layout
       )
     : [0, 0];
 
@@ -680,8 +774,7 @@ function DeckStack({
         const [offsetX, offsetY] = getDeckLayerOffset(
           index,
           metrics.layerCount,
-          width,
-          height
+          layout
         );
 
         return (
@@ -696,7 +789,7 @@ function DeckStack({
               metrics.firstCenter + index * metrics.layerStep,
             ]}
             renderOrder={index}
-            castShadow={false}
+            castShadow
             receiveShadow
           >
             <CardPaperMaterial
@@ -707,7 +800,7 @@ function DeckStack({
               }
               roughness={index % 2 ? 0.88 : 0.84}
               paperSeed={getPaperSeed(`${backUrl}:${index}`)}
-              depthWrite={false}
+              depthTest={false}
             />
           </RoundedBox>
         );
@@ -724,7 +817,7 @@ function DeckStack({
             height={height - frameInset}
             renderOrder={metrics.layerCount + 1}
             paperSeed={getPaperSeed(`${backUrl}:passive`)}
-            depthWrite={false}
+            depthTest={false}
           />
         </Suspense>
       )}
@@ -837,8 +930,8 @@ function TableSurface({
           </mesh>
         ))}
         <DriftingAstrologicalField
-          width={width}
-          height={height}
+          width={visibleWidth}
+          height={visibleHeight}
           reducedMotion={reducedMotion}
         />
       </group>
@@ -868,8 +961,6 @@ function TarotTable({
   const deckPreviewPositionRef = useRef<TablePoint | null>(null);
   const baseViewportWidth = size.width / BASE_CAMERA_ZOOM;
   const baseViewportHeight = size.height / BASE_CAMERA_ZOOM;
-  const shadowHalfWidth = (baseViewportWidth / MIN_VIEW_ZOOM) * 0.55;
-  const shadowHalfHeight = (baseViewportHeight / MIN_VIEW_ZOOM) * 0.55;
   const layout = useMemo(
     () =>
       createSceneTableLayout({
@@ -968,28 +1059,27 @@ function TarotTable({
         viewportBounds={layout.viewportBounds}
         targetZoom={viewZoom}
       />
-      <ambientLight intensity={0.48} />
-      <directionalLight
+      <ambientLight intensity={0.44} />
+      <pointLight
         castShadow
-        position={[-3, 4.5, 12]}
-        intensity={2.45}
+        position={[0, 0, 7.5]}
+        intensity={86}
+        distance={24}
+        decay={2}
         color={TAROT_SCENE_PALETTE.keyLight}
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
         shadow-bias={-0.00035}
         shadow-radius={8}
         shadow-normalBias={0.001}
-        shadow-camera-left={-shadowHalfWidth}
-        shadow-camera-right={shadowHalfWidth}
-        shadow-camera-top={shadowHalfHeight}
-        shadow-camera-bottom={-shadowHalfHeight}
-        shadow-camera-near={0.1}
-        shadow-camera-far={24}
+        shadow-camera-near={0.2}
+        shadow-camera-far={18}
       />
       <pointLight
-        position={[4, -2, 5]}
-        intensity={4.2}
-        distance={14}
+        position={[0, 0, 4.5]}
+        intensity={8}
+        distance={16}
+        decay={2}
         color={TAROT_SCENE_PALETTE.fillLight}
       />
       <TableSurface
@@ -1003,6 +1093,7 @@ function TarotTable({
         count={Math.max(0, deckCount - 1)}
         showMat={deckCount > 0}
         position={deckPosition}
+        layout={layout}
         width={layout.cardWidth}
         height={layout.cardHeight}
         backUrl={cardSet.back.preview}
@@ -1070,7 +1161,7 @@ export const TarotScene = memo(function TarotScene(props: TarotSceneProps) {
       className="tarot-canvas"
       orthographic
       shadows="soft"
-      dpr={[1, 1.5]}
+      dpr={[0.5, 1.5]}
       frameloop="demand"
       camera={{
         position: [0, 0, 10],

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -36,9 +36,11 @@ import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
 import { getTableCardRestingHeights } from "./card-stacking";
 import {
   createSceneTableLayout,
+  clampViewPan,
   DECK_MAT_HEIGHT_PADDING,
   DECK_MAT_WIDTH_PADDING,
   MIN_VIEW_ZOOM,
+  TABLE_SURFACE_OVERSCAN,
   type SceneBounds,
   type SceneTableLayout,
 } from "./table-layout";
@@ -434,20 +436,38 @@ function AnimatedCameraZoom({
   return null;
 }
 
-function CameraPan({ value }: { value?: TablePoint }) {
+function CameraPan({
+  value,
+  viewportBounds,
+  targetZoom,
+}: {
+  value?: TablePoint;
+  viewportBounds: SceneBounds;
+  targetZoom: number;
+}) {
   const camera = useThree((state) => state.camera) as OrthographicCamera;
   const invalidate = useThree((state) => state.invalidate);
-  const [x, y] = value ?? [0, 0];
 
   useEffect(() => {
+    invalidate();
+  }, [invalidate, targetZoom, value, viewportBounds]);
+
+  useFrame(() => {
+    const currentZoom = camera.zoom / BASE_CAMERA_ZOOM;
+    const safeZoom = Math.min(targetZoom, currentZoom);
+    const [x, y] = clampViewPan(
+      value ?? [0, 0],
+      viewportBounds,
+      safeZoom
+    );
+
     if (camera.position.x === x && camera.position.y === y) {
       return;
     }
 
     camera.position.set(x, y, camera.position.z);
     camera.updateMatrixWorld();
-    invalidate();
-  }, [camera, invalidate, x, y]);
+  });
 
   return null;
 }
@@ -725,8 +745,10 @@ function TableSurface({
   reducedMotion: boolean;
   onSelect: (cardId: string | null) => void;
 }) {
-  const visibleWidth = (width / MIN_VIEW_ZOOM) * 1.04;
-  const visibleHeight = (height / MIN_VIEW_ZOOM) * 1.04;
+  const visibleWidth =
+    (width / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN;
+  const visibleHeight =
+    (height / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN;
   const celestialRadius = Math.min(visibleWidth, visibleHeight) * 0.19;
   const dragOutline = useMemo(
     () => createRoundedRectanglePoints(dragBounds, 0.5, 10),
@@ -828,6 +850,8 @@ function TarotTable({
   cardSet,
   session,
   reducedMotion,
+  viewZoom,
+  viewPan,
   deckMoveMode,
   onSelect,
   onDraw,
@@ -939,6 +963,11 @@ function TarotTable({
 
   return (
     <>
+      <CameraPan
+        value={viewPan}
+        viewportBounds={layout.viewportBounds}
+        targetZoom={viewZoom}
+      />
       <ambientLight intensity={0.48} />
       <directionalLight
         castShadow
@@ -1059,7 +1088,6 @@ export const TarotScene = memo(function TarotScene(props: TarotSceneProps) {
         value={props.viewZoom}
         reducedMotion={props.reducedMotion}
       />
-      <CameraPan value={props.viewPan} />
       <TarotTable {...props} />
     </Canvas>
   );

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -2038,12 +2038,6 @@ export function TarotStudio() {
                           {selectedReading.traditionNote}
                         </p>
                       )}
-                      {selectedReading.perspective && (
-                        <div className="tarot-card-perspective">
-                          <span>{selectedReading.perspective.label}</span>
-                          <p>{selectedReading.perspective.text}</p>
-                        </div>
-                      )}
                       <div className="tarot-card-sources">
                         <span>{messages.sources}</span>
                         <ul>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/lib/tarot-workspace";
 import type { CardLayerDirection, TableLayout, TablePoint } from "@/types";
 import {
+  clampViewPan,
   MAX_VIEW_ZOOM,
   MIN_VIEW_ZOOM,
   type SceneTableLayout,
@@ -439,6 +440,7 @@ export function TarotStudio() {
   const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
+  const viewZoomRef = useRef(1);
   const activeArrangementRef = useRef<ActiveAutomaticArrangement | null>(null);
   const spacePressedRef = useRef(false);
   const panGestureRef = useRef<{
@@ -484,6 +486,28 @@ export function TarotStudio() {
   );
   const [isReadingLoading, setIsReadingLoading] = useState(false);
   const [locale, setLocale] = useState<AppLocale>("en");
+
+  useEffect(() => {
+    viewZoomRef.current = viewZoom;
+    const layout = sceneLayoutRef.current;
+
+    if (!layout) {
+      return;
+    }
+
+    setViewPan((current) => {
+      const next = clampViewPan(
+        current,
+        layout.viewportBounds,
+        viewZoom
+      );
+
+      return next[0] === current[0] && next[1] === current[1]
+        ? current
+        : next;
+    });
+  }, [viewZoom]);
+
   const messages = getMessages(locale);
   const activeCardSet = useMemo(
     () => getCardSet(activeCardSetId),
@@ -793,6 +817,17 @@ export function TarotStudio() {
   const handleLayoutChange = useCallback((layout: SceneTableLayout) => {
     sceneLayoutRef.current = layout;
     setIsSceneLayoutReady(true);
+    setViewPan((current) => {
+      const next = clampViewPan(
+        current,
+        layout.viewportBounds,
+        viewZoomRef.current
+      );
+
+      return next[0] === current[0] && next[1] === current[1]
+        ? current
+        : next;
+    });
 
     const arrangement = activeArrangementRef.current;
 
@@ -1161,10 +1196,16 @@ export function TarotStudio() {
       const deltaX = event.clientX - gesture.startX;
       const deltaY = event.clientY - gesture.startY;
 
-      setViewPan([
-        gesture.startPan[0] - deltaX * unitsPerPixel,
-        gesture.startPan[1] + deltaY * unitsPerPixel,
-      ]);
+      setViewPan(
+        clampViewPan(
+          [
+            gesture.startPan[0] - deltaX * unitsPerPixel,
+            gesture.startPan[1] + deltaY * unitsPerPixel,
+          ],
+          layout.viewportBounds,
+          viewZoom
+        )
+      );
     },
     [viewZoom]
   );

--- a/src/components/tarot-studio/table-layout.ts
+++ b/src/components/tarot-studio/table-layout.ts
@@ -3,6 +3,7 @@ import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 
 export const MIN_VIEW_ZOOM = 0.3;
 export const MAX_VIEW_ZOOM = 1.35;
+export const TABLE_SURFACE_OVERSCAN = 1.04;
 export const DECK_MAT_WIDTH_PADDING = 0.58;
 export const DECK_MAT_HEIGHT_PADDING = 0.64;
 const CARD_SCALE_AT_100_PERCENT = 0.8;
@@ -48,6 +49,49 @@ export type DeckPositionCandidate = {
   position: TablePoint;
   worldPosition: [number, number];
 };
+
+export function getViewPanBounds(
+  viewportBounds: SceneBounds,
+  viewZoom: number
+): SceneBounds {
+  const zoom = clamp(
+    Number.isFinite(viewZoom) ? viewZoom : 1,
+    MIN_VIEW_ZOOM,
+    MAX_VIEW_ZOOM
+  );
+  const viewportWidth = viewportBounds.right - viewportBounds.left;
+  const viewportHeight = viewportBounds.top - viewportBounds.bottom;
+  const surfaceHalfWidth =
+    (viewportWidth / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN * 0.5;
+  const surfaceHalfHeight =
+    (viewportHeight / MIN_VIEW_ZOOM) * TABLE_SURFACE_OVERSCAN * 0.5;
+  const visibleHalfWidth = viewportWidth / zoom / 2;
+  const visibleHalfHeight = viewportHeight / zoom / 2;
+  const maximumX = Math.max(0, surfaceHalfWidth - visibleHalfWidth);
+  const maximumY = Math.max(0, surfaceHalfHeight - visibleHalfHeight);
+
+  return {
+    left: -maximumX,
+    right: maximumX,
+    top: maximumY,
+    bottom: -maximumY,
+  };
+}
+
+export function clampViewPan(
+  pan: TablePoint,
+  viewportBounds: SceneBounds,
+  viewZoom: number
+): TablePoint {
+  const bounds = getViewPanBounds(viewportBounds, viewZoom);
+  const x = Number.isFinite(pan[0]) ? pan[0] : 0;
+  const y = Number.isFinite(pan[1]) ? pan[1] : 0;
+
+  return [
+    clamp(x, bounds.left, bounds.right),
+    clamp(y, bounds.bottom, bounds.top),
+  ];
+}
 
 export function createSceneTableLayout({
   viewportWidth,

--- a/src/data/card-readings.ts
+++ b/src/data/card-readings.ts
@@ -13,10 +13,6 @@ export type CardReading = {
     locator?: string;
   }>;
   traditionNote?: string;
-  perspective?: {
-    label: string;
-    text: string;
-  };
 };
 
 const WAITE_SOURCE = {
@@ -29,12 +25,6 @@ const BOOK_T_SOURCE = {
   label: "Golden Dawn attributions · The Equinox",
   href: "https://www.100thmonkeypress.com/biblio/acrowley/books/equinox_1_8_1912/equinox_1_8_1912.htm",
   locator: "Vol. I, No. VIII, 1912",
-} as const;
-
-const POLLACK_SOURCE = {
-  label: "Rachel Pollack · Seventy-Eight Degrees of Wisdom",
-  href: "https://redwheelweiser.com/book/seventy-eight-degrees-of-wisdom-9781578636655/",
-  locator: "Publisher overview; picture-led psychological tarot method",
 } as const;
 
 const DODAL_SOURCE = {
@@ -746,19 +736,9 @@ function getMajorReading(
         { label: "Astrology", value: reading.goldenDawn },
         { label: "Hebrew path", value: reading.hebrew },
       ],
-      sources: [WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE],
+      sources: [WAITE_SOURCE, BOOK_T_SOURCE],
       traditionNote:
         "The image note follows Waite’s companion text; astrology and Hebrew letters are labeled Golden Dawn correspondences.",
-      perspective:
-        majorKey === "fool"
-          ? {
-              label: "Rachel Pollack lens",
-              text: "A picture-led psychological reading can meet the Fool as the self at the threshold: open to experience, not yet fixed, and invited to discover itself through the journey. This is an original synopsis, not a quotation.",
-            }
-          : {
-              label: "Rachel Pollack lens",
-              text: "A picture-led psychological reading asks what in this scene is becoming conscious. Use the card as a prompt for self-discovery rather than a fixed prediction; this is a general methodology note, not a card-by-card paraphrase.",
-            },
     };
   }
 
@@ -802,13 +782,9 @@ function getMinorReading(
         { label: "Number or role", value: rankReading.correspondence },
         { label: "Esoteric theme", value: theme },
       ],
-      sources: [WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE],
+      sources: [WAITE_SOURCE, BOOK_T_SOURCE],
       traditionNote:
         "Smith’s image and Waite’s companion text ground the card; the elemental and number synthesis is presented as an editorial esoteric reading framework.",
-      perspective: {
-        label: "Rachel Pollack lens",
-        text: "A picture-led psychological reading asks what in this scene is becoming conscious. Use the card as a prompt for self-discovery rather than a fixed prediction; this is a general methodology note, not a card-by-card paraphrase.",
-      },
     };
   }
 
@@ -840,8 +816,6 @@ function getLenormandReading(definition: CardDefinition): CardReading | undefine
       { label: "System", value: `Petit Lenormand · Card ${definition.order + 1}` },
     ],
     sources: [STRALSUND_SOURCE, GAME_OF_HOPE_SOURCE],
-    traditionNote:
-      "The linked deck and museum sources establish the image, number, inset, and history. Per-card themes are a concise editorial reading, not a canonical text from the 1890 deck.",
   };
 }
 
@@ -967,10 +941,6 @@ const PORTUGUESE_SOURCE_METADATA: Record<
     label: "Atribuições da Golden Dawn · The Equinox",
     locator: "Vol. I, n.º VIII, 1912",
   },
-  [POLLACK_SOURCE.href]: {
-    label: "Rachel Pollack · Seventy-Eight Degrees of Wisdom",
-    locator: "Página da editora; método pictórico e psicológico",
-  },
   [DODAL_SOURCE.href]: {
     label: "Tarô de Jean Dodal · Biblioteca Nacional da França",
     locator: "Lyon, c. 1701–1715",
@@ -1040,20 +1010,6 @@ function localizeAstrology(value: string): string {
   return [names[name] ?? name, ...symbol].join(" ");
 }
 
-function getPortuguesePollackPerspective(majorKey?: MajorKey): NonNullable<CardReading["perspective"]> {
-  if (majorKey === "fool") {
-    return {
-      label: "Perspectiva de Rachel Pollack",
-      text: "Uma leitura psicológica orientada pela imagem pode encontrar o Louco como o eu no limiar: aberto à experiência, ainda não fixado e convidado a se descobrir pela jornada. Esta é uma síntese original, não uma citação.",
-    };
-  }
-
-  return {
-    label: "Perspectiva de Rachel Pollack",
-    text: "Uma leitura psicológica orientada pela imagem pergunta o que está se tornando consciente na cena. Use a carta como convite à autodescoberta, não como previsão fixa; esta é uma nota metodológica geral, não uma paráfrase carta a carta.",
-  };
-}
-
 function getPortugueseMajorReading(
   cardSetId: "rider-waite-smith" | "tarot-de-marseille",
   definition: CardDefinition
@@ -1078,10 +1034,9 @@ function getPortugueseMajorReading(
         { label: "Astrologia", value: localizeAstrology(reading.goldenDawn) },
         { label: "Caminho hebraico", value: reading.hebrew },
       ],
-      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE]),
+      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE]),
       traditionNote:
         "A imagem é contextualizada pelo texto de Waite; astrologia e letras hebraicas são correspondências identificadas como Golden Dawn.",
-      perspective: getPortuguesePollackPerspective(majorKey),
     };
   }
 
@@ -1130,10 +1085,9 @@ function getPortugueseMinorReading(
         { label: "Número ou figura", value: rankReading.correspondence },
         { label: "Domínio do naipe", value: suitReading.domain },
       ],
-      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE, POLLACK_SOURCE]),
+      sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE]),
       traditionNote:
         "A imagem de Smith e o texto de Waite fundamentam a carta; a síntese elemental e numérica é apresentada como uma estrutura editorial de leitura esotérica.",
-      perspective: getPortuguesePollackPerspective(),
     };
   }
 
@@ -1195,8 +1149,6 @@ function getPortugueseLenormandReading(
       { label: "Sistema", value: `Petit Lenormand · Carta ${definition.order + 1}` },
     ],
     sources: localizeSources([STRALSUND_SOURCE, GAME_OF_HOPE_SOURCE]),
-    traditionNote:
-      "As fontes do baralho e do museu estabelecem imagem, número, inserto e história. Os temas carta a carta são uma leitura editorial concisa, não um texto canônico do baralho de 1890.",
   };
 }
 

--- a/src/lib/card-stack-layout.ts
+++ b/src/lib/card-stack-layout.ts
@@ -1,0 +1,14 @@
+import type { TablePoint } from "@/types";
+
+export function getCardStackOffset(
+  index: number,
+  count: number
+): TablePoint {
+  const finalIndex = Math.max(0, count - 1);
+  const safeIndex = Math.min(finalIndex, Math.max(0, index));
+  const intervals = Math.max(1, finalIndex);
+  const horizontalStep = Math.min(0.008, 0.08 / intervals);
+  const verticalStep = Math.min(0.01, 0.1 / intervals);
+
+  return [safeIndex * horizontalStep, safeIndex * verticalStep];
+}

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/types";
 import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
 import type { CardSpread } from "@/lib/tarot-spreads";
+import { getCardStackOffset } from "@/lib/card-stack-layout";
 
 const HISTORY_LIMIT = 24;
 
@@ -149,16 +150,14 @@ export function createLayout(
       : cards;
 
   if (layout === "stack") {
-    const stackIntervals = Math.max(1, orderedCards.length - 1);
-    const horizontalStep = Math.min(0.008, 0.08 / stackIntervals);
-    const verticalStep = Math.min(0.01, 0.1 / stackIntervals);
-
     orderedCards.forEach((card, index) => {
+      const [offsetX, offsetY] = getCardStackOffset(
+        index,
+        orderedCards.length
+      );
+
       placements.set(card.id, {
-        position: [
-          0.3 + index * horizontalStep,
-          index * verticalStep,
-        ],
+        position: [0.3 + offsetX, offsetY],
         rotation: alignedRotation(card),
         zIndex: index + 1,
       });


### PR DESCRIPTION
Selected-card readings no longer include the Rachel Pollack methodology panel or source in English or Brazilian Portuguese. Rider–Waite–Smith readings retain their Waite and Golden Dawn provenance, and Lenormand retains its deck and museum sources without the defensive editorial disclaimer.

Zoom and space-drag navigation now share bounds derived from the visible table surface. Pan is re-constrained after zoom changes, responsive layout changes, and throughout camera animation, so the transparent canvas cannot expose the page background at any supported viewport or zoom level.

The deck now uses the same stepped geometry as Arrange > Stack, stays visually above resting table cards, and casts a real shadow from a centered point light. A larger randomized field of nine planetary and astrological glyphs drifts subtly across the full table, with reduced-motion behavior preserved. Low-density displays also use their native canvas density instead of allocating an oversized WebGL buffer.

Depends on: https://github.com/vtrpldn/tarot/pull/9

## Why

The cards and deck should read as one tactile scene: clear source-backed meanings, a continuous navigable table, richer celestial atmosphere, and depth cues that behave consistently wherever the cards land.
