### PR TITLE
Add mobile fullscreen and reliable popovers

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1577,7 +1577,7 @@ input:focus-visible {
   }
 }
 
-@media (max-width: 399px) {
+@media (max-width: 419px) {
   .tarot-toolbar {
     display: grid;
     grid-template-columns: repeat(4, 2.75rem);
@@ -1601,11 +1601,6 @@ input:focus-visible {
   .tarot-toolbar {
     gap: 0.18rem;
     padding: 0.28rem;
-  }
-
-  .tarot-zoom-controls {
-    grid-template-columns: 2.5rem 2.75rem 2.5rem;
-    gap: 0.1rem;
   }
 
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -830,6 +830,7 @@ button {
 }
 
 .tarot-fullscreen-trigger,
+.tarot-mobile-toolbar-spacer,
 .tarot-arrange-popover .tarot-mobile-reset-action {
   display: none;
 }
@@ -1588,6 +1589,13 @@ input:focus-visible {
   .tarot-card-menu {
     grid-row: 2;
     grid-column: 4;
+  }
+
+  .tarot-mobile-toolbar-spacer {
+    display: block;
+    width: 2.75rem;
+    height: 2.75rem;
+    pointer-events: none;
   }
 
   .tarot-mobile-popover {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1293,7 +1293,7 @@ input:focus-visible {
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767px), (pointer: coarse) and (max-height: 767px) {
   .tarot-toolbar-sigil {
     display: none;
   }
@@ -1613,7 +1613,7 @@ input:focus-visible {
 
 }
 
-@media (max-height: 660px) and (min-width: 720px) {
+@media (max-height: 660px) and (min-width: 720px) and (hover: hover) and (pointer: fine) {
   .tarot-inspector {
     width: min(18rem, calc(100vw - 1.5rem));
     max-height: calc(100dvh - 6.5rem);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,6 +72,11 @@ button {
     linear-gradient(135deg, #0e0815 0%, #281733 47%, #171021 100%);
 }
 
+.tarot-app:fullscreen {
+  width: 100%;
+  height: 100%;
+}
+
 .tarot-app::before,
 .tarot-app::after {
   content: "";
@@ -824,6 +829,11 @@ button {
   display: none;
 }
 
+.tarot-fullscreen-trigger,
+.tarot-arrange-popover .tarot-mobile-reset-action {
+  display: none;
+}
+
 .tarot-toolbar-trigger svg {
   width: 0.9rem;
   height: 0.9rem;
@@ -1397,15 +1407,31 @@ input:focus-visible {
 
   .tarot-toolbar {
     bottom: max(0.65rem, var(--safe-bottom));
+    right: max(0.625rem, var(--safe-right));
+    left: max(0.625rem, var(--safe-left));
     display: flex;
     gap: 0.22rem;
     width: max-content;
-    max-width: calc(100vw - 1.25rem);
+    max-width: calc(
+      100vw - max(0.625rem, var(--safe-left)) -
+        max(0.625rem, var(--safe-right))
+    );
+    margin-inline: auto;
     padding: 0.35rem;
+    transform: none;
   }
 
-  .tarot-zoom-trigger {
+  .tarot-zoom-trigger,
+  .tarot-fullscreen-trigger {
     display: inline-flex;
+  }
+
+  .tarot-reset-trigger {
+    display: none;
+  }
+
+  .tarot-arrange-popover .tarot-mobile-reset-action {
+    display: grid;
   }
 
   .tarot-zoom-controls {
@@ -1509,37 +1535,72 @@ input:focus-visible {
     animation-name: tarot-arrange-popover-enter;
   }
 
+  .tarot-mobile-popover {
+    --mobile-popover-bottom: calc(
+      max(0.65rem, var(--safe-bottom)) + 3.9rem
+    );
+    position: fixed;
+    z-index: 20;
+    right: max(0.625rem, var(--safe-right));
+    bottom: var(--mobile-popover-bottom);
+    left: max(0.625rem, var(--safe-left));
+    width: min(
+      var(--mobile-popover-width, 20rem),
+      calc(
+        100vw - max(0.625rem, var(--safe-left)) -
+          max(0.625rem, var(--safe-right))
+      )
+    );
+    max-width: none;
+    max-height: calc(
+      100dvh - var(--mobile-popover-bottom) -
+        max(0.625rem, var(--safe-top))
+    );
+    margin-inline: auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    transform: none;
+    animation-name: tarot-popover-enter;
+  }
+
+  .tarot-language-popover,
+  .tarot-zoom-controls {
+    --mobile-popover-width: 18rem;
+  }
+
+  .tarot-zoom-controls {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .tarot-live-status {
     display: block;
   }
 }
 
 @media (max-width: 399px) {
-  .tarot-toolbar-trigger,
-  .tarot-reset-trigger,
-  .tarot-mode-cancel {
-    width: 2.25rem;
-    min-height: 2.25rem;
+  .tarot-toolbar {
+    display: grid;
+    grid-template-columns: repeat(4, 2.75rem);
+    gap: 0.22rem;
+    max-width: none;
   }
 
-  .tarot-language-trigger {
-    width: 2.25rem;
+  .tarot-card-menu {
+    grid-row: 2;
+    grid-column: 4;
+  }
+
+  .tarot-mobile-popover {
+    --mobile-popover-bottom: calc(
+      max(0.65rem, var(--safe-bottom)) + 6.85rem
+    );
   }
 }
 
 @media (max-width: 349px) {
   .tarot-toolbar {
-    gap: 0.16rem;
-    max-width: calc(100vw - 0.5rem);
-    padding: 0.2rem;
-  }
-
-  .tarot-toolbar-trigger,
-  .tarot-reset-trigger,
-  .tarot-mode-cancel,
-  .tarot-language-trigger {
-    width: 2.15rem;
-    min-height: 2.15rem;
+    gap: 0.18rem;
+    padding: 0.28rem;
   }
 
   .tarot-zoom-controls {
@@ -1547,35 +1608,6 @@ input:focus-visible {
     gap: 0.1rem;
   }
 
-  .tarot-arrange-popover {
-    position: fixed;
-    right: 0.625rem;
-    bottom: calc(max(0.65rem, var(--safe-bottom)) + 3rem);
-    left: 0.625rem;
-    width: auto;
-    transform: none;
-    animation-name: tarot-popover-enter;
-  }
-
-  .tarot-config-popover {
-    position: fixed;
-    right: 0.625rem;
-    bottom: calc(max(0.65rem, var(--safe-bottom)) + 3rem);
-    left: 0.625rem;
-    width: auto;
-    max-height: calc(100dvh - 4.6rem);
-    transform: none;
-    animation-name: tarot-popover-enter;
-  }
-
-  .tarot-spread-actions {
-    right: -10.2rem;
-  }
-
-  .tarot-inspector {
-    right: auto;
-    inset-inline-end: -0.7rem;
-  }
 }
 
 @media (max-height: 660px) and (min-width: 720px) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: "#100918",
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -510,6 +510,7 @@ type TarotSceneProps = {
   session: TarotSession;
   reducedMotion: boolean;
   sceneSettings: SceneSettings;
+  isMobileViewport: boolean;
   viewZoom: number;
   /**
    * The camera centre in scene world units. This intentionally stays
@@ -1594,6 +1595,7 @@ function TarotTable({
   session,
   reducedMotion,
   sceneSettings,
+  isMobileViewport,
   viewZoom,
   viewPan,
   deckMoveMode,
@@ -1621,12 +1623,14 @@ function TarotTable({
         viewportWidth: baseViewportWidth,
         viewportHeight: baseViewportHeight,
         pixelWidth: size.width,
+        isMobileViewport,
         cardAspectRatio: cardSet.cardAspectRatio,
       }),
     [
       baseViewportHeight,
       baseViewportWidth,
       cardSet.cardAspectRatio,
+      isMobileViewport,
       size.width,
     ]
   );

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -2,12 +2,10 @@
 
 import dynamic from "next/dynamic";
 import {
-  type Dispatch,
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
-  type SetStateAction,
   type WheelEvent as ReactWheelEvent,
   useCallback,
   useEffect,
@@ -415,7 +413,7 @@ type DockPopoverOptions = {
   containerRef: RefObject<HTMLDivElement | null>;
   isOpen: boolean;
   popoverRef: RefObject<HTMLElement | null>;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setIsOpen: (isOpen: boolean) => void;
   triggerRef: RefObject<HTMLButtonElement | null>;
 };
 
@@ -514,6 +512,7 @@ export function TarotStudio() {
   const languageMenuRef = useRef<HTMLDivElement>(null);
   const languageMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const languagePopoverRef = useRef<HTMLElement>(null);
+  const cardMenuRef = useRef<HTMLDivElement>(null);
   const inspectorCollapseRef = useRef<HTMLButtonElement>(null);
   const inspectorToggleRef = useRef<HTMLButtonElement>(null);
   const inspectorPopoverRef = useRef<HTMLElement>(null);
@@ -719,6 +718,10 @@ export function TarotStudio() {
     viewZoom,
   ]);
 
+  const setInspectorOpen = useCallback((isOpen: boolean) => {
+    setIsInspectorCollapsed(!isOpen);
+  }, []);
+
   useDockPopover({
     containerRef: deckMenuRef,
     isOpen: isDeckMenuOpen,
@@ -760,6 +763,13 @@ export function TarotStudio() {
     popoverRef: languagePopoverRef,
     setIsOpen: setIsLanguageMenuOpen,
     triggerRef: languageMenuTriggerRef,
+  });
+  useDockPopover({
+    containerRef: cardMenuRef,
+    isOpen: isInspectorOpen,
+    popoverRef: inspectorPopoverRef,
+    setIsOpen: setInspectorOpen,
+    triggerRef: inspectorToggleRef,
   });
 
   useEffect(() => {
@@ -1740,6 +1750,9 @@ export function TarotStudio() {
             <span>{messages.cancel}</span>
           </button>
         )}
+        {tableCards.length > 0 && !isDeckMoveMode && (
+          <span className="tarot-mobile-toolbar-spacer" aria-hidden="true" />
+        )}
         {tableCards.length === 0 &&
           !isDeckMoveMode && (
             <div className="tarot-spread-menu" ref={spreadMenuRef}>
@@ -2278,7 +2291,7 @@ export function TarotStudio() {
             </MobilePopoverPortal>
           )}
         </div>
-        <div className="tarot-card-menu">
+        <div className="tarot-card-menu" ref={cardMenuRef}>
           <button
             ref={inspectorToggleRef}
             type="button"

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -16,6 +16,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   cardSets,
   getCardDisplayName,
@@ -177,6 +178,38 @@ function useReducedMotionPreference() {
   }, []);
 
   return reducedMotion;
+}
+
+function useMobileViewport() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const updateViewport = () => setIsMobileViewport(mediaQuery.matches);
+
+    updateViewport();
+    mediaQuery.addEventListener("change", updateViewport);
+
+    return () => mediaQuery.removeEventListener("change", updateViewport);
+  }, []);
+
+  return isMobileViewport;
+}
+
+function MobilePopoverPortal({
+  children,
+  isMobileViewport,
+  portalRoot,
+}: {
+  children: ReactNode;
+  isMobileViewport: boolean;
+  portalRoot: HTMLElement | null;
+}) {
+  if (!isMobileViewport || !portalRoot) {
+    return children;
+  }
+
+  return createPortal(children, portalRoot);
 }
 
 function useCardSounds() {
@@ -381,6 +414,7 @@ function Shortcut({ children }: { children: ReactNode }) {
 type DockPopoverOptions = {
   containerRef: RefObject<HTMLDivElement | null>;
   isOpen: boolean;
+  popoverRef: RefObject<HTMLElement | null>;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   triggerRef: RefObject<HTMLButtonElement | null>;
 };
@@ -388,6 +422,7 @@ type DockPopoverOptions = {
 function useDockPopover({
   containerRef,
   isOpen,
+  popoverRef,
   setIsOpen,
   triggerRef,
 }: DockPopoverOptions) {
@@ -397,14 +432,18 @@ function useDockPopover({
     }
 
     const focusTimer = window.requestAnimationFrame(() => {
-      containerRef.current
+      (popoverRef.current ?? containerRef.current)
         ?.querySelector<HTMLElement>(
-          "[role='dialog'] [role='radio'][aria-checked='true'], [role='dialog'] button:not(:disabled), [role='dialog'] select:not(:disabled), [role='dialog'] input:not(:disabled)"
+          "[role='radio'][aria-checked='true'], button:not(:disabled), select:not(:disabled), input:not(:disabled)"
         )
         ?.focus();
     });
     const closeOnOutsidePress = (event: PointerEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
+      const targetNode = event.target as Node;
+      const isInsideTrigger = containerRef.current?.contains(targetNode);
+      const isInsidePopover = popoverRef.current?.contains(targetNode);
+
+      if (!isInsideTrigger && !isInsidePopover) {
         setIsOpen(false);
 
         const target = event.target;
@@ -440,10 +479,11 @@ function useDockPopover({
       document.removeEventListener("pointerdown", closeOnOutsidePress);
       document.removeEventListener("keydown", closeOnEscape);
     };
-  }, [containerRef, isOpen, setIsOpen, triggerRef]);
+  }, [containerRef, isOpen, popoverRef, setIsOpen, triggerRef]);
 }
 
 export function TarotStudio() {
+  const tarotAppRef = useRef<HTMLElement>(null);
   const canvasShellRef = useRef<HTMLDivElement>(null);
   const hoveredCardIdRef = useRef<string | null>(null);
   const sceneLayoutRef = useRef<SceneTableLayout | null>(null);
@@ -458,18 +498,25 @@ export function TarotStudio() {
   } | null>(null);
   const deckMenuRef = useRef<HTMLDivElement>(null);
   const deckMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const deckPopoverRef = useRef<HTMLDivElement>(null);
   const zoomMenuRef = useRef<HTMLDivElement>(null);
   const zoomMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const zoomPopoverRef = useRef<HTMLDivElement>(null);
   const spreadMenuRef = useRef<HTMLDivElement>(null);
   const spreadMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const spreadPopoverRef = useRef<HTMLElement>(null);
   const arrangeMenuRef = useRef<HTMLDivElement>(null);
   const arrangeMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const arrangePopoverRef = useRef<HTMLDivElement>(null);
   const configMenuRef = useRef<HTMLDivElement>(null);
   const configMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const configPopoverRef = useRef<HTMLElement>(null);
   const languageMenuRef = useRef<HTMLDivElement>(null);
   const languageMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const languagePopoverRef = useRef<HTMLElement>(null);
   const inspectorCollapseRef = useRef<HTMLButtonElement>(null);
   const inspectorToggleRef = useRef<HTMLButtonElement>(null);
+  const inspectorPopoverRef = useRef<HTMLElement>(null);
   const layerWheelRef = useRef({
     accumulatedDelta: 0,
     direction: 0,
@@ -487,6 +534,8 @@ export function TarotStudio() {
   const [isArrangeMenuOpen, setIsArrangeMenuOpen] = useState(false);
   const [isConfigMenuOpen, setIsConfigMenuOpen] = useState(false);
   const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
+  const [isFullscreenAvailable, setIsFullscreenAvailable] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const [isInspectorCollapsed, setIsInspectorCollapsed] = useState(true);
   const [isDeckMoveMode, setIsDeckMoveMode] = useState(false);
   const [isSceneLayoutReady, setIsSceneLayoutReady] = useState(false);
@@ -499,6 +548,43 @@ export function TarotStudio() {
   const [sceneSettings, setSceneSettings] = useState<SceneSettings>(() => ({
     ...DEFAULT_SCENE_SETTINGS,
   }));
+  const isMobileViewport = useMobileViewport();
+
+  useEffect(() => {
+    const updateFullscreenState = () => {
+      setIsFullscreen(document.fullscreenElement === tarotAppRef.current);
+    };
+    const app = tarotAppRef.current;
+
+    setIsFullscreenAvailable(
+      document.fullscreenEnabled &&
+        typeof app?.requestFullscreen === "function"
+    );
+    updateFullscreenState();
+    document.addEventListener("fullscreenchange", updateFullscreenState);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", updateFullscreenState);
+    };
+  }, []);
+
+  const toggleFullscreen = useCallback(() => {
+    const app = tarotAppRef.current;
+
+    if (!app) {
+      return;
+    }
+
+    try {
+      const fullscreenAction = document.fullscreenElement
+        ? document.exitFullscreen()
+        : app.requestFullscreen();
+
+      void fullscreenAction.catch(() => undefined);
+    } catch {
+      // Fullscreen can be denied by browser or embedding permissions.
+    }
+  }, []);
 
   useEffect(() => {
     viewZoomRef.current = viewZoom;
@@ -636,36 +722,42 @@ export function TarotStudio() {
   useDockPopover({
     containerRef: deckMenuRef,
     isOpen: isDeckMenuOpen,
+    popoverRef: deckPopoverRef,
     setIsOpen: setIsDeckMenuOpen,
     triggerRef: deckMenuTriggerRef,
   });
   useDockPopover({
     containerRef: zoomMenuRef,
     isOpen: isZoomMenuOpen,
+    popoverRef: zoomPopoverRef,
     setIsOpen: setIsZoomMenuOpen,
     triggerRef: zoomMenuTriggerRef,
   });
   useDockPopover({
     containerRef: spreadMenuRef,
     isOpen: isSpreadMenuOpen,
+    popoverRef: spreadPopoverRef,
     setIsOpen: setIsSpreadMenuOpen,
     triggerRef: spreadMenuTriggerRef,
   });
   useDockPopover({
     containerRef: arrangeMenuRef,
     isOpen: isArrangeMenuOpen,
+    popoverRef: arrangePopoverRef,
     setIsOpen: setIsArrangeMenuOpen,
     triggerRef: arrangeMenuTriggerRef,
   });
   useDockPopover({
     containerRef: configMenuRef,
     isOpen: isConfigMenuOpen,
+    popoverRef: configPopoverRef,
     setIsOpen: setIsConfigMenuOpen,
     triggerRef: configMenuTriggerRef,
   });
   useDockPopover({
     containerRef: languageMenuRef,
     isOpen: isLanguageMenuOpen,
+    popoverRef: languagePopoverRef,
     setIsOpen: setIsLanguageMenuOpen,
     triggerRef: languageMenuTriggerRef,
   });
@@ -1477,6 +1569,7 @@ export function TarotStudio() {
   if (!isWorkspaceReady) {
     return (
       <main
+        ref={tarotAppRef}
         className="tarot-app tarot-app--restoring"
         data-scene-theme={sceneSettings.themeId}
       >
@@ -1489,7 +1582,11 @@ export function TarotStudio() {
   }
 
   return (
-    <main className="tarot-app" data-scene-theme={sceneSettings.themeId}>
+    <main
+      ref={tarotAppRef}
+      className="tarot-app"
+      data-scene-theme={sceneSettings.themeId}
+    >
       <div className="tarot-grain" aria-hidden="true" />
       <div
         ref={canvasShellRef}
@@ -1577,47 +1674,51 @@ export function TarotStudio() {
             </svg>
           </button>
           {isDeckMenuOpen && (
-            <div
-              id="deck-actions"
-              className="tarot-set-picker"
-              role="dialog"
-              aria-label={messages.chooseDeck}
+            <MobilePopoverPortal
+              isMobileViewport={isMobileViewport}
+              portalRoot={tarotAppRef.current}
             >
-              <label htmlFor="card-set">{messages.deck}</label>
-              <select
-                id="card-set"
-                name="card-set"
-                autoComplete="off"
-                value={activeCardSetId}
-                onChange={(event) => {
-                  const nextCardSet = getCardSet(event.target.value);
-                  activeArrangementRef.current = null;
-                  setIsDeckMoveMode(false);
-                  setIsSceneLayoutReady(false);
-                  setActiveCardSetId(nextCardSet.id);
-                  playCardSound("shuffle");
-                  dispatch({ type: "new-shuffle", cardSet: nextCardSet });
-                  setViewZoom(1);
-                  setViewPan([0, 0]);
-                  setIsDeckMenuOpen(false);
-                  window.requestAnimationFrame(() =>
-                    deckMenuTriggerRef.current?.focus()
-                  );
-                }}
+              <div
+                ref={deckPopoverRef}
+                id="deck-actions"
+                className="tarot-set-picker tarot-mobile-popover"
+                role="dialog"
+                aria-label={messages.chooseDeck}
               >
-                {cardSets.map((cardSet) => (
-                  <option key={cardSet.id} value={cardSet.id}>
-                    {getCardSetDisplayLabel(cardSet, locale)}
-                  </option>
-                ))}
-              </select>
-              <p className="tarot-set-picker-description">
-                {getCardSetDisplayDescription(activeCardSet, locale)}
-              </p>
-              <span>
-                {messages.cardsInDeck(deckCardCount)}
-              </span>
-            </div>
+                <label htmlFor="card-set">{messages.deck}</label>
+                <select
+                  id="card-set"
+                  name="card-set"
+                  autoComplete="off"
+                  value={activeCardSetId}
+                  onChange={(event) => {
+                    const nextCardSet = getCardSet(event.target.value);
+                    activeArrangementRef.current = null;
+                    setIsDeckMoveMode(false);
+                    setIsSceneLayoutReady(false);
+                    setActiveCardSetId(nextCardSet.id);
+                    playCardSound("shuffle");
+                    dispatch({ type: "new-shuffle", cardSet: nextCardSet });
+                    setViewZoom(1);
+                    setViewPan([0, 0]);
+                    setIsDeckMenuOpen(false);
+                    window.requestAnimationFrame(() =>
+                      deckMenuTriggerRef.current?.focus()
+                    );
+                  }}
+                >
+                  {cardSets.map((cardSet) => (
+                    <option key={cardSet.id} value={cardSet.id}>
+                      {getCardSetDisplayLabel(cardSet, locale)}
+                    </option>
+                  ))}
+                </select>
+                <p className="tarot-set-picker-description">
+                  {getCardSetDisplayDescription(activeCardSet, locale)}
+                </p>
+                <span>{messages.cardsInDeck(deckCardCount)}</span>
+              </div>
+            </MobilePopoverPortal>
           )}
         </div>
         {isDeckMoveMode && (
@@ -1671,35 +1772,42 @@ export function TarotStudio() {
                 </svg>
               </button>
               {isSpreadMenuOpen && (
-                <section
-                  id="spread-actions"
-                  className="tarot-spread-actions"
-                  role="dialog"
-                  aria-label={messages.popularSpreads}
+                <MobilePopoverPortal
+                  isMobileViewport={isMobileViewport}
+                  portalRoot={tarotAppRef.current}
                 >
-                  <span>{messages.chooseASpread}</span>
-                  <div>
-                    {availableSpreads.map((spread) => (
-                      <button
-                        key={spread.id}
-                        type="button"
-                        onClick={() => {
-                          dealSpread(spread);
-                          setIsSpreadMenuOpen(false);
-                          window.requestAnimationFrame(() =>
-                            canvasShellRef.current?.focus()
-                          );
-                        }}
-                        disabled={
-                          !isSceneLayoutReady || deckCount < spread.slots.length
-                        }
-                      >
-                        {messages.spreadLabels[spread.id][0]}
-                        <small>{messages.spreadLabels[spread.id][1]}</small>
-                      </button>
-                    ))}
-                  </div>
-                </section>
+                  <section
+                    ref={spreadPopoverRef}
+                    id="spread-actions"
+                    className="tarot-spread-actions tarot-mobile-popover"
+                    role="dialog"
+                    aria-label={messages.popularSpreads}
+                  >
+                    <span>{messages.chooseASpread}</span>
+                    <div>
+                      {availableSpreads.map((spread) => (
+                        <button
+                          key={spread.id}
+                          type="button"
+                          onClick={() => {
+                            dealSpread(spread);
+                            setIsSpreadMenuOpen(false);
+                            window.requestAnimationFrame(() =>
+                              canvasShellRef.current?.focus()
+                            );
+                          }}
+                          disabled={
+                            !isSceneLayoutReady ||
+                            deckCount < spread.slots.length
+                          }
+                        >
+                          {messages.spreadLabels[spread.id][0]}
+                          <small>{messages.spreadLabels[spread.id][1]}</small>
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                </MobilePopoverPortal>
               )}
             </div>
           )}
@@ -1745,14 +1853,19 @@ export function TarotStudio() {
             </svg>
           </button>
           {isArrangeMenuOpen && (
-            <div
-              id="arrange-actions"
-              className="tarot-arrange-popover"
-              role="dialog"
-              aria-label={messages.arrangeAndUndo}
+            <MobilePopoverPortal
+              isMobileViewport={isMobileViewport}
+              portalRoot={tarotAppRef.current}
             >
-              <p>{messages.tableActionsTitle}</p>
-              <div className="tarot-arrange-grid">
+              <div
+                ref={arrangePopoverRef}
+                id="arrange-actions"
+                className="tarot-arrange-popover tarot-mobile-popover"
+                role="dialog"
+                aria-label={messages.arrangeAndUndo}
+              >
+                <p>{messages.tableActionsTitle}</p>
+                <div className="tarot-arrange-grid">
                 {(
                   [
                     ["fan", ...messages.layouts.fan],
@@ -1816,38 +1929,52 @@ export function TarotStudio() {
                   <span>{messages.redo[0]}</span>
                   <small>{messages.redo[1]}</small>
                 </button>
+                  <button
+                    type="button"
+                    className="tarot-mobile-reset-action"
+                    onClick={() => {
+                      resetTable();
+                      closeArrangeMenu();
+                    }}
+                  >
+                    <span>{messages.resetTable}</span>
+                    <small>
+                      {messages.resetTableDescription(activeCardSet.cards.length)}
+                    </small>
+                  </button>
+                </div>
+                {activeCardSet.kind === "tarot" && (
+                  <section
+                    className="tarot-arrange-section"
+                    aria-label={messages.tarotCollectionActions}
+                  >
+                    <h3 className="tarot-arrange-section-title">
+                      {messages.tarotCollection}
+                    </h3>
+                    <div className="tarot-arrange-grid">
+                      {(
+                        ["all", "major", "minor", "court"] as const
+                      ).map((collection) => (
+                        <button
+                          key={collection}
+                          type="button"
+                          onClick={() => {
+                            showTarotCollection(collection);
+                            closeArrangeMenu();
+                          }}
+                          disabled={!isSceneLayoutReady}
+                        >
+                          <span>{messages.tarotCollections[collection][0]}</span>
+                          <small>
+                            {messages.tarotCollections[collection][1]}
+                          </small>
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                )}
               </div>
-              {activeCardSet.kind === "tarot" && (
-                <section
-                  className="tarot-arrange-section"
-                  aria-label={messages.tarotCollectionActions}
-                >
-                  <h3 className="tarot-arrange-section-title">
-                    {messages.tarotCollection}
-                  </h3>
-                  <div className="tarot-arrange-grid">
-                    {(
-                      ["all", "major", "minor", "court"] as const
-                    ).map((collection) => (
-                      <button
-                        key={collection}
-                        type="button"
-                        onClick={() => {
-                          showTarotCollection(collection);
-                          closeArrangeMenu();
-                        }}
-                        disabled={!isSceneLayoutReady}
-                      >
-                        <span>{messages.tarotCollections[collection][0]}</span>
-                        <small>
-                          {messages.tarotCollections[collection][1]}
-                        </small>
-                      </button>
-                    ))}
-                  </div>
-                </section>
-              )}
-            </div>
+            </MobilePopoverPortal>
           )}
         </div>
         <button
@@ -1900,38 +2027,87 @@ export function TarotStudio() {
               <path d="m8 10 4 4 4-4" />
             </svg>
           </button>
-          <div
-            id="zoom-actions"
-            className={`tarot-zoom-controls${isZoomMenuOpen ? " tarot-zoom-controls--open" : ""}`}
-            role={isZoomMenuOpen ? "dialog" : undefined}
-            aria-label={messages.zoom}
+          <MobilePopoverPortal
+            isMobileViewport={isMobileViewport}
+            portalRoot={tarotAppRef.current}
           >
-            <button
-              type="button"
-              aria-label={messages.zoomOut}
-              onClick={() => adjustViewZoom(-0.1)}
-              disabled={viewZoom <= MIN_VIEW_ZOOM}
+            <div
+              ref={zoomPopoverRef}
+              id="zoom-actions"
+              className={`tarot-zoom-controls tarot-mobile-popover${isZoomMenuOpen ? " tarot-zoom-controls--open" : ""}`}
+              role={isZoomMenuOpen ? "dialog" : undefined}
+              aria-label={messages.zoom}
             >
-              −
-            </button>
-            <button
-              type="button"
-              aria-label={messages.resetZoom}
-              title={messages.resetZoom}
-              onClick={() => setViewZoom(1)}
-            >
-              {Math.round(viewZoom * 100)}%
-            </button>
-            <button
-              type="button"
-              aria-label={messages.zoomIn}
-              onClick={() => adjustViewZoom(0.1)}
-              disabled={viewZoom >= MAX_VIEW_ZOOM}
-            >
-              +
-            </button>
-          </div>
+              <button
+                type="button"
+                aria-label={messages.zoomOut}
+                onClick={() => adjustViewZoom(-0.1)}
+                disabled={viewZoom <= MIN_VIEW_ZOOM}
+              >
+                −
+              </button>
+              <button
+                type="button"
+                aria-label={messages.resetZoom}
+                title={messages.resetZoom}
+                onClick={() => setViewZoom(1)}
+              >
+                {Math.round(viewZoom * 100)}%
+              </button>
+              <button
+                type="button"
+                aria-label={messages.zoomIn}
+                onClick={() => adjustViewZoom(0.1)}
+                disabled={viewZoom >= MAX_VIEW_ZOOM}
+              >
+                +
+              </button>
+            </div>
+          </MobilePopoverPortal>
         </div>
+        {isFullscreenAvailable && (
+          <button
+            type="button"
+            className="tarot-toolbar-trigger tarot-fullscreen-trigger"
+            aria-label={
+              isFullscreen
+                ? messages.exitFullscreen
+                : messages.enterFullscreen
+            }
+            title={
+              isFullscreen
+                ? messages.exitFullscreen
+                : messages.enterFullscreen
+            }
+            onClick={() => {
+              setIsDeckMenuOpen(false);
+              setIsZoomMenuOpen(false);
+              setIsSpreadMenuOpen(false);
+              setIsArrangeMenuOpen(false);
+              setIsConfigMenuOpen(false);
+              setIsLanguageMenuOpen(false);
+              setIsInspectorCollapsed(true);
+              toggleFullscreen();
+            }}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              {isFullscreen ? (
+                <>
+                  <path d="M9 4v5H4M15 4v5h5M9 20v-5H4M15 20v-5h5" />
+                </>
+              ) : (
+                <>
+                  <path d="M9 4H4v5M15 4h5v5M9 20H4v-5M15 20h5v-5" />
+                </>
+              )}
+            </svg>
+            <span>
+              {isFullscreen
+                ? messages.exitFullscreen
+                : messages.enterFullscreen}
+            </span>
+          </button>
+        )}
         <div className="tarot-config-menu" ref={configMenuRef}>
           <button
             ref={configMenuTriggerRef}
@@ -1962,64 +2138,72 @@ export function TarotStudio() {
             </svg>
           </button>
           {isConfigMenuOpen && (
-            <section
-              id="config-actions"
-              className="tarot-config-popover"
-              role="dialog"
-              aria-label={messages.configureTable}
+            <MobilePopoverPortal
+              isMobileViewport={isMobileViewport}
+              portalRoot={tarotAppRef.current}
             >
-              <h2 className="tarot-config-heading">{messages.configureTable}</h2>
-              <div className="tarot-config-section">
-                <h3 className="tarot-config-section-title">
-                  {messages.background}
-                </h3>
-                <div
-                  className="tarot-config-choice-grid"
-                  role="radiogroup"
-                  aria-label={messages.backgroundOptions}
-                >
-                  {SCENE_THEME_IDS.map((themeId) => (
-                    <button
-                      key={themeId}
-                      type="button"
-                      className="tarot-config-choice"
-                      role="radio"
-                      aria-checked={sceneSettings.themeId === themeId}
-                      data-scene-theme={themeId}
-                      data-scene-theme-option={themeId}
-                      tabIndex={sceneSettings.themeId === themeId ? 0 : -1}
-                      onKeyDown={(event) =>
-                        handleSceneThemeRadioKeyDown(event, themeId)
-                      }
-                      onClick={() => updateSceneTheme(themeId)}
-                    >
-                      <span>{sceneThemeLabels[themeId]}</span>
-                    </button>
-                  ))}
+              <section
+                ref={configPopoverRef}
+                id="config-actions"
+                className="tarot-config-popover tarot-mobile-popover"
+                role="dialog"
+                aria-label={messages.configureTable}
+              >
+                <h2 className="tarot-config-heading">
+                  {messages.configureTable}
+                </h2>
+                <div className="tarot-config-section">
+                  <h3 className="tarot-config-section-title">
+                    {messages.background}
+                  </h3>
+                  <div
+                    className="tarot-config-choice-grid"
+                    role="radiogroup"
+                    aria-label={messages.backgroundOptions}
+                  >
+                    {SCENE_THEME_IDS.map((themeId) => (
+                      <button
+                        key={themeId}
+                        type="button"
+                        className="tarot-config-choice"
+                        role="radio"
+                        aria-checked={sceneSettings.themeId === themeId}
+                        data-scene-theme={themeId}
+                        data-scene-theme-option={themeId}
+                        tabIndex={sceneSettings.themeId === themeId ? 0 : -1}
+                        onKeyDown={(event) =>
+                          handleSceneThemeRadioKeyDown(event, themeId)
+                        }
+                        onClick={() => updateSceneTheme(themeId)}
+                      >
+                        <span>{sceneThemeLabels[themeId]}</span>
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
-              <div className="tarot-config-section">
-                <h3 className="tarot-config-section-title">
-                  {messages.cardSounds}
-                </h3>
-                <button
-                  type="button"
-                  className="tarot-config-sound"
-                  role="switch"
-                  aria-checked={!areCardSoundsMuted}
-                  onClick={toggleCardSounds}
-                >
-                  <span>
+                <div className="tarot-config-section">
+                  <h3 className="tarot-config-section-title">
+                    {messages.cardSounds}
+                  </h3>
+                  <button
+                    type="button"
+                    className="tarot-config-sound"
+                    role="switch"
+                    aria-checked={!areCardSoundsMuted}
+                    onClick={toggleCardSounds}
+                  >
                     <span>
-                      {areCardSoundsMuted
-                        ? messages.cardSoundsOff
-                        : messages.cardSoundsOn}
+                      <span>
+                        {areCardSoundsMuted
+                          ? messages.cardSoundsOff
+                          : messages.cardSoundsOn}
+                      </span>
+                      <small>{messages.cardSoundsDescription}</small>
                     </span>
-                    <small>{messages.cardSoundsDescription}</small>
-                  </span>
-                </button>
-              </div>
-            </section>
+                  </button>
+                </div>
+              </section>
+            </MobilePopoverPortal>
           )}
         </div>
         <div className="tarot-language-menu" ref={languageMenuRef}>
@@ -2055,37 +2239,43 @@ export function TarotStudio() {
             </svg>
           </button>
           {isLanguageMenuOpen && (
-            <section
-              id="language-actions"
-              className="tarot-language-popover"
-              role="dialog"
-              aria-label={messages.chooseLanguage}
+            <MobilePopoverPortal
+              isMobileViewport={isMobileViewport}
+              portalRoot={tarotAppRef.current}
             >
-              <span>{messages.language}</span>
-              <div role="radiogroup" aria-label={messages.languageOptions}>
-                {LANGUAGE_OPTIONS.map((optionLocale) => {
-                  const optionMessages = getMessages(optionLocale);
+              <section
+                ref={languagePopoverRef}
+                id="language-actions"
+                className="tarot-language-popover tarot-mobile-popover"
+                role="dialog"
+                aria-label={messages.chooseLanguage}
+              >
+                <span>{messages.language}</span>
+                <div role="radiogroup" aria-label={messages.languageOptions}>
+                  {LANGUAGE_OPTIONS.map((optionLocale) => {
+                    const optionMessages = getMessages(optionLocale);
 
-                  return (
-                    <button
-                      key={optionLocale}
-                      type="button"
-                      role="radio"
-                      aria-checked={locale === optionLocale}
-                      data-locale-option={optionLocale}
-                      tabIndex={locale === optionLocale ? 0 : -1}
-                      onKeyDown={(event) =>
-                        handleLanguageRadioKeyDown(event, optionLocale)
-                      }
-                      onClick={() => updateLocale(optionLocale, true)}
-                    >
-                      <span>{optionMessages.localeShortLabel}</span>
-                      <small>{optionMessages.localeLabel}</small>
-                    </button>
-                  );
-                })}
-              </div>
-            </section>
+                    return (
+                      <button
+                        key={optionLocale}
+                        type="button"
+                        role="radio"
+                        aria-checked={locale === optionLocale}
+                        data-locale-option={optionLocale}
+                        tabIndex={locale === optionLocale ? 0 : -1}
+                        onKeyDown={(event) =>
+                          handleLanguageRadioKeyDown(event, optionLocale)
+                        }
+                        onClick={() => updateLocale(optionLocale, true)}
+                      >
+                        <span>{optionMessages.localeShortLabel}</span>
+                        <small>{optionMessages.localeLabel}</small>
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            </MobilePopoverPortal>
           )}
         </div>
         <div className="tarot-card-menu">
@@ -2125,11 +2315,16 @@ export function TarotStudio() {
             </svg>
           </button>
           {isInspectorOpen && (
-            <aside
-              id="selected-card-inspector"
-              className={`tarot-inspector${selectedCard?.faceUp ? " tarot-inspector--with-reading" : ""}`}
-              aria-label={messages.selectedCardControls(selectedTitle, true)}
+            <MobilePopoverPortal
+              isMobileViewport={isMobileViewport}
+              portalRoot={tarotAppRef.current}
             >
+              <aside
+                ref={inspectorPopoverRef}
+                id="selected-card-inspector"
+                className={`tarot-inspector tarot-mobile-popover${selectedCard?.faceUp ? " tarot-inspector--with-reading" : ""}`}
+                aria-label={messages.selectedCardControls(selectedTitle, true)}
+              >
               <div className="tarot-inspector-controls">
                 <div className="tarot-inspector-heading">
                   <p className="tarot-eyebrow">{messages.selectedCard}</p>
@@ -2263,7 +2458,8 @@ export function TarotStudio() {
                   )}
                 </section>
               )}
-            </aside>
+              </aside>
+            </MobilePopoverPortal>
           )}
         </div>
       </nav>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -76,6 +76,10 @@ const WHEEL_LAYER_THRESHOLD = 36;
 const DOCK_EDGE_REVEAL_DISTANCE = 52;
 const DOCK_HIDE_DELAY = 850;
 const DOCK_INITIAL_HIDE_DELAY = 1800;
+const MOBILE_VIEWPORT_QUERY =
+  "(max-width: 767px), ((pointer: coarse) and (max-height: 767px))";
+const MOBILE_DEFAULT_VIEW_ZOOM = 0.5;
+const DESKTOP_DEFAULT_VIEW_ZOOM = 1;
 const LANGUAGE_OPTIONS = ["en", "pt-BR"] as const satisfies readonly AppLocale[];
 const COURT_RANKS = new Set(["page", "knight", "queen", "king"]);
 
@@ -182,9 +186,7 @@ function useMobileViewport() {
   const [isMobileViewport, setIsMobileViewport] = useState(false);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia(
-      "(max-width: 767px), ((pointer: coarse) and (max-height: 767px))"
-    );
+    const mediaQuery = window.matchMedia(MOBILE_VIEWPORT_QUERY);
     const updateViewport = () => setIsMobileViewport(mediaQuery.matches);
 
     updateViewport();
@@ -195,6 +197,9 @@ function useMobileViewport() {
 
   return isMobileViewport;
 }
+
+const getDefaultViewZoom = (isMobileViewport: boolean) =>
+  isMobileViewport ? MOBILE_DEFAULT_VIEW_ZOOM : DESKTOP_DEFAULT_VIEW_ZOOM;
 
 function MobilePopoverPortal({
   children,
@@ -550,6 +555,7 @@ export function TarotStudio() {
     ...DEFAULT_SCENE_SETTINGS,
   }));
   const isMobileViewport = useMobileViewport();
+  const defaultViewZoom = getDefaultViewZoom(isMobileViewport);
 
   useEffect(() => {
     const updateFullscreenState = () => {
@@ -690,6 +696,12 @@ export function TarotStudio() {
       setSceneSettings(resolveSceneSettings(workspace.sceneSettings));
       setIsInspectorCollapsed(true);
       dispatch({ type: "restore", session: workspace.session });
+    } else {
+      setViewZoom(
+        getDefaultViewZoom(
+          window.matchMedia(MOBILE_VIEWPORT_QUERY).matches
+        )
+      );
     }
 
     setIsWorkspaceReady(true);
@@ -1169,11 +1181,11 @@ export function TarotStudio() {
     setIsDeckMoveMode(false);
     setIsInspectorCollapsed(true);
     setViewPan([0, 0]);
-    setViewZoom(1);
+    setViewZoom(defaultViewZoom);
     playCardSound("shuffle");
     dispatch({ type: "reset-table", cardSet: activeCardSet });
     window.requestAnimationFrame(() => canvasShellRef.current?.focus());
-  }, [activeCardSet, playCardSound]);
+  }, [activeCardSet, defaultViewZoom, playCardSound]);
 
   const showTarotCollection = useCallback(
     (collection: TarotCollectionId) => {
@@ -1510,7 +1522,7 @@ export function TarotStudio() {
 
     if (event.key === "0") {
       event.preventDefault();
-      setViewZoom(1);
+      setViewZoom(defaultViewZoom);
       setViewPan([0, 0]);
       return;
     }
@@ -1619,6 +1631,7 @@ export function TarotStudio() {
           session={session}
           reducedMotion={reducedMotion}
           sceneSettings={sceneSettings}
+          isMobileViewport={isMobileViewport}
           viewZoom={viewZoom}
           viewPan={viewPan}
           deckMoveMode={isDeckMoveMode}
@@ -1711,7 +1724,7 @@ export function TarotStudio() {
                     setActiveCardSetId(nextCardSet.id);
                     playCardSound("shuffle");
                     dispatch({ type: "new-shuffle", cardSet: nextCardSet });
-                    setViewZoom(1);
+                    setViewZoom(defaultViewZoom);
                     setViewPan([0, 0]);
                     setIsDeckMenuOpen(false);
                     window.requestAnimationFrame(() =>
@@ -2065,7 +2078,7 @@ export function TarotStudio() {
                 type="button"
                 aria-label={messages.resetZoom}
                 title={messages.resetZoom}
-                onClick={() => setViewZoom(1)}
+                onClick={() => setViewZoom(defaultViewZoom)}
               >
                 {Math.round(viewZoom * 100)}%
               </button>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -182,7 +182,9 @@ function useMobileViewport() {
   const [isMobileViewport, setIsMobileViewport] = useState(false);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const mediaQuery = window.matchMedia(
+      "(max-width: 767px), ((pointer: coarse) and (max-height: 767px))"
+    );
     const updateViewport = () => setIsMobileViewport(mediaQuery.matches);
 
     updateViewport();

--- a/src/components/tarot-studio/table-layout.ts
+++ b/src/components/tarot-studio/table-layout.ts
@@ -44,6 +44,7 @@ export type DeckPositionCandidate = {
     | "top-right"
     | "bottom-left"
     | "bottom-right"
+    | "bottom"
     | "left"
     | "right";
   position: TablePoint;
@@ -97,14 +98,16 @@ export function createSceneTableLayout({
   viewportWidth,
   viewportHeight,
   pixelWidth,
+  isMobileViewport,
   cardAspectRatio,
 }: {
   viewportWidth: number;
   viewportHeight: number;
   pixelWidth: number;
+  isMobileViewport?: boolean;
   cardAspectRatio: number;
 }): SceneTableLayout {
-  const isMobile = pixelWidth < 720;
+  const isMobile = isMobileViewport ?? pixelWidth < 720;
   const unscaledRequestedCardWidth = clamp(
     viewportWidth * (isMobile ? 0.66 : 0.36),
     isMobile ? 2.82 : 3.15,
@@ -190,11 +193,17 @@ export function createSceneTableLayout({
     worldPosition: [x, y],
   });
   const deckPositionCandidates: DeckPositionCandidate[] = [
-    createDeckCandidate(
-      "left",
-      tableLeft + deckWidth / 2 + deckSideInset,
-      viewportCenterY
-    ),
+    isMobile
+      ? createDeckCandidate(
+          "bottom",
+          centerX,
+          tableBottom + deckHeight / 2 + deckSideInset
+        )
+      : createDeckCandidate(
+          "left",
+          tableLeft + deckWidth / 2 + deckSideInset,
+          viewportCenterY
+        ),
     createDeckCandidate(
       "top-left",
       tableLeft + deckWidth / 2 + deckSideInset,
@@ -215,6 +224,15 @@ export function createSceneTableLayout({
       tableRight - deckWidth / 2 - deckSideInset,
       tableBottom + deckHeight / 2 + deckSideInset
     ),
+    ...(isMobile
+      ? [
+          createDeckCandidate(
+            "left",
+            tableLeft + deckWidth / 2 + deckSideInset,
+            viewportCenterY
+          ),
+        ]
+      : []),
     createDeckCandidate(
       "right",
       tableRight - deckWidth / 2 - deckSideInset,

--- a/src/components/tarot-studio/table-layout.ts
+++ b/src/components/tarot-studio/table-layout.ts
@@ -132,6 +132,8 @@ export function createSceneTableLayout({
     top: viewportHeight / 2,
     bottom: -viewportHeight / 2,
   };
+  const viewportCenterY =
+    (viewportBounds.top + viewportBounds.bottom) / 2;
   const centerX = (tableLeft + tableRight) / 2;
   const centerY = (tableBottom + tableTop) / 2;
   const halfWidth = Math.max((tableRight - tableLeft) / 2, cardWidth / 2);
@@ -189,6 +191,11 @@ export function createSceneTableLayout({
   });
   const deckPositionCandidates: DeckPositionCandidate[] = [
     createDeckCandidate(
+      "left",
+      tableLeft + deckWidth / 2 + deckSideInset,
+      viewportCenterY
+    ),
+    createDeckCandidate(
       "top-left",
       tableLeft + deckWidth / 2 + deckSideInset,
       tableTop - deckHeight / 2 - deckVerticalInset
@@ -209,14 +216,9 @@ export function createSceneTableLayout({
       tableBottom + deckHeight / 2 + deckSideInset
     ),
     createDeckCandidate(
-      "left",
-      tableLeft + deckWidth / 2 + deckSideInset,
-      centerY
-    ),
-    createDeckCandidate(
       "right",
       tableRight - deckWidth / 2 - deckSideInset,
-      centerY
+      viewportCenterY
     ),
   ];
   const defaultDeckPosition = deckPositionCandidates[0].position;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -23,6 +23,8 @@ type Messages = {
   zoomOut: string;
   resetZoom: string;
   zoomIn: string;
+  enterFullscreen: string;
+  exitFullscreen: string;
   cancelDeckMove: string;
   movingDeck: string;
   cancel: string;
@@ -117,6 +119,8 @@ const messages: Record<AppLocale, Messages> = {
     zoomOut: "Zoom out",
     resetZoom: "Reset table zoom",
     zoomIn: "Zoom in",
+    enterFullscreen: "Enter fullscreen",
+    exitFullscreen: "Exit fullscreen",
     cancelDeckMove: "Cancel deck move mode",
     movingDeck: "Moving deck",
     cancel: "Cancel",
@@ -232,6 +236,8 @@ const messages: Record<AppLocale, Messages> = {
     zoomOut: "Diminuir zoom",
     resetZoom: "Redefinir zoom da mesa",
     zoomIn: "Aumentar zoom",
+    enterFullscreen: "Entrar em tela cheia",
+    exitFullscreen: "Sair da tela cheia",
     cancelDeckMove: "Cancelar modo de mover baralho",
     movingDeck: "Movendo baralho",
     cancel: "Cancelar",


### PR DESCRIPTION
Mobile popovers now render in a viewport-safe layer inside the table in portrait and landscape, so deck, spread, arrange, zoom, configuration, language, and card panels stay visible above the dock. Every panel shares outside-tap, Escape, focus-return, safe-area, and internal-scrolling behavior.

The mobile dock adds a localized fullscreen toggle when the browser supports the Fullscreen API. Very narrow phones use a stable two-row dock to preserve 44px touch targets as table state changes, with Reset table available inside Arrange.

Fresh and reset mobile tables open at 50% zoom with the deck centered along the table's bottom edge, including phone landscape. Desktop decks keep their left-side placement at the screen's vertical midpoint; user-moved and spread-parked positions remain persisted.

## Why

Trigger-relative offsets made panels drift beyond the clipped canvas, while the smallest breakpoint reduced core controls below comfortable touch size. A shared mobile presentation and centered resting deck keep cards central without sacrificing usable controls.
