### PR TITLE
Refine table atmosphere and deck depth

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,54 @@ button {
   transform: rotate(-7deg);
 }
 
+.tarot-app[data-scene-theme="solar-temple"] {
+  background:
+    radial-gradient(circle at 14% 74%, rgba(226, 151, 70, 0.18), transparent 28rem),
+    radial-gradient(circle at 86% 16%, rgba(186, 72, 53, 0.2), transparent 25rem),
+    radial-gradient(circle at 56% 48%, rgba(125, 39, 39, 0.18), transparent 34rem),
+    linear-gradient(135deg, #1a090b 0%, #48201d 47%, #210c0d 100%);
+}
+
+.tarot-app[data-scene-theme="solar-temple"]::before {
+  opacity: 0.4;
+  background-image:
+    radial-gradient(circle at 18% 28%, rgba(255, 224, 163, 0.76) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 72% 16%, rgba(238, 151, 94, 0.62) 0 1px, transparent 1.6px),
+    radial-gradient(circle at 44% 76%, rgba(255, 205, 118, 0.5) 0 0.8px, transparent 1.4px),
+    radial-gradient(circle at 88% 64%, rgba(227, 124, 86, 0.44) 0 0.8px, transparent 1.4px);
+}
+
+.tarot-app[data-scene-theme="solar-temple"]::after {
+  border-color: rgba(255, 207, 129, 0.055);
+  box-shadow:
+    0 0 8rem rgba(185, 72, 49, 0.14),
+    inset 0 0 7rem rgba(255, 208, 127, 0.04);
+}
+
+.tarot-app[data-scene-theme="moonlit-grove"] {
+  background:
+    radial-gradient(circle at 16% 77%, rgba(102, 163, 132, 0.14), transparent 29rem),
+    radial-gradient(circle at 84% 16%, rgba(103, 153, 175, 0.14), transparent 25rem),
+    radial-gradient(circle at 57% 45%, rgba(42, 102, 89, 0.18), transparent 35rem),
+    linear-gradient(135deg, #071212 0%, #153631 47%, #0a1918 100%);
+}
+
+.tarot-app[data-scene-theme="moonlit-grove"]::before {
+  opacity: 0.42;
+  background-image:
+    radial-gradient(circle at 18% 28%, rgba(210, 239, 214, 0.7) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 72% 16%, rgba(154, 211, 205, 0.58) 0 1px, transparent 1.6px),
+    radial-gradient(circle at 44% 76%, rgba(175, 223, 181, 0.48) 0 0.8px, transparent 1.4px),
+    radial-gradient(circle at 88% 64%, rgba(120, 185, 178, 0.42) 0 0.8px, transparent 1.4px);
+}
+
+.tarot-app[data-scene-theme="moonlit-grove"]::after {
+  border-color: rgba(172, 219, 190, 0.05);
+  box-shadow:
+    0 0 8rem rgba(70, 138, 119, 0.12),
+    inset 0 0 7rem rgba(188, 230, 201, 0.035);
+}
+
 @keyframes tarot-constellation-drift {
   from {
     transform: translate3d(-0.3rem, 0.15rem, 0) rotate(-0.15deg);
@@ -743,6 +791,7 @@ button {
 .tarot-deck-menu,
 .tarot-zoom-menu,
 .tarot-card-menu,
+.tarot-config-menu,
 .tarot-language-menu,
 .tarot-spread-menu,
 .tarot-arrange-menu {
@@ -813,6 +862,202 @@ button {
 
 .tarot-sound-toggle[aria-pressed="false"] {
   color: var(--faint-ink);
+}
+
+.tarot-config-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.58rem);
+  z-index: 4;
+  display: grid;
+  gap: 0.7rem;
+  width: min(20rem, calc(100vw - 2rem));
+  max-height: min(34rem, calc(100dvh - 7rem));
+  padding: 0.76rem 0.8rem 0.8rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--panel-edge);
+  border-radius: 0.82rem;
+  background: rgba(20, 11, 29, 0.98);
+  box-shadow: 0 0.9rem 2.8rem rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
+  animation: tarot-popover-enter 150ms ease-out both;
+}
+
+.tarot-config-heading,
+.tarot-config-section-title {
+  margin: 0;
+  color: var(--faint-ink);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.13em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.tarot-config-section {
+  display: grid;
+  gap: 0.44rem;
+}
+
+.tarot-config-section + .tarot-config-section {
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(234, 212, 155, 0.14);
+}
+
+.tarot-config-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.32rem;
+}
+
+.tarot-config-choice,
+.tarot-config-popover [role="radio"] {
+  display: grid;
+  gap: 0.2rem;
+  min-height: 4.55rem;
+  padding: 0.5rem 0.44rem;
+  border: 1px solid rgba(247, 239, 217, 0.15);
+  border-radius: 0.52rem;
+  background: rgba(48, 28, 59, 0.58);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease,
+    color 160ms ease, transform 160ms ease;
+}
+
+.tarot-config-choice::before,
+.tarot-config-popover [role="radio"]::before {
+  content: "";
+  display: block;
+  width: 1.1rem;
+  height: 0.24rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #c9a563, #8f6ba3);
+  box-shadow: 0 0 0.65rem rgba(234, 212, 155, 0.2);
+}
+
+.tarot-config-choice[data-scene-theme="solar-temple"]::before,
+.tarot-config-popover [role="radio"][data-scene-theme="solar-temple"]::before {
+  background: linear-gradient(90deg, #e5b15a, #9a4036);
+}
+
+.tarot-config-choice[data-scene-theme="moonlit-grove"]::before,
+.tarot-config-popover [role="radio"][data-scene-theme="moonlit-grove"]::before {
+  background: linear-gradient(90deg, #c5e3c9, #4a8f82);
+}
+
+.tarot-config-choice:hover,
+.tarot-config-choice[aria-checked="true"],
+.tarot-config-popover [role="radio"]:hover,
+.tarot-config-popover [role="radio"][aria-checked="true"] {
+  border-color: rgba(234, 212, 155, 0.58);
+  background: var(--control-hover);
+  color: #fff9e8;
+}
+
+.tarot-config-choice:hover,
+.tarot-config-popover [role="radio"]:hover {
+  transform: translateY(-1px);
+}
+
+.tarot-config-choice span,
+.tarot-config-popover [role="radio"] span {
+  align-self: end;
+  font-size: 0.72rem;
+  line-height: 1.08;
+}
+
+.tarot-config-sound {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  width: 100%;
+  min-height: 3.25rem;
+  padding: 0.54rem 0.62rem;
+  border: 1px solid rgba(247, 239, 217, 0.16);
+  border-radius: 0.52rem;
+  background: rgba(48, 28, 59, 0.58);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease,
+    color 160ms ease;
+}
+
+.tarot-config-sound:hover,
+.tarot-config-sound[aria-checked="true"],
+.tarot-config-sound[aria-pressed="true"] {
+  border-color: rgba(234, 212, 155, 0.48);
+  background: var(--control-hover);
+  color: #fff9e8;
+}
+
+.tarot-config-sound > span {
+  display: grid;
+  gap: 0.14rem;
+}
+
+.tarot-config-sound small {
+  color: var(--faint-ink);
+  font-family: var(--font-mono);
+  font-size: 0.59rem;
+  letter-spacing: 0.045em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.tarot-config-sound::after {
+  content: "";
+  width: 2rem;
+  height: 1.14rem;
+  flex: 0 0 auto;
+  border: 1px solid rgba(247, 239, 217, 0.28);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 0.54rem 50%, #d8cdb6 0 0.3rem, transparent 0.33rem),
+    rgba(9, 5, 13, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.tarot-config-sound[aria-checked="true"]::after,
+.tarot-config-sound[aria-pressed="true"]::after {
+  border-color: rgba(234, 212, 155, 0.68);
+  background:
+    radial-gradient(circle at calc(100% - 0.54rem) 50%, #fff5d9 0 0.3rem, transparent 0.33rem),
+    linear-gradient(90deg, #896337, #d7b46f);
+}
+
+.tarot-config-range-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem 0.7rem;
+  align-items: center;
+}
+
+.tarot-config-range-row label {
+  color: var(--ink);
+  font-size: 0.8rem;
+}
+
+.tarot-config-range-value {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.07em;
+}
+
+.tarot-config-range {
+  grid-column: 1 / -1;
+  width: 100%;
+  height: 1.3rem;
+  margin: 0;
+  accent-color: var(--accent-bright);
+  cursor: ew-resize;
 }
 
 .tarot-language-popover {
@@ -1000,7 +1245,8 @@ button {
 }
 
 button:focus-visible,
-select:focus-visible {
+select:focus-visible,
+input:focus-visible {
   outline: 2px solid var(--accent-bright);
   outline-offset: 3px;
 }
@@ -1253,6 +1499,28 @@ select:focus-visible {
     width: min(12.4rem, calc(100vw - 1.25rem));
   }
 
+  .tarot-config-popover {
+    right: auto;
+    bottom: calc(100% + 0.42rem);
+    left: 50%;
+    width: min(20rem, calc(100vw - 1.25rem));
+    max-height: calc(100dvh - 7.5rem);
+    padding: 0.68rem 0.72rem 0.74rem;
+    transform: translateX(-50%);
+    animation-name: tarot-arrange-popover-enter;
+  }
+
+  .tarot-config-choice,
+  .tarot-config-popover [role="radio"] {
+    min-height: 4.25rem;
+    padding: 0.42rem 0.38rem;
+  }
+
+  .tarot-config-choice span,
+  .tarot-config-popover [role="radio"] span {
+    font-size: 0.68rem;
+  }
+
   .tarot-toolbar-trigger svg,
   .tarot-reset-trigger svg,
   .tarot-mode-cancel svg {
@@ -1313,6 +1581,17 @@ select:focus-visible {
     bottom: calc(max(0.65rem, var(--safe-bottom)) + 3rem);
     left: 0.625rem;
     width: auto;
+    transform: none;
+    animation-name: tarot-popover-enter;
+  }
+
+  .tarot-config-popover {
+    position: fixed;
+    right: 0.625rem;
+    bottom: calc(max(0.65rem, var(--safe-bottom)) + 3rem);
+    left: 0.625rem;
+    width: auto;
+    max-height: calc(100dvh - 4.6rem);
     transform: none;
     animation-name: tarot-popover-enter;
   }

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -476,6 +476,7 @@ export const CardMesh = memo(function CardMesh({
     useRef<PointerEndFallbackBinding | null>(null);
   const deckPreviewRef = useRef<TablePoint | null>(null);
   const [hasRevealed, setHasRevealed] = useState(card.faceUp);
+  const [hasActiveDrag, setHasActiveDrag] = useState(false);
   const hasPositionedRef = useRef(false);
   const cardIdentityRef = useRef(card.id);
   const invalidate = useThree((state) => state.invalidate);
@@ -802,8 +803,11 @@ export const CardMesh = memo(function CardMesh({
       const nextY = point.y - drag.offset.y;
       const [deltaX, deltaY] = sampleDragVelocity(drag, point, timestamp);
 
-      if (point.distanceTo(drag.origin) > DRAG_THRESHOLD) {
+      if (!drag.moved && point.distanceTo(drag.origin) > DRAG_THRESHOLD) {
         drag.moved = true;
+        if (drag.mode === "move") {
+          setHasActiveDrag(true);
+        }
       }
 
       if (drag.moved && Math.hypot(deltaX, deltaY) > 0.003) {
@@ -919,6 +923,7 @@ export const CardMesh = memo(function CardMesh({
       }
 
       dragRef.current = null;
+      setHasActiveDrag(false);
 
       if (drag.mode === "move-deck") {
         setDeckPreview(null);
@@ -1013,7 +1018,8 @@ export const CardMesh = memo(function CardMesh({
     // them out of the shadow pass prevents another card's shadow from reading
     // as transparency, while the slab still gives placed cards a stable shadow.
     if (slab) {
-      slab.castShadow = !flipIsActive;
+      slab.castShadow =
+        !flipIsActive && (card.zone !== "deck" || hasActiveDrag);
     }
 
     const positionXTarget = moving
@@ -1053,9 +1059,10 @@ export const CardMesh = memo(function CardMesh({
     const nextScale = reducedMotion
       ? scaleTarget
       : MathUtils.damp(group.scale.x, scaleTarget, 17, delta);
-    let flipLift = 0;
+    const isLiftedDrag = drag?.moved && drag.mode === "move";
+    let projectedSurfaceLift = 0;
 
-    if (flipIsActive) {
+    if (flipIsActive || isLiftedDrag) {
       const parentRotation = parentRotationRef.current.set(
         nextTiltX,
         nextTiltY,
@@ -1075,10 +1082,11 @@ export const CardMesh = memo(function CardMesh({
           Math.abs(rotationElements[6]) * (cardHeight / 2) +
           Math.abs(rotationElements[10]) * CARD_VISIBLE_HALF_DEPTH);
 
-      // Keep the lowest visible corner on or above the surface throughout the
-      // turn. A fixed cosmetic lift lets most of a wide card pass through the
-      // table when the card approaches edge-on.
-      flipLift =
+      // Keep the lowest visible corner on or above the surface throughout a
+      // flip or a tilted drag. Without this lift, a fast pointer delta can
+      // tip a card through the table or an overlapping card before depth
+      // testing gets a chance to draw it on top.
+      projectedSurfaceLift =
         Math.max(0, projectedHalfDepth - CARD_VISIBLE_HALF_DEPTH) +
         FLIP_SURFACE_CLEARANCE;
     }
@@ -1087,7 +1095,7 @@ export const CardMesh = memo(function CardMesh({
       drag?.moved && drag.mode !== "move-deck"
         ? draggingZ
         : restingZ + (drag?.mode === "move-deck" ? 0.006 : 0);
-    const zTarget = zBase + flipLift;
+    const zTarget = zBase + projectedSurfaceLift;
 
     if (reducedMotion) {
       group.rotation.x = 0;
@@ -1103,7 +1111,7 @@ export const CardMesh = memo(function CardMesh({
       return;
     }
 
-    const nextZ = flipIsActive
+    const nextZ = flipIsActive || isLiftedDrag
       ? Math.max(
           MathUtils.damp(group.position.z, zTarget, 18, delta),
           zTarget
@@ -1361,7 +1369,7 @@ export const CardMesh = memo(function CardMesh({
         <mesh
           ref={slabRef}
           geometry={slabGeometry}
-          castShadow
+          castShadow={card.zone !== "deck" || hasActiveDrag}
           receiveShadow
           renderOrder={0}
         >
@@ -1369,7 +1377,7 @@ export const CardMesh = memo(function CardMesh({
             color={TAROT_SCENE_PALETTE.cardPaper}
             roughness={0.94}
             paperSeed={paperSeed}
-            depthTest={card.zone !== "deck"}
+            depthTest={card.zone !== "deck" || hasActiveDrag}
           />
         </mesh>
         {hasRevealed && (
@@ -1379,7 +1387,7 @@ export const CardMesh = memo(function CardMesh({
             cardWidth={cardWidth}
             cardHeight={cardHeight}
             paperSeed={paperSeed}
-            depthTest={card.zone !== "deck"}
+            depthTest={card.zone !== "deck" || hasActiveDrag}
           />
         )}
         <CardFaceLayers
@@ -1388,7 +1396,7 @@ export const CardMesh = memo(function CardMesh({
           cardWidth={cardWidth}
           cardHeight={cardHeight}
           paperSeed={paperSeed + 0.417}
-          depthTest={card.zone !== "deck"}
+          depthTest={card.zone !== "deck" || hasActiveDrag}
           reverse
         />
       </group>

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -45,7 +45,13 @@ import {
   type SceneBounds,
   type SceneTableLayout,
 } from "./table-layout";
-import { TAROT_SCENE_PALETTE } from "./theme";
+import {
+  getSceneTheme,
+  MAX_SCENE_LIGHT_INTENSITY,
+  MIN_SCENE_LIGHT_INTENSITY,
+  type ScenePalette,
+  type SceneSettings,
+} from "./theme";
 
 const BASE_CAMERA_ZOOM = 75;
 const TABLE_SURFACE_Z = -0.16;
@@ -58,6 +64,7 @@ const TABLE_CARD_RENDER_ORDER = 100;
 const CARD_RENDER_ORDER_STEP = 10;
 const DRAG_RENDER_ORDER = 10_000;
 const MAX_DECK_VISUAL_LAYERS = 12;
+const MAX_DECK_STACK_HEIGHT = 0.21;
 const CELESTIAL_MARKS = [
   [-0.38, 0.31, 0.018],
   [-0.29, 0.18, 0.011],
@@ -254,6 +261,7 @@ function createDriftingAstrologicalMarks(): DriftingAstrologicalMark[] {
 }
 
 function AstrologicalMark({
+  color,
   kind,
   position,
   rotation,
@@ -261,6 +269,7 @@ function AstrologicalMark({
   opacity,
   markRef,
 }: {
+  color: string;
   kind: AstrologicalMarkKind;
   position: [number, number, number];
   rotation: number;
@@ -386,7 +395,7 @@ function AstrologicalMark({
         <Line
           key={index}
           points={points}
-          color={TAROT_SCENE_PALETTE.celestialGold}
+          color={color}
           lineWidth={0.7}
           transparent
           opacity={opacity}
@@ -398,10 +407,12 @@ function AstrologicalMark({
 }
 
 function DriftingAstrologicalField({
+  color,
   width,
   height,
   reducedMotion,
 }: {
+  color: string;
   width: number;
   height: number;
   reducedMotion: boolean;
@@ -456,6 +467,7 @@ function DriftingAstrologicalField({
   return marks.map((mark, index) => (
     <AstrologicalMark
       key={`${mark.kind}:${index}`}
+      color={color}
       kind={mark.kind}
       position={[mark.x * width, mark.y * height, 0.001]}
       rotation={mark.rotation}
@@ -472,6 +484,7 @@ type TarotSceneProps = {
   cardSet: CardSetDefinition;
   session: TarotSession;
   reducedMotion: boolean;
+  sceneSettings: SceneSettings;
   viewZoom: number;
   /**
    * The camera centre in scene world units. This intentionally stays
@@ -568,20 +581,23 @@ function CameraPan({
   return null;
 }
 
-function getDeckMetrics(count: number) {
-  const layerCount =
-    count > 0
-      ? Math.min(
-          MAX_DECK_VISUAL_LAYERS,
-          Math.max(1, Math.ceil(count / 7))
-        )
+function getDeckMetrics(lowerCardCount: number, deckCapacity: number) {
+  const layerCount = Math.min(
+    MAX_DECK_VISUAL_LAYERS,
+    Math.max(0, lowerCardCount)
+  );
+  const drawableCardCount = Math.max(1, deckCapacity - 1);
+  const stackHeight =
+    layerCount > 0
+      ? (Math.min(lowerCardCount, drawableCardCount) / drawableCardCount) *
+        MAX_DECK_STACK_HEIGHT
       : 0;
-  const layerThickness = 0.018;
-  const layerStep = 0.019;
+  const layerThickness = layerCount ? stackHeight / layerCount : 0;
+  const layerStep = layerThickness;
   const firstCenter =
     DECK_MAT_SURFACE_Z + CARD_SURFACE_CLEARANCE + layerThickness / 2;
   const topSurface = layerCount
-    ? firstCenter + (layerCount - 1) * layerStep + layerThickness / 2
+    ? DECK_MAT_SURFACE_Z + CARD_SURFACE_CLEARANCE + stackHeight
     : DECK_MAT_SURFACE_Z;
 
   return {
@@ -589,6 +605,8 @@ function getDeckMetrics(count: number) {
     layerCount,
     layerStep,
     layerThickness,
+    stackHeight,
+    stackHeightRatio: stackHeight / MAX_DECK_STACK_HEIGHT,
     topSurface,
     topCardCenter:
       topSurface + CARD_THICKNESS / 2 + CARD_SURFACE_CLEARANCE,
@@ -598,18 +616,38 @@ function getDeckMetrics(count: number) {
 function getDeckLayerOffset(
   index: number,
   layerCount: number,
+  stackHeightRatio: number,
   layout: SceneTableLayout
 ): TablePoint {
-  const visualCount = layerCount + 1;
-  const [layerX, layerY] = getCardStackOffset(index, visualCount);
-  const [topX, topY] = getCardStackOffset(layerCount, visualCount);
+  if (layerCount <= 1 || stackHeightRatio <= 0) {
+    return [0, 0];
+  }
+
+  const depth = index / (layerCount - 1);
+  const [topX, topY] = getCardStackOffset(
+    MAX_DECK_VISUAL_LAYERS,
+    MAX_DECK_VISUAL_LAYERS + 1
+  );
   const origin = layout.toWorld([0, 0]);
-  const layer = layout.toWorld([layerX - topX, layerY - topY]);
+  const layer = layout.toWorld([
+    (depth - 1) * topX * stackHeightRatio,
+    (depth - 1) * topY * stackHeightRatio,
+  ]);
 
   return [layer[0] - origin[0], layer[1] - origin[1]];
 }
 
-function DeckMat({ width, height }: { width: number; height: number }) {
+function DeckMat({
+  palette,
+  width,
+  height,
+  position,
+}: {
+  palette: ScenePalette;
+  width: number;
+  height: number;
+  position: TablePoint;
+}) {
   const matWidth = width + DECK_MAT_WIDTH_PADDING;
   const matHeight = height + DECK_MAT_HEIGHT_PADDING;
   const shape = useMemo(
@@ -632,11 +670,11 @@ function DeckMat({ width, height }: { width: number; height: number }) {
   const surfaceZ = DECK_MAT_SURFACE_Z;
 
   return (
-    <group renderOrder={0}>
+    <group position={[position[0], position[1], 0]} renderOrder={0}>
       <mesh position={[0, 0, surfaceZ]} receiveShadow>
         <shapeGeometry args={[shape, 12]} />
         <meshStandardMaterial
-          color={TAROT_SCENE_PALETTE.deckMat}
+          color={palette.deckMat}
           roughness={1}
           metalness={0}
         />
@@ -644,7 +682,7 @@ function DeckMat({ width, height }: { width: number; height: number }) {
       <Line
         points={outline}
         position={[0, 0, surfaceZ + 0.001]}
-        color={TAROT_SCENE_PALETTE.deckMatEdge}
+        color={palette.deckMatEdge}
         lineWidth={0.7}
         transparent
         opacity={0.5}
@@ -653,7 +691,7 @@ function DeckMat({ width, height }: { width: number; height: number }) {
       <group position={[0, -matHeight * 0.43, surfaceZ + 0.0015]}>
         <Line
           points={createArcPoints(0.085, 0, Math.PI * 2)}
-          color={TAROT_SCENE_PALETTE.celestialGold}
+          color={palette.celestialGold}
           lineWidth={0.65}
           transparent
           opacity={0.42}
@@ -662,7 +700,7 @@ function DeckMat({ width, height }: { width: number; height: number }) {
         <mesh>
           <circleGeometry args={[0.018, 12]} />
           <meshBasicMaterial
-            color={TAROT_SCENE_PALETTE.celestialGold}
+            color={palette.celestialGold}
             transparent
             opacity={0.42}
             depthWrite={false}
@@ -675,6 +713,8 @@ function DeckMat({ width, height }: { width: number; height: number }) {
 
 function DeckStack({
   count,
+  deckCapacity,
+  palette,
   showMat,
   position,
   layout,
@@ -686,6 +726,8 @@ function DeckStack({
   previewPositionRef,
 }: {
   count: number;
+  deckCapacity: number;
+  palette: ScenePalette;
   showMat: boolean;
   position: TablePoint;
   layout: SceneTableLayout;
@@ -699,7 +741,7 @@ function DeckStack({
   const groupRef = useRef<Group>(null);
   const hasPositionedRef = useRef(false);
   const invalidate = useThree((state) => state.invalidate);
-  const metrics = getDeckMetrics(count);
+  const metrics = getDeckMetrics(count, deckCapacity);
 
   useLayoutEffect(() => {
     const group = groupRef.current;
@@ -718,7 +760,7 @@ function DeckStack({
     }
 
     invalidate();
-  }, [invalidate, metrics.layerCount, position]);
+  }, [invalidate, metrics.layerCount, metrics.stackHeight, position]);
 
   useFrame((_, delta) => {
     const group = groupRef.current;
@@ -759,23 +801,73 @@ function DeckStack({
   }
 
   const frameInset = Math.min(0.34, width * 0.105);
-  const [topOffsetX, topOffsetY] = metrics.layerCount
-    ? getDeckLayerOffset(
-        metrics.layerCount - 1,
-        metrics.layerCount,
-        layout
-      )
-    : [0, 0];
+  const layerOffsets = Array.from({ length: metrics.layerCount }, (_, index) =>
+    getDeckLayerOffset(
+      index,
+      metrics.layerCount,
+      metrics.stackHeightRatio,
+      layout
+    )
+  );
+  const footprintOffsets = [[0, 0] as TablePoint, ...layerOffsets];
+  const minimumOffsetX = Math.min(
+    ...footprintOffsets.map(([offsetX]) => offsetX)
+  );
+  const maximumOffsetX = Math.max(
+    ...footprintOffsets.map(([offsetX]) => offsetX)
+  );
+  const minimumOffsetY = Math.min(
+    ...footprintOffsets.map(([, offsetY]) => offsetY)
+  );
+  const maximumOffsetY = Math.max(
+    ...footprintOffsets.map(([, offsetY]) => offsetY)
+  );
+  const matPosition: TablePoint = [
+    (minimumOffsetX + maximumOffsetX) / 2,
+    (minimumOffsetY + maximumOffsetY) / 2,
+  ];
+  const matWidth = width + maximumOffsetX - minimumOffsetX;
+  const matHeight = height + maximumOffsetY - minimumOffsetY;
+  const [topOffsetX, topOffsetY] =
+    layerOffsets[metrics.layerCount - 1] ?? [0, 0];
+  const shadowCasterBottom =
+    DECK_MAT_SURFACE_Z + CARD_SURFACE_CLEARANCE;
+  const shadowCasterTop =
+    metrics.topCardCenter + CARD_THICKNESS / 2;
+  const shadowCasterHeight = shadowCasterTop - shadowCasterBottom;
 
   return (
     <group ref={groupRef} renderOrder={DECK_STACK_RENDER_ORDER}>
-      {showMat && <DeckMat width={width} height={height} />}
+      {showMat && (
+        <DeckMat
+          palette={palette}
+          width={matWidth}
+          height={matHeight}
+          position={matPosition}
+        />
+      )}
+      {showMat && (
+        <RoundedBox
+          args={[matWidth, matHeight, shadowCasterHeight]}
+          radius={0.045}
+          smoothness={3}
+          position={[
+            matPosition[0],
+            matPosition[1],
+            shadowCasterBottom + shadowCasterHeight / 2,
+          ]}
+          castShadow
+          receiveShadow={false}
+        >
+          <meshBasicMaterial
+            colorWrite={false}
+            depthTest={false}
+            depthWrite={false}
+          />
+        </RoundedBox>
+      )}
       {Array.from({ length: metrics.layerCount }, (_, index) => {
-        const [offsetX, offsetY] = getDeckLayerOffset(
-          index,
-          metrics.layerCount,
-          layout
-        );
+        const [offsetX, offsetY] = layerOffsets[index];
 
         return (
           <RoundedBox
@@ -789,14 +881,14 @@ function DeckStack({
               metrics.firstCenter + index * metrics.layerStep,
             ]}
             renderOrder={index}
-            castShadow
-            receiveShadow
+            castShadow={false}
+            receiveShadow={false}
           >
             <CardPaperMaterial
               color={
                 index % 2
-                  ? TAROT_SCENE_PALETTE.cardPaper
-                  : TAROT_SCENE_PALETTE.cardPaperShadow
+                  ? palette.cardPaper
+                  : palette.cardPaperShadow
               }
               roughness={index % 2 ? 0.88 : 0.84}
               paperSeed={getPaperSeed(`${backUrl}:${index}`)}
@@ -826,12 +918,14 @@ function DeckStack({
 }
 
 function TableSurface({
+  palette,
   width,
   height,
   dragBounds,
   reducedMotion,
   onSelect,
 }: {
+  palette: ScenePalette;
   width: number;
   height: number;
   dragBounds: SceneBounds;
@@ -857,17 +951,17 @@ function TableSurface({
       >
         <planeGeometry args={[visibleWidth, visibleHeight]} />
         <meshStandardMaterial
-          color={TAROT_SCENE_PALETTE.table}
+          color={palette.table}
           roughness={0.94}
           metalness={0.012}
-          emissive={TAROT_SCENE_PALETTE.tableEmissive}
+          emissive={palette.tableEmissive}
           emissiveIntensity={0.24}
         />
       </mesh>
       <group position={[0, 0, TABLE_SURFACE_Z + 0.002]} renderOrder={1}>
         <Line
           points={dragOutline}
-          color={TAROT_SCENE_PALETTE.dragBoundary}
+          color={palette.dragBoundary}
           lineWidth={0.7}
           transparent
           opacity={0.2}
@@ -885,7 +979,7 @@ function TableSurface({
             ]}
           />
           <meshBasicMaterial
-            color={TAROT_SCENE_PALETTE.celestialGold}
+            color={palette.celestialGold}
             transparent
             opacity={0.11}
             depthWrite={false}
@@ -903,7 +997,7 @@ function TableSurface({
             ]}
           />
           <meshBasicMaterial
-            color={TAROT_SCENE_PALETTE.fillLight}
+            color={palette.fillLight}
             transparent
             opacity={0.085}
             depthWrite={false}
@@ -920,8 +1014,8 @@ function TableSurface({
             <meshBasicMaterial
               color={
                 index % 2
-                  ? TAROT_SCENE_PALETTE.fillLight
-                  : TAROT_SCENE_PALETTE.celestialGold
+                  ? palette.fillLight
+                  : palette.celestialGold
               }
               transparent
               opacity={index % 3 === 0 ? 0.2 : 0.13}
@@ -930,6 +1024,7 @@ function TableSurface({
           </mesh>
         ))}
         <DriftingAstrologicalField
+          color={palette.celestialGold}
           width={visibleWidth}
           height={visibleHeight}
           reducedMotion={reducedMotion}
@@ -943,6 +1038,7 @@ function TarotTable({
   cardSet,
   session,
   reducedMotion,
+  sceneSettings,
   viewZoom,
   viewPan,
   deckMoveMode,
@@ -961,6 +1057,21 @@ function TarotTable({
   const deckPreviewPositionRef = useRef<TablePoint | null>(null);
   const baseViewportWidth = size.width / BASE_CAMERA_ZOOM;
   const baseViewportHeight = size.height / BASE_CAMERA_ZOOM;
+  const palette = getSceneTheme(sceneSettings.themeId).palette;
+  const shadowFillMultiplier = MathUtils.mapLinear(
+    sceneSettings.shadowDepth,
+    MIN_SCENE_LIGHT_INTENSITY,
+    MAX_SCENE_LIGHT_INTENSITY,
+    1.18,
+    0.82
+  );
+  const shadowRadius = MathUtils.mapLinear(
+    sceneSettings.shadowDepth,
+    MIN_SCENE_LIGHT_INTENSITY,
+    MAX_SCENE_LIGHT_INTENSITY,
+    11,
+    5
+  );
   const layout = useMemo(
     () =>
       createSceneTableLayout({
@@ -1015,7 +1126,10 @@ function TarotTable({
     },
     [invalidate]
   );
-  const deckMetrics = getDeckMetrics(Math.max(0, deckCount - 1));
+  const deckMetrics = getDeckMetrics(
+    Math.max(0, deckCount - 1),
+    cardSet.cards.length
+  );
   const visibleCards = topDeckCard
     ? [topDeckCard, ...tableCards]
     : tableCards;
@@ -1059,30 +1173,37 @@ function TarotTable({
         viewportBounds={layout.viewportBounds}
         targetZoom={viewZoom}
       />
-      <ambientLight intensity={0.44} />
+      <ambientLight
+        intensity={
+          0.44 * sceneSettings.lightIntensity * shadowFillMultiplier
+        }
+      />
       <pointLight
         castShadow
         position={[0, 0, 7.5]}
-        intensity={86}
+        intensity={86 * sceneSettings.lightIntensity}
         distance={24}
         decay={2}
-        color={TAROT_SCENE_PALETTE.keyLight}
+        color={palette.keyLight}
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
         shadow-bias={-0.00035}
-        shadow-radius={8}
+        shadow-radius={shadowRadius}
         shadow-normalBias={0.001}
         shadow-camera-near={0.2}
         shadow-camera-far={18}
       />
       <pointLight
         position={[0, 0, 4.5]}
-        intensity={8}
+        intensity={
+          8 * sceneSettings.lightIntensity * shadowFillMultiplier
+        }
         distance={16}
         decay={2}
-        color={TAROT_SCENE_PALETTE.fillLight}
+        color={palette.fillLight}
       />
       <TableSurface
+        palette={palette}
         width={baseViewportWidth}
         height={baseViewportHeight}
         dragBounds={layout.dragBounds}
@@ -1091,6 +1212,8 @@ function TarotTable({
       />
       <DeckStack
         count={Math.max(0, deckCount - 1)}
+        deckCapacity={cardSet.cards.length}
+        palette={palette}
         showMat={deckCount > 0}
         position={deckPosition}
         layout={layout}

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -64,6 +64,15 @@ import {
   MIN_VIEW_ZOOM,
   type SceneTableLayout,
 } from "./table-layout";
+import {
+  DEFAULT_SCENE_SETTINGS,
+  MAX_SCENE_LIGHT_INTENSITY,
+  MIN_SCENE_LIGHT_INTENSITY,
+  resolveSceneSettings,
+  SCENE_THEME_IDS,
+  type SceneSettings,
+  type SceneThemeId,
+} from "./theme";
 
 const WHEEL_LAYER_COOLDOWN = 110;
 const WHEEL_LAYER_THRESHOLD = 36;
@@ -392,7 +401,7 @@ function useDockPopover({
     const focusTimer = window.requestAnimationFrame(() => {
       containerRef.current
         ?.querySelector<HTMLElement>(
-          "[role='dialog'] [role='radio'][aria-checked='true'], [role='dialog'] button:not(:disabled), [role='dialog'] select:not(:disabled)"
+          "[role='dialog'] [role='radio'][aria-checked='true'], [role='dialog'] button:not(:disabled), [role='dialog'] select:not(:disabled), [role='dialog'] input:not(:disabled)"
         )
         ?.focus();
     });
@@ -457,6 +466,8 @@ export function TarotStudio() {
   const spreadMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const arrangeMenuRef = useRef<HTMLDivElement>(null);
   const arrangeMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const configMenuRef = useRef<HTMLDivElement>(null);
+  const configMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const languageMenuRef = useRef<HTMLDivElement>(null);
   const languageMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const inspectorCollapseRef = useRef<HTMLButtonElement>(null);
@@ -476,6 +487,7 @@ export function TarotStudio() {
   const [isZoomMenuOpen, setIsZoomMenuOpen] = useState(false);
   const [isSpreadMenuOpen, setIsSpreadMenuOpen] = useState(false);
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
+  const [isConfigMenuOpen, setIsConfigMenuOpen] = useState(false);
   const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
   const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(true);
   const [isDeckMoveMode, setIsDeckMoveMode] = useState(false);
@@ -486,6 +498,9 @@ export function TarotStudio() {
   );
   const [isReadingLoading, setIsReadingLoading] = useState(false);
   const [locale, setLocale] = useState<AppLocale>("en");
+  const [sceneSettings, setSceneSettings] = useState<SceneSettings>(() => ({
+    ...DEFAULT_SCENE_SETTINGS,
+  }));
 
   useEffect(() => {
     viewZoomRef.current = viewZoom;
@@ -509,6 +524,11 @@ export function TarotStudio() {
   }, [viewZoom]);
 
   const messages = getMessages(locale);
+  const sceneThemeLabels: Record<SceneThemeId, string> = {
+    constellation: messages.backgroundConstellation,
+    "solar-temple": messages.backgroundSolarTemple,
+    "moonlit-grove": messages.backgroundMoonlitGrove,
+  };
   const activeCardSet = useMemo(
     () => getCardSet(activeCardSetId),
     [activeCardSetId]
@@ -543,6 +563,7 @@ export function TarotStudio() {
     isZoomMenuOpen ||
     isSpreadMenuOpen ||
     isArrangeMenuOpen ||
+    isConfigMenuOpen ||
     isLanguageMenuOpen ||
     isInspectorOpen ||
     isDeckMoveMode;
@@ -581,6 +602,7 @@ export function TarotStudio() {
       setViewZoom(
         Math.min(MAX_VIEW_ZOOM, Math.max(MIN_VIEW_ZOOM, workspace.viewZoom))
       );
+      setSceneSettings(resolveSceneSettings(workspace.sceneSettings));
       setIsInspectorCollapsed(true);
       dispatch({ type: "restore", session: workspace.session });
     }
@@ -597,6 +619,7 @@ export function TarotStudio() {
       saveTarotWorkspace({
         activeCardSetId,
         isInspectorCollapsed,
+        sceneSettings,
         session,
         viewZoom,
       });
@@ -607,6 +630,7 @@ export function TarotStudio() {
     activeCardSetId,
     isInspectorCollapsed,
     isWorkspaceReady,
+    sceneSettings,
     session,
     viewZoom,
   ]);
@@ -634,6 +658,12 @@ export function TarotStudio() {
     isOpen: isArrangeMenuOpen,
     setIsOpen: setIsArrangeMenuOpen,
     triggerRef: arrangeMenuTriggerRef,
+  });
+  useDockPopover({
+    containerRef: configMenuRef,
+    isOpen: isConfigMenuOpen,
+    setIsOpen: setIsConfigMenuOpen,
+    triggerRef: configMenuTriggerRef,
   });
   useDockPopover({
     containerRef: languageMenuRef,
@@ -955,6 +985,66 @@ export function TarotStudio() {
       updateLocale(LANGUAGE_OPTIONS[nextIndex], false);
     },
     [updateLocale]
+  );
+
+  const updateSceneTheme = useCallback(
+    (themeId: SceneThemeId, restoreFocus = false) => {
+      setSceneSettings((current) =>
+        resolveSceneSettings({ ...current, themeId })
+      );
+
+      if (restoreFocus) {
+        window.requestAnimationFrame(() =>
+          configMenuRef.current
+            ?.querySelector<HTMLButtonElement>(
+              `[data-scene-theme-option="${themeId}"]`
+            )
+            ?.focus()
+        );
+      }
+    },
+    []
+  );
+
+  const handleSceneThemeRadioKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, currentTheme: SceneThemeId) => {
+      const currentIndex = SCENE_THEME_IDS.indexOf(currentTheme);
+      let nextIndex: number;
+
+      switch (event.key) {
+        case "ArrowLeft":
+        case "ArrowUp":
+          nextIndex =
+            (currentIndex - 1 + SCENE_THEME_IDS.length) %
+            SCENE_THEME_IDS.length;
+          break;
+        case "ArrowRight":
+        case "ArrowDown":
+          nextIndex = (currentIndex + 1) % SCENE_THEME_IDS.length;
+          break;
+        case "Home":
+          nextIndex = 0;
+          break;
+        case "End":
+          nextIndex = SCENE_THEME_IDS.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      updateSceneTheme(SCENE_THEME_IDS[nextIndex], true);
+    },
+    [updateSceneTheme]
+  );
+
+  const updateSceneRange = useCallback(
+    (key: "lightIntensity" | "shadowDepth", value: number) => {
+      setSceneSettings((current) =>
+        resolveSceneSettings({ ...current, [key]: value })
+      );
+    },
+    []
   );
 
   const undoLastAction = useCallback(() => {
@@ -1397,7 +1487,10 @@ export function TarotStudio() {
 
   if (!isWorkspaceReady) {
     return (
-      <main className="tarot-app tarot-app--restoring">
+      <main
+        className="tarot-app tarot-app--restoring"
+        data-scene-theme={sceneSettings.themeId}
+      >
         <div className="tarot-grain" aria-hidden="true" />
         <div className="tarot-workspace-loading" role="status">
           {messages.loadingTable}
@@ -1407,7 +1500,7 @@ export function TarotStudio() {
   }
 
   return (
-    <main className="tarot-app">
+    <main className="tarot-app" data-scene-theme={sceneSettings.themeId}>
       <div className="tarot-grain" aria-hidden="true" />
       <div
         ref={canvasShellRef}
@@ -1427,6 +1520,7 @@ export function TarotStudio() {
           cardSet={activeCardSet}
           session={session}
           reducedMotion={reducedMotion}
+          sceneSettings={sceneSettings}
           viewZoom={viewZoom}
           viewPan={viewPan}
           deckMoveMode={isDeckMoveMode}
@@ -1475,6 +1569,7 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
+              setIsConfigMenuOpen(false);
               setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
@@ -1536,66 +1631,6 @@ export function TarotStudio() {
             </div>
           )}
         </div>
-        <div className="tarot-zoom-menu" ref={zoomMenuRef}>
-          <button
-            ref={zoomMenuTriggerRef}
-            type="button"
-            className="tarot-toolbar-trigger tarot-zoom-trigger"
-            aria-label={messages.tableZoom(Math.round(viewZoom * 100))}
-            aria-controls="zoom-actions"
-            aria-expanded={isZoomMenuOpen}
-            aria-haspopup="dialog"
-            onClick={() => {
-              const willOpen = !isZoomMenuOpen;
-              setIsDeckMenuOpen(false);
-              setIsSpreadMenuOpen(false);
-              setIsArrangeMenuOpen(false);
-              setIsLanguageMenuOpen(false);
-              setIsInspectorCollapsed(true);
-              setIsZoomMenuOpen(willOpen);
-            }}
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="10.5" cy="10.5" r="5.5" />
-              <path d="m14.5 14.5 5 5M8 10.5h5M10.5 8v5" />
-            </svg>
-            <span>{messages.zoom}</span>
-            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
-              <path d="m8 10 4 4 4-4" />
-            </svg>
-          </button>
-          <div
-            id="zoom-actions"
-            className={`tarot-zoom-controls${isZoomMenuOpen ? " tarot-zoom-controls--open" : ""}`}
-            role={isZoomMenuOpen ? "dialog" : undefined}
-            aria-label={messages.zoom}
-          >
-            <button
-              type="button"
-              aria-label={messages.zoomOut}
-              onClick={() => adjustViewZoom(-0.1)}
-              disabled={viewZoom <= MIN_VIEW_ZOOM}
-            >
-              −
-            </button>
-            <button
-              type="button"
-              aria-label={messages.resetZoom}
-              title={messages.resetZoom}
-              onClick={() => setViewZoom(1)}
-            >
-              {Math.round(viewZoom * 100)}%
-            </button>
-            <button
-              type="button"
-              aria-label={messages.zoomIn}
-              onClick={() => adjustViewZoom(0.1)}
-              disabled={viewZoom >= MAX_VIEW_ZOOM}
-            >
-              +
-            </button>
-          </div>
-        </div>
         {isDeckMoveMode && (
           <button
             type="button"
@@ -1631,6 +1666,7 @@ export function TarotStudio() {
                   setIsDeckMenuOpen(false);
                   setIsZoomMenuOpen(false);
                   setIsArrangeMenuOpen(false);
+                  setIsConfigMenuOpen(false);
                   setIsLanguageMenuOpen(false);
                   setIsSpreadMenuOpen(willOpen);
                 }}
@@ -1692,6 +1728,7 @@ export function TarotStudio() {
               setIsDeckMenuOpen(false);
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
+              setIsConfigMenuOpen(false);
               setIsLanguageMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
@@ -1755,6 +1792,7 @@ export function TarotStudio() {
                     setIsDeckMenuOpen(false);
                     setIsZoomMenuOpen(false);
                     setIsSpreadMenuOpen(false);
+                    setIsConfigMenuOpen(false);
                     setIsLanguageMenuOpen(false);
                     setIsDeckMoveMode(true);
                     setIsArrangeMenuOpen(false);
@@ -1833,6 +1871,7 @@ export function TarotStudio() {
             setIsZoomMenuOpen(false);
             setIsSpreadMenuOpen(false);
             setIsArrangeMenuOpen(false);
+            setIsConfigMenuOpen(false);
             setIsLanguageMenuOpen(false);
             resetTable();
           }}
@@ -1843,24 +1882,220 @@ export function TarotStudio() {
           </svg>
           <span>{messages.resetTable}</span>
         </button>
-        <button
-          type="button"
-          className="tarot-toolbar-trigger tarot-sound-toggle"
-          aria-label={messages.cardSounds}
-          aria-pressed={!areCardSoundsMuted}
-          title={areCardSoundsMuted ? messages.cardSoundsOff : messages.cardSoundsOn}
-          onClick={toggleCardSounds}
-        >
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M5 10h3.2L13 6.2v11.6L8.2 14H5z" />
-            {areCardSoundsMuted ? (
-              <path d="m16.5 9.2 4.3 5.6m0-5.6-4.3 5.6" />
-            ) : (
-              <path d="M16.5 9.2a4 4 0 0 1 0 5.6M18.8 7a7 7 0 0 1 0 10" />
-            )}
-          </svg>
-          <span>{messages.cardSounds}</span>
-        </button>
+        <div className="tarot-zoom-menu" ref={zoomMenuRef}>
+          <button
+            ref={zoomMenuTriggerRef}
+            type="button"
+            className="tarot-toolbar-trigger tarot-zoom-trigger"
+            aria-label={messages.tableZoom(Math.round(viewZoom * 100))}
+            aria-controls="zoom-actions"
+            aria-expanded={isZoomMenuOpen}
+            aria-haspopup="dialog"
+            onClick={() => {
+              const willOpen = !isZoomMenuOpen;
+              setIsDeckMenuOpen(false);
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsConfigMenuOpen(false);
+              setIsLanguageMenuOpen(false);
+              setIsInspectorCollapsed(true);
+              setIsZoomMenuOpen(willOpen);
+            }}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="10.5" cy="10.5" r="5.5" />
+              <path d="m14.5 14.5 5 5M8 10.5h5M10.5 8v5" />
+            </svg>
+            <span>{messages.zoom}</span>
+            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m8 10 4 4 4-4" />
+            </svg>
+          </button>
+          <div
+            id="zoom-actions"
+            className={`tarot-zoom-controls${isZoomMenuOpen ? " tarot-zoom-controls--open" : ""}`}
+            role={isZoomMenuOpen ? "dialog" : undefined}
+            aria-label={messages.zoom}
+          >
+            <button
+              type="button"
+              aria-label={messages.zoomOut}
+              onClick={() => adjustViewZoom(-0.1)}
+              disabled={viewZoom <= MIN_VIEW_ZOOM}
+            >
+              −
+            </button>
+            <button
+              type="button"
+              aria-label={messages.resetZoom}
+              title={messages.resetZoom}
+              onClick={() => setViewZoom(1)}
+            >
+              {Math.round(viewZoom * 100)}%
+            </button>
+            <button
+              type="button"
+              aria-label={messages.zoomIn}
+              onClick={() => adjustViewZoom(0.1)}
+              disabled={viewZoom >= MAX_VIEW_ZOOM}
+            >
+              +
+            </button>
+          </div>
+        </div>
+        <div className="tarot-config-menu" ref={configMenuRef}>
+          <button
+            ref={configMenuTriggerRef}
+            type="button"
+            className="tarot-toolbar-trigger tarot-config-trigger"
+            aria-label={messages.configureTable}
+            aria-controls="config-actions"
+            aria-expanded={isConfigMenuOpen}
+            aria-haspopup="dialog"
+            onClick={() => {
+              const willOpen = !isConfigMenuOpen;
+
+              setIsDeckMenuOpen(false);
+              setIsZoomMenuOpen(false);
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsLanguageMenuOpen(false);
+              setIsInspectorCollapsed(true);
+              setIsConfigMenuOpen(willOpen);
+            }}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M4 7h10M18 7h2M4 17h2M10 17h10M14 4v6M6 14v6" />
+            </svg>
+            <span>{messages.config}</span>
+            <svg className="tarot-menu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m8 10 4 4 4-4" />
+            </svg>
+          </button>
+          {isConfigMenuOpen && (
+            <section
+              id="config-actions"
+              className="tarot-config-popover"
+              role="dialog"
+              aria-label={messages.configureTable}
+            >
+              <h2 className="tarot-config-heading">{messages.configureTable}</h2>
+              <div className="tarot-config-section">
+                <h3 className="tarot-config-section-title">
+                  {messages.background}
+                </h3>
+                <div
+                  className="tarot-config-choice-grid"
+                  role="radiogroup"
+                  aria-label={messages.backgroundOptions}
+                >
+                  {SCENE_THEME_IDS.map((themeId) => (
+                    <button
+                      key={themeId}
+                      type="button"
+                      className="tarot-config-choice"
+                      role="radio"
+                      aria-checked={sceneSettings.themeId === themeId}
+                      data-scene-theme={themeId}
+                      data-scene-theme-option={themeId}
+                      tabIndex={sceneSettings.themeId === themeId ? 0 : -1}
+                      onKeyDown={(event) =>
+                        handleSceneThemeRadioKeyDown(event, themeId)
+                      }
+                      onClick={() => updateSceneTheme(themeId)}
+                    >
+                      <span>{sceneThemeLabels[themeId]}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="tarot-config-section">
+                <h3 className="tarot-config-section-title">
+                  {messages.lighting}
+                </h3>
+                <div className="tarot-config-range-row">
+                  <label htmlFor="scene-light-intensity">
+                    {messages.lightIntensity}
+                  </label>
+                  <output
+                    className="tarot-config-range-value"
+                    htmlFor="scene-light-intensity"
+                  >
+                    {messages.lightIntensityValue(sceneSettings.lightIntensity)}
+                  </output>
+                  <input
+                    id="scene-light-intensity"
+                    className="tarot-config-range"
+                    type="range"
+                    min={MIN_SCENE_LIGHT_INTENSITY}
+                    max={MAX_SCENE_LIGHT_INTENSITY}
+                    step="0.05"
+                    value={sceneSettings.lightIntensity}
+                    aria-valuetext={messages.lightIntensityValue(
+                      sceneSettings.lightIntensity
+                    )}
+                    onChange={(event) =>
+                      updateSceneRange(
+                        "lightIntensity",
+                        event.currentTarget.valueAsNumber
+                      )
+                    }
+                  />
+                </div>
+                <div className="tarot-config-range-row">
+                  <label htmlFor="scene-shadow-depth">
+                    {messages.shadowDepth}
+                  </label>
+                  <output
+                    className="tarot-config-range-value"
+                    htmlFor="scene-shadow-depth"
+                  >
+                    {messages.shadowDepthValue(sceneSettings.shadowDepth)}
+                  </output>
+                  <input
+                    id="scene-shadow-depth"
+                    className="tarot-config-range"
+                    type="range"
+                    min={MIN_SCENE_LIGHT_INTENSITY}
+                    max={MAX_SCENE_LIGHT_INTENSITY}
+                    step="0.05"
+                    value={sceneSettings.shadowDepth}
+                    aria-valuetext={messages.shadowDepthValue(
+                      sceneSettings.shadowDepth
+                    )}
+                    onChange={(event) =>
+                      updateSceneRange(
+                        "shadowDepth",
+                        event.currentTarget.valueAsNumber
+                      )
+                    }
+                  />
+                </div>
+              </div>
+              <div className="tarot-config-section">
+                <h3 className="tarot-config-section-title">
+                  {messages.cardSounds}
+                </h3>
+                <button
+                  type="button"
+                  className="tarot-config-sound"
+                  role="switch"
+                  aria-checked={!areCardSoundsMuted}
+                  onClick={toggleCardSounds}
+                >
+                  <span>
+                    <span>
+                      {areCardSoundsMuted
+                        ? messages.cardSoundsOff
+                        : messages.cardSoundsOn}
+                    </span>
+                    <small>{messages.cardSoundsDescription}</small>
+                  </span>
+                </button>
+              </div>
+            </section>
+          )}
+        </div>
         <div className="tarot-language-menu" ref={languageMenuRef}>
           <button
             ref={languageMenuTriggerRef}
@@ -1877,6 +2112,7 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
+              setIsConfigMenuOpen(false);
               if (selectedCard?.zone === "table") {
                 setIsInspectorCollapsed(true);
               }
@@ -1944,6 +2180,7 @@ export function TarotStudio() {
               setIsZoomMenuOpen(false);
               setIsSpreadMenuOpen(false);
               setIsArrangeMenuOpen(false);
+              setIsConfigMenuOpen(false);
               setIsLanguageMenuOpen(false);
               if (isInspectorOpen) {
                 collapseInspector();

--- a/src/components/tarot-studio/theme.ts
+++ b/src/components/tarot-studio/theme.ts
@@ -10,3 +10,115 @@ export const TAROT_SCENE_PALETTE = {
   keyLight: "#ffe4b8",
   fillLight: "#8f6ba3",
 } as const;
+
+export const SCENE_THEME_IDS = [
+  "constellation",
+  "solar-temple",
+  "moonlit-grove",
+] as const;
+
+export type SceneThemeId = (typeof SCENE_THEME_IDS)[number];
+
+export type ScenePalette = {
+  [Key in keyof typeof TAROT_SCENE_PALETTE]: string;
+};
+
+export type SceneTheme = {
+  id: SceneThemeId;
+  palette: ScenePalette;
+};
+
+export const MIN_SCENE_LIGHT_INTENSITY = 0.65;
+export const MAX_SCENE_LIGHT_INTENSITY = 1.35;
+
+export type SceneSettings = {
+  lightIntensity: number;
+  shadowDepth: number;
+  themeId: SceneThemeId;
+};
+
+export const DEFAULT_SCENE_SETTINGS: SceneSettings = {
+  lightIntensity: 1,
+  shadowDepth: 1,
+  themeId: "constellation",
+};
+
+export const SCENE_THEMES: Readonly<Record<SceneThemeId, SceneTheme>> = {
+  constellation: {
+    id: "constellation",
+    palette: TAROT_SCENE_PALETTE,
+  },
+  "solar-temple": {
+    id: "solar-temple",
+    palette: {
+      ...TAROT_SCENE_PALETTE,
+      celestialGold: "#d59b45",
+      deckMat: "#4a1f1e",
+      deckMatEdge: "#b97846",
+      dragBoundary: "#d2a45e",
+      fillLight: "#bd6745",
+      keyLight: "#ffe0a5",
+      table: "#3a171b",
+      tableEmissive: "#1d090b",
+    },
+  },
+  "moonlit-grove": {
+    id: "moonlit-grove",
+    palette: {
+      ...TAROT_SCENE_PALETTE,
+      celestialGold: "#a9c9a5",
+      deckMat: "#173a35",
+      deckMatEdge: "#6f9d91",
+      dragBoundary: "#92b8aa",
+      fillLight: "#6ea69c",
+      keyLight: "#d6f0d9",
+      table: "#102b2b",
+      tableEmissive: "#061414",
+    },
+  },
+};
+
+function isSceneThemeId(value: unknown): value is SceneThemeId {
+  return (
+    typeof value === "string" &&
+    SCENE_THEME_IDS.includes(value as SceneThemeId)
+  );
+}
+
+function clampLightIntensity(value: number) {
+  return Math.min(
+    MAX_SCENE_LIGHT_INTENSITY,
+    Math.max(MIN_SCENE_LIGHT_INTENSITY, value)
+  );
+}
+
+/**
+ * Coerces persisted or partial settings to safe scene values. Keeping this
+ * here makes new controls additive for existing saved workspaces.
+ */
+export function resolveSceneSettings(value: unknown): SceneSettings {
+  const settings =
+    value && typeof value === "object"
+      ? (value as Partial<SceneSettings>)
+      : undefined;
+
+  return {
+    themeId: isSceneThemeId(settings?.themeId)
+      ? settings.themeId
+      : DEFAULT_SCENE_SETTINGS.themeId,
+    lightIntensity:
+      typeof settings?.lightIntensity === "number" &&
+      Number.isFinite(settings.lightIntensity)
+        ? clampLightIntensity(settings.lightIntensity)
+        : DEFAULT_SCENE_SETTINGS.lightIntensity,
+    shadowDepth:
+      typeof settings?.shadowDepth === "number" &&
+      Number.isFinite(settings.shadowDepth)
+        ? clampLightIntensity(settings.shadowDepth)
+        : DEFAULT_SCENE_SETTINGS.shadowDepth,
+  };
+}
+
+export function getSceneTheme(themeId: SceneThemeId): SceneTheme {
+  return SCENE_THEMES[themeId];
+}

--- a/src/data/card-readings.ts
+++ b/src/data/card-readings.ts
@@ -783,8 +783,6 @@ function getMinorReading(
         { label: "Esoteric theme", value: theme },
       ],
       sources: [WAITE_SOURCE, BOOK_T_SOURCE],
-      traditionNote:
-        "Smith’s image and Waite’s companion text ground the card; the elemental and number synthesis is presented as an editorial esoteric reading framework.",
     };
   }
 
@@ -1086,8 +1084,6 @@ function getPortugueseMinorReading(
         { label: "Domínio do naipe", value: suitReading.domain },
       ],
       sources: localizeSources([WAITE_SOURCE, BOOK_T_SOURCE]),
-      traditionNote:
-        "A imagem de Smith e o texto de Waite fundamentam a carta; a síntese elemental e numérica é apresentada como uma estrutura editorial de leitura esotérica.",
     };
   }
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -47,6 +47,21 @@ type Messages = {
   cardSounds: string;
   cardSoundsOn: string;
   cardSoundsOff: string;
+  cardSoundsDescription: string;
+  config: string;
+  configureTable: string;
+  configOptions: string;
+  appearance: string;
+  background: string;
+  backgroundOptions: string;
+  backgroundConstellation: string;
+  backgroundSolarTemple: string;
+  backgroundMoonlitGrove: string;
+  lighting: string;
+  lightIntensity: string;
+  lightIntensityValue: (value: number) => string;
+  shadowDepth: string;
+  shadowDepthValue: (value: number) => string;
   language: string;
   chooseLanguage: string;
   languageOptions: string;
@@ -141,6 +156,21 @@ const messages: Record<AppLocale, Messages> = {
     cardSounds: "Card sounds",
     cardSoundsOn: "Card sounds on",
     cardSoundsOff: "Card sounds off",
+    cardSoundsDescription: "Atmospheric sounds while you handle cards",
+    config: "Config",
+    configureTable: "Configure table",
+    configOptions: "Configuration options",
+    appearance: "Appearance",
+    background: "Background",
+    backgroundOptions: "Background options",
+    backgroundConstellation: "Constellation",
+    backgroundSolarTemple: "Solar temple",
+    backgroundMoonlitGrove: "Moonlit grove",
+    lighting: "Lighting",
+    lightIntensity: "Light intensity",
+    lightIntensityValue: (value) => `${Math.round(value * 100)}%`,
+    shadowDepth: "Shadow depth",
+    shadowDepthValue: (value) => `${Math.round(value * 100)}%`,
     language: "Language",
     chooseLanguage: "Choose language",
     languageOptions: "Language options",
@@ -248,6 +278,21 @@ const messages: Record<AppLocale, Messages> = {
     cardSounds: "Sons das cartas",
     cardSoundsOn: "Sons das cartas ativados",
     cardSoundsOff: "Sons das cartas desativados",
+    cardSoundsDescription: "Sons atmosféricos ao interagir com as cartas",
+    config: "Configurações",
+    configureTable: "Configurar mesa",
+    configOptions: "Opções de configuração",
+    appearance: "Aparência",
+    background: "Fundo",
+    backgroundOptions: "Opções de fundo",
+    backgroundConstellation: "Constelação",
+    backgroundSolarTemple: "Templo solar",
+    backgroundMoonlitGrove: "Bosque ao luar",
+    lighting: "Iluminação",
+    lightIntensity: "Intensidade da luz",
+    lightIntensityValue: (value) => `${Math.round(value * 100)}%`,
+    shadowDepth: "Profundidade das sombras",
+    shadowDepthValue: (value) => `${Math.round(value * 100)}%`,
     language: "Idioma",
     chooseLanguage: "Escolher idioma",
     languageOptions: "Opções de idioma",

--- a/src/lib/tarot-workspace.ts
+++ b/src/lib/tarot-workspace.ts
@@ -5,6 +5,10 @@ import type {
   TarotSession,
 } from "@/types";
 import { DECK_POINT_LIMIT, TABLE_POINT_LIMIT } from "@/types";
+import {
+  resolveSceneSettings,
+  type SceneSettings,
+} from "@/components/tarot-studio/theme";
 
 export const TAROT_WORKSPACE_STORAGE_KEY = "tarot-table:workspace:v1";
 
@@ -13,11 +17,14 @@ const WORKSPACE_VERSION = 1;
 export type TarotWorkspace = {
   activeCardSetId: string;
   isInspectorCollapsed: boolean;
+  sceneSettings: SceneSettings;
   session: TarotSession;
   viewZoom: number;
 };
 
-type StoredWorkspace = TarotWorkspace & {
+type StoredWorkspace = Omit<TarotWorkspace, "sceneSettings"> & {
+  /** Absent in version-one workspaces; it then resolves to the default scene. */
+  sceneSettings?: SceneSettings;
   version: typeof WORKSPACE_VERSION;
 };
 
@@ -148,6 +155,7 @@ export function loadTarotWorkspace(
       ? {
           activeCardSetId: cardSet.id,
           isInspectorCollapsed: stored.isInspectorCollapsed,
+          sceneSettings: resolveSceneSettings(stored.sceneSettings),
           session,
           viewZoom: stored.viewZoom,
         }
@@ -163,6 +171,7 @@ export function saveTarotWorkspace(workspace: TarotWorkspace): void {
       version: WORKSPACE_VERSION,
       activeCardSetId: workspace.activeCardSetId,
       isInspectorCollapsed: workspace.isInspectorCollapsed,
+      sceneSettings: resolveSceneSettings(workspace.sceneSettings),
       session: {
         ...workspace.session,
         history: [],


### PR DESCRIPTION
## What changed

- adds a persistent Config popover with three table themes, light intensity, shadow depth, and card sounds
- groups the bottom bar into table actions, view controls, preferences, language, and the rightmost Card trigger
- gives the deck a continuously shrinking stacked profile, a fitted mat, and one cohesive full-stack shadow
- keeps fast tilted drags above other cards and the table without changing whole-deck movement
- removes the repeated minor-arcana editorial disclaimer in English and Brazilian Portuguese

Depends on: https://github.com/vtrpldn/tarot/pull/10

## Why

The table should feel like one tactile, atmospheric workspace: preferences belong together, cards must remain physically legible during fast handling, and the deck should visibly behave like a diminishing stack rather than a separate flat object.

## Checks

- lint and TypeScript
- production build
- locale and card-reading validators
- Lenormand and Marseille asset validators
- desktop and mobile in-app browser review, including theme switching, fast dragging, drawing, undo, and a clean console reload
