### PR TITLE
Deepen card physicality and reveal spread constellations

### DIFF
--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -39,7 +39,11 @@ import type {
 } from "@/types";
 import type { CardSoundPlayer } from "@/lib/card-sounds";
 import type { SceneTableLayout } from "./table-layout";
-import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
+import {
+  type CardPaperMotion,
+  CardPaperMaterial,
+  getPaperSeed,
+} from "./CardPaperMaterial";
 import { TAROT_SCENE_PALETTE } from "./theme";
 
 const DRAG_PLANE = new Plane(new Vector3(0, 0, 1), 0);
@@ -222,6 +226,7 @@ export function CardArtwork({
   paperSeed = 0,
   depthTest = true,
   depthWrite = true,
+  motionRef,
 }: {
   url: string;
   crop?: CardArtworkCrop;
@@ -233,10 +238,11 @@ export function CardArtwork({
   paperSeed?: number;
   depthTest?: boolean;
   depthWrite?: boolean;
+  motionRef?: MutableRefObject<CardPaperMotion>;
 }) {
   const texture = useTextureForCard(url);
   const geometry = useMemo(() => {
-    const nextGeometry = new PlaneGeometry(width, height);
+    const nextGeometry = new PlaneGeometry(width, height, 12, 18);
 
     if (crop) {
       const uvs = nextGeometry.attributes.uv;
@@ -271,6 +277,9 @@ export function CardArtwork({
         color="#fffdf7"
         roughness={0.9}
         paperSeed={paperSeed}
+        cardSize={[width, height]}
+        edgePatina={0.035}
+        motionRef={motionRef}
         toneMapped={false}
         depthTest={depthTest}
         depthWrite={depthWrite}
@@ -288,6 +297,7 @@ function CardFaceLayers({
   paperSeed,
   depthTest = true,
   depthWrite = true,
+  motionRef,
 }: {
   artworkUrl: string;
   artworkCrop?: CardArtworkCrop;
@@ -297,6 +307,7 @@ function CardFaceLayers({
   paperSeed: number;
   depthTest?: boolean;
   depthWrite?: boolean;
+  motionRef?: MutableRefObject<CardPaperMotion>;
 }) {
   const direction = reverse ? -1 : 1;
   const rotation: [number, number, number] | undefined = reverse
@@ -319,6 +330,7 @@ function CardFaceLayers({
         paperSeed={paperSeed}
         depthTest={depthTest}
         depthWrite={depthWrite}
+        motionRef={motionRef}
       />
     </Suspense>
   );
@@ -514,6 +526,7 @@ export const CardMesh = memo(function CardMesh({
   const cardHeight = layout.cardHeight;
   const frontTexture = definition.image.preview;
   const paperSeed = useMemo(() => getPaperSeed(card.id), [card.id]);
+  const paperMotionRef = useRef<CardPaperMotion>({ curlX: 0, curlY: 0 });
   const slabColor =
     card.zone === "deck"
       ? paperSeed > 0.66
@@ -1040,6 +1053,7 @@ export const CardMesh = memo(function CardMesh({
     let flipIsActive = false;
     let flipScaleX = 1;
     let flipScaleY = 1;
+    let flipSqueeze = 0;
 
     if (reducedMotion) {
       flippingCard.rotation.set(0, card.faceUp ? 0 : Math.PI, 0);
@@ -1056,6 +1070,7 @@ export const CardMesh = memo(function CardMesh({
           : 1 - Math.pow(-2 * progress + 2, 3) / 2;
 
       const squeeze = Math.sin(Math.PI * easedProgress);
+      flipSqueeze = squeeze;
 
       flipScaleX = Math.max(
         0.018,
@@ -1128,6 +1143,23 @@ export const CardMesh = memo(function CardMesh({
     const nextScale = reducedMotion
       ? scaleTarget
       : MathUtils.damp(group.scale.x, scaleTarget, 17, delta);
+    const curlXTarget = reducedMotion
+      ? 0
+      : moving
+        ? tiltYTarget * 0.036
+        : flipSqueeze * (card.faceUp ? 0.006 : -0.006);
+    const curlYTarget = reducedMotion
+      ? 0
+      : moving
+        ? -tiltXTarget * 0.03
+        : -flipSqueeze * 0.0035;
+    const paperMotion = paperMotionRef.current;
+    const nextCurlX = reducedMotion
+      ? 0
+      : MathUtils.damp(paperMotion.curlX, curlXTarget, 15, delta);
+    const nextCurlY = reducedMotion
+      ? 0
+      : MathUtils.damp(paperMotion.curlY, curlYTarget, 15, delta);
     const isLiftedDrag =
       (drag?.moved && drag.mode === "move") || Boolean(externalDrag);
     const expandsToCardThickness =
@@ -1190,6 +1222,8 @@ export const CardMesh = memo(function CardMesh({
       group.position.z = zTarget;
       group.scale.set(scaleTarget, scaleTarget, 1);
       flippingCard.scale.set(flipScaleX, flipScaleY, depthScaleTarget);
+      paperMotion.curlX = 0;
+      paperMotion.curlY = 0;
       if (drag?.mode === "move-deck") {
         setDeckPreview([
           positionXTarget - deckOffset[0],
@@ -1215,7 +1249,9 @@ export const CardMesh = memo(function CardMesh({
       Math.abs(nextY - positionYTarget) > 0.0008 ||
       Math.abs(nextZ - zTarget) > 0.0008 ||
       Math.abs(nextScale - scaleTarget) > 0.0008 ||
-      Math.abs(nextDepthScale - depthScaleTarget) > 0.0008;
+      Math.abs(nextDepthScale - depthScaleTarget) > 0.0008 ||
+      Math.abs(nextCurlX - curlXTarget) > 0.00008 ||
+      Math.abs(nextCurlY - curlYTarget) > 0.00008;
 
     group.rotation.x = nextTiltX;
     group.rotation.y = nextTiltY;
@@ -1225,6 +1261,8 @@ export const CardMesh = memo(function CardMesh({
     group.position.z = nextZ;
     group.scale.set(nextScale, nextScale, 1);
     flippingCard.scale.set(flipScaleX, flipScaleY, nextDepthScale);
+    paperMotion.curlX = nextCurlX;
+    paperMotion.curlY = nextCurlY;
 
     if (drag?.mode === "move-deck") {
       setDeckPreview([
@@ -1469,9 +1507,23 @@ export const CardMesh = memo(function CardMesh({
           renderOrder={0}
         >
           <CardPaperMaterial
+            attach="material-0"
             color={slabColor}
             roughness={0.94}
             paperSeed={paperSeed}
+            cardSize={[cardWidth, cardHeight]}
+            edgePatina={0.12}
+            motionRef={paperMotionRef}
+            depthTest
+          />
+          <CardPaperMaterial
+            attach="material-1"
+            color="#cdbd9e"
+            roughness={0.88}
+            paperSeed={paperSeed + 0.213}
+            cardSize={[cardWidth, cardHeight]}
+            edgePatina={0.3}
+            motionRef={paperMotionRef}
             depthTest
           />
         </mesh>
@@ -1482,6 +1534,7 @@ export const CardMesh = memo(function CardMesh({
             cardWidth={cardWidth}
             cardHeight={cardHeight}
             paperSeed={paperSeed}
+            motionRef={paperMotionRef}
             depthTest
           />
         )}
@@ -1491,6 +1544,7 @@ export const CardMesh = memo(function CardMesh({
           cardWidth={cardWidth}
           cardHeight={cardHeight}
           paperSeed={paperSeed + 0.417}
+          motionRef={paperMotionRef}
           depthTest
           reverse
         />

--- a/src/components/tarot-studio/CardPaperMaterial.tsx
+++ b/src/components/tarot-studio/CardPaperMaterial.tsx
@@ -1,11 +1,23 @@
 "use client";
 
-import { memo, useEffect, useMemo } from "react";
+import { useFrame } from "@react-three/fiber";
+import {
+  type MutableRefObject,
+  memo,
+  useEffect,
+  useMemo,
+} from "react";
 import {
   MeshStandardMaterial,
   type ColorRepresentation,
   type Texture,
+  Vector2,
 } from "three";
+
+export type CardPaperMotion = {
+  curlX: number;
+  curlY: number;
+};
 
 type CardPaperMaterialProps = {
   color: ColorRepresentation;
@@ -17,16 +29,40 @@ type CardPaperMaterialProps = {
   toneMapped?: boolean;
   depthTest?: boolean;
   depthWrite?: boolean;
+  attach?: string;
+  cardSize?: readonly [number, number];
+  edgePatina?: number;
+  motionRef?: MutableRefObject<CardPaperMotion>;
 };
+
+type PaperShader = {
+  uniforms: Record<string, { value: unknown }>;
+};
+
+const DEFAULT_CARD_SIZE = [1, 1] as const;
 
 const PAPER_VERTEX_DECLARATION = /* glsl */ `
 #include <common>
 varying vec3 vPaperPosition;
+varying float vPaperEdge;
+uniform vec2 uPaperCurl;
+uniform vec2 uPaperSize;
 `;
 
 const PAPER_VERTEX_POSITION = /* glsl */ `
 #include <begin_vertex>
 vPaperPosition = position;
+vec2 paperSize = max(uPaperSize, vec2(0.001));
+vec2 normalizedPaper = clamp(
+  position.xy / (paperSize * 0.5),
+  vec2(-1.0),
+  vec2(1.0)
+);
+vec2 paperCurve = pow(abs(normalizedPaper), vec2(2.35));
+transformed.z +=
+  uPaperCurl.x * (paperCurve.x - 0.26) +
+  uPaperCurl.y * (paperCurve.y - 0.26);
+vPaperEdge = max(abs(normalizedPaper.x), abs(normalizedPaper.y));
 `;
 
 const PAPER_FRAGMENT_DECLARATION = /* glsl */ `
@@ -34,7 +70,9 @@ const PAPER_FRAGMENT_DECLARATION = /* glsl */ `
 uniform float uPaperSeed;
 uniform float uPaperAlbedoVariation;
 uniform float uPaperRoughnessVariation;
+uniform float uPaperEdgePatina;
 varying vec3 vPaperPosition;
+varying float vPaperEdge;
 
 float paperHash(vec2 point) {
   return fract(
@@ -72,12 +110,24 @@ float paperGrain =
   (paperCloud - 0.5) * 0.62 +
   (paperFiber - 0.5) * 0.38;
 diffuseColor.rgb *= 1.0 + paperGrain * uPaperAlbedoVariation;
+float paperEdgeWear = smoothstep(0.78, 1.0, vPaperEdge);
+vec3 agedPaperEdge = vec3(0.76, 0.67, 0.52);
+diffuseColor.rgb = mix(
+  diffuseColor.rgb,
+  diffuseColor.rgb * agedPaperEdge,
+  paperEdgeWear * uPaperEdgePatina
+);
 `;
 
 const PAPER_FRAGMENT_ROUGHNESS = /* glsl */ `
 #include <roughnessmap_fragment>
 roughnessFactor = clamp(
   roughnessFactor + paperGrain * uPaperRoughnessVariation,
+  0.72,
+  1.0
+);
+roughnessFactor = clamp(
+  roughnessFactor + paperEdgeWear * uPaperEdgePatina * 0.12,
   0.72,
   1.0
 );
@@ -104,7 +154,13 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
   toneMapped = true,
   depthTest = true,
   depthWrite = true,
+  attach = "material",
+  cardSize = DEFAULT_CARD_SIZE,
+  edgePatina = 0.08,
+  motionRef,
 }: CardPaperMaterialProps) {
+  const cardWidth = cardSize[0];
+  const cardHeight = cardSize[1];
   const material = useMemo(() => {
     const nextMaterial = new MeshStandardMaterial({
       color,
@@ -125,6 +181,11 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
       shader.uniforms.uPaperRoughnessVariation = {
         value: roughnessVariation,
       };
+      shader.uniforms.uPaperCurl = { value: new Vector2() };
+      shader.uniforms.uPaperSize = {
+        value: new Vector2(cardWidth, cardHeight),
+      };
+      shader.uniforms.uPaperEdgePatina = { value: edgePatina };
       shader.vertexShader = shader.vertexShader
         .replace("#include <common>", PAPER_VERTEX_DECLARATION)
         .replace("#include <begin_vertex>", PAPER_VERTEX_POSITION);
@@ -135,23 +196,39 @@ export const CardPaperMaterial = memo(function CardPaperMaterial({
           "#include <roughnessmap_fragment>",
           PAPER_FRAGMENT_ROUGHNESS
         );
+      nextMaterial.userData.paperShader = shader;
     };
-    nextMaterial.customProgramCacheKey = () => "tarot-card-paper-v1";
+    nextMaterial.customProgramCacheKey = () => "tarot-card-paper-v2";
 
     return nextMaterial;
   }, [
     albedoVariation,
+    cardHeight,
+    cardWidth,
     color,
     depthTest,
     depthWrite,
     map,
     paperSeed,
+    edgePatina,
     roughness,
     roughnessVariation,
     toneMapped,
   ]);
 
+  useFrame(() => {
+    const shader = material.userData.paperShader as PaperShader | undefined;
+    const curl = shader?.uniforms.uPaperCurl?.value;
+
+    if (curl instanceof Vector2) {
+      curl.set(
+        motionRef?.current.curlX ?? 0,
+        motionRef?.current.curlY ?? 0
+      );
+    }
+  });
+
   useEffect(() => () => material.dispose(), [material]);
 
-  return <primitive object={material} attach="material" />;
+  return <primitive object={material} attach={attach} />;
 });

--- a/src/components/tarot-studio/ConstellationReading.tsx
+++ b/src/components/tarot-studio/ConstellationReading.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { useFrame, useThree } from "@react-three/fiber";
+import {
+  memo,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  InstancedMesh,
+  LineBasicMaterial,
+  MathUtils,
+  MeshBasicMaterial,
+  Object3D,
+} from "three";
+import { getSpreadById } from "@/lib/tarot-spreads";
+import type {
+  ActiveSpreadReading,
+  TableCard,
+} from "@/types";
+import type { SceneTableLayout } from "./table-layout";
+import type { ScenePalette } from "./theme";
+
+type ConstellationNode = {
+  cardId: string;
+  position: readonly [number, number, number];
+  ringScale: number;
+};
+
+type ConstellationEdge = {
+  fromCardId: string;
+  toCardId: string;
+  start: readonly [number, number, number];
+  end: readonly [number, number, number];
+};
+
+function createLineGeometry(edgeCount: number): BufferGeometry {
+  const geometry = new BufferGeometry();
+  geometry.setAttribute(
+    "position",
+    new Float32BufferAttribute(new Float32Array(edgeCount * 6), 3)
+  );
+  return geometry;
+}
+
+function updateLineGeometry(
+  geometry: BufferGeometry,
+  edges: ConstellationEdge[],
+  progress: number
+) {
+  const position = geometry.getAttribute("position");
+
+  edges.forEach((edge, index) => {
+    const offset = index * 2;
+    const endX = MathUtils.lerp(edge.start[0], edge.end[0], progress);
+    const endY = MathUtils.lerp(edge.start[1], edge.end[1], progress);
+    const endZ = MathUtils.lerp(edge.start[2], edge.end[2], progress);
+
+    position.setXYZ(offset, edge.start[0], edge.start[1], edge.start[2]);
+    position.setXYZ(offset + 1, endX, endY, endZ);
+  });
+  position.needsUpdate = true;
+}
+
+function getNodeKey(position: readonly [number, number, number]): string {
+  return `${position[0].toFixed(3)}:${position[1].toFixed(3)}`;
+}
+
+export const ConstellationReading = memo(function ConstellationReading({
+  activeSpread,
+  cards,
+  isMobileViewport,
+  layout,
+  palette,
+  reducedMotion,
+  selectedCardId,
+  surfaceZ,
+}: {
+  activeSpread: ActiveSpreadReading | null;
+  cards: TableCard[];
+  isMobileViewport: boolean;
+  layout: SceneTableLayout;
+  palette: ScenePalette;
+  reducedMotion: boolean;
+  selectedCardId: string | null;
+  surfaceZ: number;
+}) {
+  const invalidate = useThree((state) => state.invalidate);
+  const ringInstancesRef = useRef<InstancedMesh>(null);
+  const dotInstancesRef = useRef<InstancedMesh>(null);
+  const lineMaterialRef = useRef<LineBasicMaterial>(null);
+  const selectedLineMaterialRef = useRef<LineBasicMaterial>(null);
+  const ringMaterialRef = useRef<MeshBasicMaterial>(null);
+  const dotMaterialRef = useRef<MeshBasicMaterial>(null);
+  const selectedRingMaterialRef = useRef<MeshBasicMaterial>(null);
+  const revealProgressRef = useRef(reducedMotion ? 1 : 0);
+  const instanceDummy = useMemo(() => new Object3D(), []);
+  const cardById = useMemo(
+    () => new Map(cards.map((card) => [card.id, card])),
+    [cards]
+  );
+  const spread = activeSpread ? getSpreadById(activeSpread.id) : undefined;
+  const rawNodes = useMemo(
+    () =>
+      activeSpread?.cardIds.flatMap((cardId) => {
+        const card = cardById.get(cardId);
+
+        if (!card?.faceUp || card.zone !== "table") {
+          return [];
+        }
+
+        const [x, y] = layout.toWorld(card.position);
+        return [{ cardId, position: [x, y, surfaceZ] as const }];
+      }) ?? [],
+    [activeSpread, cardById, layout, surfaceZ]
+  );
+  const nodes = useMemo<ConstellationNode[]>(() => {
+    const duplicateCounts = new Map<string, number>();
+
+    return rawNodes.map((node) => {
+      const key = getNodeKey(node.position);
+      const duplicateIndex = duplicateCounts.get(key) ?? 0;
+      duplicateCounts.set(key, duplicateIndex + 1);
+
+      return {
+        ...node,
+        ringScale: 1 + duplicateIndex * 0.5,
+      };
+    });
+  }, [rawNodes]);
+  const nodeByCardId = useMemo(
+    () => new Map(nodes.map((node) => [node.cardId, node])),
+    [nodes]
+  );
+  const edges = useMemo<ConstellationEdge[]>(
+    () =>
+      spread?.connections.flatMap(([fromIndex, toIndex]) => {
+        if (!activeSpread) {
+          return [];
+        }
+
+        const fromCardId = activeSpread.cardIds[fromIndex];
+        const toCardId = activeSpread.cardIds[toIndex];
+        const from = nodeByCardId.get(fromCardId);
+        const to = nodeByCardId.get(toCardId);
+
+        if (!from || !to) {
+          return [];
+        }
+
+        const distance = Math.hypot(
+          to.position[0] - from.position[0],
+          to.position[1] - from.position[1]
+        );
+
+        return distance > 0.04
+          ? [
+              {
+                fromCardId,
+                toCardId,
+                start: from.position,
+                end: to.position,
+              },
+            ]
+          : [];
+      }) ?? [],
+    [activeSpread, nodeByCardId, spread]
+  );
+  const selectedEdges = useMemo(
+    () =>
+      selectedCardId
+        ? edges.filter(
+            (edge) =>
+              edge.fromCardId === selectedCardId ||
+              edge.toCardId === selectedCardId
+          )
+        : [],
+    [edges, selectedCardId]
+  );
+  const lineGeometry = useMemo(
+    () => createLineGeometry(edges.length),
+    [edges.length]
+  );
+  const selectedLineGeometry = useMemo(
+    () => createLineGeometry(selectedEdges.length),
+    [selectedEdges.length]
+  );
+  const selectedNode = selectedCardId
+    ? nodeByCardId.get(selectedCardId)
+    : undefined;
+  const selectedHaloRadius = layout.cardWidth * 0.56;
+  const revealSignature = nodes
+    .map(
+      (node) =>
+        `${node.cardId}:${node.position[0].toFixed(3)}:${node.position[1].toFixed(3)}`
+    )
+    .join("|");
+
+  useEffect(
+    () => () => {
+      lineGeometry.dispose();
+    },
+    [lineGeometry]
+  );
+  useEffect(
+    () => () => {
+      selectedLineGeometry.dispose();
+    },
+    [selectedLineGeometry]
+  );
+
+  useLayoutEffect(() => {
+    const ringInstances = ringInstancesRef.current;
+    const dotInstances = dotInstancesRef.current;
+
+    if (!ringInstances || !dotInstances) {
+      return;
+    }
+
+    nodes.forEach((node, index) => {
+      instanceDummy.position.set(...node.position);
+      instanceDummy.scale.setScalar(node.ringScale);
+      instanceDummy.rotation.set(0, 0, index * 0.37);
+      instanceDummy.updateMatrix();
+      ringInstances.setMatrixAt(index, instanceDummy.matrix);
+
+      instanceDummy.scale.setScalar(0.72);
+      instanceDummy.updateMatrix();
+      dotInstances.setMatrixAt(index, instanceDummy.matrix);
+    });
+    ringInstances.instanceMatrix.needsUpdate = true;
+    dotInstances.instanceMatrix.needsUpdate = true;
+    invalidate();
+  }, [instanceDummy, invalidate, nodes]);
+
+  useEffect(() => {
+    revealProgressRef.current = reducedMotion ? 1 : 0;
+    updateLineGeometry(
+      lineGeometry,
+      edges,
+      revealProgressRef.current
+    );
+    updateLineGeometry(
+      selectedLineGeometry,
+      selectedEdges,
+      revealProgressRef.current
+    );
+    invalidate();
+  }, [
+    edges,
+    invalidate,
+    lineGeometry,
+    reducedMotion,
+    revealSignature,
+    selectedEdges,
+    selectedLineGeometry,
+  ]);
+
+  useFrame((_, delta) => {
+    const currentProgress = revealProgressRef.current;
+    const nextProgress = reducedMotion
+      ? 1
+      : MathUtils.damp(currentProgress, 1, 7.5, delta);
+    const easedProgress = 1 - Math.pow(1 - nextProgress, 3);
+    const fade = MathUtils.smoothstep(nextProgress, 0, 0.72);
+
+    revealProgressRef.current = nextProgress;
+    updateLineGeometry(lineGeometry, edges, easedProgress);
+    updateLineGeometry(selectedLineGeometry, selectedEdges, easedProgress);
+
+    if (lineMaterialRef.current) {
+      lineMaterialRef.current.opacity =
+        fade * (isMobileViewport ? 0.15 : 0.21);
+    }
+    if (selectedLineMaterialRef.current) {
+      selectedLineMaterialRef.current.opacity = fade * 0.54;
+    }
+    if (ringMaterialRef.current) {
+      ringMaterialRef.current.opacity = fade * 0.42;
+    }
+    if (dotMaterialRef.current) {
+      dotMaterialRef.current.opacity = fade * 0.3;
+    }
+    if (selectedRingMaterialRef.current) {
+      selectedRingMaterialRef.current.opacity = fade * 0.68;
+    }
+
+    if (Math.abs(1 - nextProgress) > 0.001) {
+      invalidate();
+    }
+  });
+
+  if (!activeSpread || !spread || nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <group renderOrder={2}>
+      <lineSegments
+        geometry={lineGeometry}
+        frustumCulled={false}
+        renderOrder={2}
+        raycast={() => undefined}
+      >
+        <lineBasicMaterial
+          ref={lineMaterialRef}
+          color={palette.celestialGold}
+          depthTest
+          depthWrite={false}
+          opacity={0}
+          toneMapped={false}
+          transparent
+        />
+      </lineSegments>
+      <lineSegments
+        geometry={selectedLineGeometry}
+        frustumCulled={false}
+        renderOrder={3}
+        raycast={() => undefined}
+      >
+        <lineBasicMaterial
+          ref={selectedLineMaterialRef}
+          color={palette.fillLight}
+          depthTest
+          depthWrite={false}
+          opacity={0}
+          toneMapped={false}
+          transparent
+        />
+      </lineSegments>
+      <instancedMesh
+        ref={ringInstancesRef}
+        args={[undefined, undefined, nodes.length]}
+        frustumCulled={false}
+        renderOrder={3}
+        raycast={() => undefined}
+      >
+        <ringGeometry args={[0.034, 0.048, 28]} />
+        <meshBasicMaterial
+          ref={ringMaterialRef}
+          color={palette.celestialGold}
+          depthTest
+          depthWrite={false}
+          opacity={0}
+          toneMapped={false}
+          transparent
+        />
+      </instancedMesh>
+      <instancedMesh
+        ref={dotInstancesRef}
+        args={[undefined, undefined, nodes.length]}
+        frustumCulled={false}
+        renderOrder={3}
+        raycast={() => undefined}
+      >
+        <circleGeometry args={[0.019, 18]} />
+        <meshBasicMaterial
+          ref={dotMaterialRef}
+          color={palette.fillLight}
+          depthTest
+          depthWrite={false}
+          opacity={0}
+          toneMapped={false}
+          transparent
+        />
+      </instancedMesh>
+      {selectedNode ? (
+        <mesh
+          position={selectedNode.position}
+          renderOrder={4}
+          scale={Math.min(1.24, selectedNode.ringScale)}
+          raycast={() => undefined}
+        >
+          <ringGeometry
+            args={[
+              selectedHaloRadius,
+              selectedHaloRadius + 0.012,
+              72,
+            ]}
+          />
+          <meshBasicMaterial
+            ref={selectedRingMaterialRef}
+            color={palette.fillLight}
+            depthTest
+            depthWrite={false}
+            opacity={0}
+            toneMapped={false}
+            transparent
+          />
+        </mesh>
+      ) : null}
+    </group>
+  );
+});

--- a/src/components/tarot-studio/ConstellationReading.tsx
+++ b/src/components/tarot-studio/ConstellationReading.tsx
@@ -10,14 +10,20 @@ import {
 } from "react";
 import {
   BufferGeometry,
+  CanvasTexture,
   Float32BufferAttribute,
   InstancedMesh,
+  LinearFilter,
   LineBasicMaterial,
   MathUtils,
   MeshBasicMaterial,
   Object3D,
+  SRGBColorSpace,
 } from "three";
-import { getSpreadById } from "@/lib/tarot-spreads";
+import {
+  getSpreadById,
+  type SpreadRelationshipId,
+} from "@/lib/tarot-spreads";
 import type {
   ActiveSpreadReading,
   TableCard,
@@ -36,7 +42,153 @@ type ConstellationEdge = {
   toCardId: string;
   start: readonly [number, number, number];
   end: readonly [number, number, number];
+  relationship?: SpreadRelationshipId;
+  label?: string;
+  labelSide: -1 | 1;
 };
+
+type RelationshipLabelPlacement = {
+  edge: ConstellationEdge;
+  key: string;
+  label: string;
+  position: readonly [number, number, number];
+  selected: boolean;
+};
+
+type RelationshipLabelTexture = {
+  aspect: number;
+  texture: CanvasTexture;
+};
+
+function traceRoundedRectangle(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+) {
+  const resolvedRadius = Math.min(radius, width / 2, height / 2);
+
+  context.beginPath();
+  context.moveTo(x + resolvedRadius, y);
+  context.lineTo(x + width - resolvedRadius, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + resolvedRadius);
+  context.lineTo(x + width, y + height - resolvedRadius);
+  context.quadraticCurveTo(
+    x + width,
+    y + height,
+    x + width - resolvedRadius,
+    y + height
+  );
+  context.lineTo(x + resolvedRadius, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - resolvedRadius);
+  context.lineTo(x, y + resolvedRadius);
+  context.quadraticCurveTo(x, y, x + resolvedRadius, y);
+  context.closePath();
+}
+
+function createRelationshipLabelTexture(
+  label: string,
+  palette: ScenePalette
+): RelationshipLabelTexture | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    return null;
+  }
+
+  const font = 'italic 500 38px "Iowan Old Style", Baskerville, Georgia, serif';
+  const horizontalPadding = 34;
+  const height = 88;
+  context.font = font;
+  const measuredWidth = Math.ceil(context.measureText(label).width);
+  canvas.width = measuredWidth + horizontalPadding * 2;
+  canvas.height = height;
+
+  context.font = font;
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.globalAlpha = 0.88;
+  context.fillStyle = palette.tableEmissive;
+  traceRoundedRectangle(context, 2, 7, canvas.width - 4, height - 14, 24);
+  context.fill();
+  context.globalAlpha = 0.5;
+  context.strokeStyle = palette.celestialGold;
+  context.lineWidth = 1.5;
+  context.stroke();
+  context.globalAlpha = 1;
+  context.fillStyle = palette.celestialGold;
+  context.fillText(label, canvas.width / 2, height / 2 + 1);
+
+  const texture = new CanvasTexture(canvas);
+  texture.colorSpace = SRGBColorSpace;
+  texture.generateMipmaps = false;
+  texture.magFilter = LinearFilter;
+  texture.minFilter = LinearFilter;
+  texture.name = `spread-relationship:${label}`;
+  texture.needsUpdate = true;
+
+  return {
+    aspect: canvas.width / canvas.height,
+    texture,
+  };
+}
+
+const RelationshipLabel = memo(function RelationshipLabel({
+  label,
+  materialRef,
+  palette,
+  position,
+  height,
+}: {
+  label: string;
+  materialRef: (material: MeshBasicMaterial | null) => void;
+  palette: ScenePalette;
+  position: readonly [number, number, number];
+  height: number;
+}) {
+  const labelTexture = useMemo(
+    () => createRelationshipLabelTexture(label, palette),
+    [label, palette]
+  );
+
+  useEffect(
+    () => () => {
+      labelTexture?.texture.dispose();
+    },
+    [labelTexture]
+  );
+
+  if (!labelTexture) {
+    return null;
+  }
+
+  return (
+    <mesh
+      position={position}
+      renderOrder={4}
+      raycast={() => undefined}
+    >
+      <planeGeometry args={[height * labelTexture.aspect, height]} />
+      <meshBasicMaterial
+        ref={materialRef}
+        alphaTest={0.015}
+        depthTest
+        depthWrite={false}
+        map={labelTexture.texture}
+        opacity={0}
+        toneMapped={false}
+        transparent
+      />
+    </mesh>
+  );
+});
 
 function createLineGeometry(edgeCount: number): BufferGeometry {
   const geometry = new BufferGeometry();
@@ -77,6 +229,7 @@ export const ConstellationReading = memo(function ConstellationReading({
   layout,
   palette,
   reducedMotion,
+  relationshipLabels,
   selectedCardId,
   surfaceZ,
 }: {
@@ -86,6 +239,7 @@ export const ConstellationReading = memo(function ConstellationReading({
   layout: SceneTableLayout;
   palette: ScenePalette;
   reducedMotion: boolean;
+  relationshipLabels: Readonly<Record<SpreadRelationshipId, string>>;
   selectedCardId: string | null;
   surfaceZ: number;
 }) {
@@ -97,6 +251,7 @@ export const ConstellationReading = memo(function ConstellationReading({
   const ringMaterialRef = useRef<MeshBasicMaterial>(null);
   const dotMaterialRef = useRef<MeshBasicMaterial>(null);
   const selectedRingMaterialRef = useRef<MeshBasicMaterial>(null);
+  const labelMaterialRefs = useRef<Array<MeshBasicMaterial | null>>([]);
   const revealProgressRef = useRef(reducedMotion ? 1 : 0);
   const instanceDummy = useMemo(() => new Object3D(), []);
   const cardById = useMemo(
@@ -138,13 +293,13 @@ export const ConstellationReading = memo(function ConstellationReading({
   );
   const edges = useMemo<ConstellationEdge[]>(
     () =>
-      spread?.connections.flatMap(([fromIndex, toIndex]) => {
+      spread?.connections.flatMap((connection) => {
         if (!activeSpread) {
           return [];
         }
 
-        const fromCardId = activeSpread.cardIds[fromIndex];
-        const toCardId = activeSpread.cardIds[toIndex];
+        const fromCardId = activeSpread.cardIds[connection.from];
+        const toCardId = activeSpread.cardIds[connection.to];
         const from = nodeByCardId.get(fromCardId);
         const to = nodeByCardId.get(toCardId);
 
@@ -164,11 +319,16 @@ export const ConstellationReading = memo(function ConstellationReading({
                 toCardId,
                 start: from.position,
                 end: to.position,
+                relationship: connection.relationship,
+                label: connection.relationship
+                  ? relationshipLabels[connection.relationship]
+                  : undefined,
+                labelSide: connection.labelSide ?? 1,
               },
             ]
           : [];
       }) ?? [],
-    [activeSpread, nodeByCardId, spread]
+    [activeSpread, nodeByCardId, relationshipLabels, spread]
   );
   const selectedEdges = useMemo(
     () =>
@@ -193,6 +353,89 @@ export const ConstellationReading = memo(function ConstellationReading({
     ? nodeByCardId.get(selectedCardId)
     : undefined;
   const selectedHaloRadius = layout.cardWidth * 0.56;
+  const relationshipLabelHeight =
+    layout.cardWidth * (isMobileViewport ? 0.17 : 0.115);
+  const visibleRelationshipLabels = useMemo<
+    RelationshipLabelPlacement[]
+  >(() => {
+    const labelledEdges = edges
+      .filter(
+        (edge): edge is ConstellationEdge & { label: string } =>
+          Boolean(edge.label)
+      )
+      .map((edge) => ({
+        edge,
+        selected:
+          edge.fromCardId === selectedCardId ||
+          edge.toCardId === selectedCardId,
+      }))
+      .sort((first, second) => Number(second.selected) - Number(first.selected));
+    const candidates = isMobileViewport
+      ? labelledEdges.filter((candidate) => candidate.selected).slice(0, 2)
+      : labelledEdges;
+    const accepted: RelationshipLabelPlacement[] = [];
+
+    candidates.forEach(({ edge, selected }) => {
+      const deltaX = edge.end[0] - edge.start[0];
+      const deltaY = edge.end[1] - edge.start[1];
+      const distance = Math.hypot(deltaX, deltaY);
+
+      if (distance < layout.cardWidth * 0.24) {
+        return;
+      }
+
+      const normalX = -deltaY / distance;
+      const normalY = deltaX / distance;
+      const approximateLabelWidth = relationshipLabelHeight * MathUtils.clamp(
+        2.8 + edge.label.length * 0.115,
+        3.4,
+        6.6
+      );
+      const clearGap = distance - layout.cardWidth * 1.08;
+      const crowded = clearGap < approximateLabelWidth;
+      const cardClearance =
+        Math.abs(normalX) * (layout.cardWidth / 2) +
+        Math.abs(normalY) * (layout.cardHeight / 2);
+      const offset = crowded
+        ? cardClearance + relationshipLabelHeight * 0.9
+        : relationshipLabelHeight * 0.72;
+      const midpointX = (edge.start[0] + edge.end[0]) / 2;
+      const midpointY = (edge.start[1] + edge.end[1]) / 2;
+      const position = [
+        midpointX + normalX * offset * edge.labelSide,
+        midpointY + normalY * offset * edge.labelSide,
+        surfaceZ + 0.0015,
+      ] as const;
+      const collidesWithAccepted = accepted.some((placement) => {
+        const labelDistance = Math.hypot(
+          placement.position[0] - position[0],
+          placement.position[1] - position[1]
+        );
+
+        return labelDistance < layout.cardWidth * 0.38;
+      });
+
+      if (!collidesWithAccepted) {
+        accepted.push({
+          edge,
+          key: `${edge.fromCardId}:${edge.toCardId}:${edge.relationship}`,
+          label: edge.label,
+          position,
+          selected,
+        });
+      }
+    });
+
+    return accepted;
+  }, [
+    edges,
+    isMobileViewport,
+    layout.cardHeight,
+    layout.cardWidth,
+    relationshipLabelHeight,
+    selectedCardId,
+    surfaceZ,
+  ]);
   const revealSignature = nodes
     .map(
       (node) =>
@@ -244,11 +487,6 @@ export const ConstellationReading = memo(function ConstellationReading({
       edges,
       revealProgressRef.current
     );
-    updateLineGeometry(
-      selectedLineGeometry,
-      selectedEdges,
-      revealProgressRef.current
-    );
     invalidate();
   }, [
     edges,
@@ -256,9 +494,26 @@ export const ConstellationReading = memo(function ConstellationReading({
     lineGeometry,
     reducedMotion,
     revealSignature,
+  ]);
+
+  useEffect(() => {
+    const progress = revealProgressRef.current;
+    const easedProgress = 1 - Math.pow(1 - progress, 3);
+    updateLineGeometry(
+      selectedLineGeometry,
+      selectedEdges,
+      easedProgress
+    );
+    invalidate();
+  }, [
+    invalidate,
     selectedEdges,
     selectedLineGeometry,
   ]);
+
+  useEffect(() => {
+    labelMaterialRefs.current.length = visibleRelationshipLabels.length;
+  }, [visibleRelationshipLabels.length]);
 
   useFrame((_, delta) => {
     const currentProgress = revealProgressRef.current;
@@ -267,6 +522,7 @@ export const ConstellationReading = memo(function ConstellationReading({
       : MathUtils.damp(currentProgress, 1, 7.5, delta);
     const easedProgress = 1 - Math.pow(1 - nextProgress, 3);
     const fade = MathUtils.smoothstep(nextProgress, 0, 0.72);
+    const labelFade = MathUtils.smoothstep(nextProgress, 0.58, 0.9);
 
     revealProgressRef.current = nextProgress;
     updateLineGeometry(lineGeometry, edges, easedProgress);
@@ -288,6 +544,15 @@ export const ConstellationReading = memo(function ConstellationReading({
     if (selectedRingMaterialRef.current) {
       selectedRingMaterialRef.current.opacity = fade * 0.68;
     }
+    visibleRelationshipLabels.forEach((placement, index) => {
+      const material = labelMaterialRefs.current[index];
+
+      if (material) {
+        material.opacity =
+          labelFade *
+          (placement.selected ? 1 : isMobileViewport ? 0.78 : 0.86);
+      }
+    });
 
     if (Math.abs(1 - nextProgress) > 0.001) {
       invalidate();
@@ -332,6 +597,18 @@ export const ConstellationReading = memo(function ConstellationReading({
           transparent
         />
       </lineSegments>
+      {visibleRelationshipLabels.map((placement, index) => (
+        <RelationshipLabel
+          key={placement.key}
+          height={relationshipLabelHeight}
+          label={placement.label}
+          materialRef={(material) => {
+            labelMaterialRefs.current[index] = material;
+          }}
+          palette={palette}
+          position={placement.position}
+        />
+      ))}
       <instancedMesh
         ref={ringInstancesRef}
         args={[undefined, undefined, nodes.length]}

--- a/src/components/tarot-studio/TableClothMaterial.tsx
+++ b/src/components/tarot-studio/TableClothMaterial.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { memo, useEffect, useMemo } from "react";
+import {
+  Color,
+  MeshStandardMaterial,
+  type ColorRepresentation,
+} from "three";
+
+const CLOTH_VERTEX_DECLARATION = /* glsl */ `
+#include <common>
+varying vec3 vClothPosition;
+`;
+
+const CLOTH_VERTEX_POSITION = /* glsl */ `
+#include <begin_vertex>
+vClothPosition = position;
+`;
+
+const CLOTH_FRAGMENT_DECLARATION = /* glsl */ `
+#include <common>
+varying vec3 vClothPosition;
+
+float clothHash(vec2 point) {
+  return fract(sin(dot(point, vec2(41.7, 289.1))) * 43758.5453);
+}
+
+float clothNoise(vec2 point) {
+  vec2 cell = floor(point);
+  vec2 offset = fract(point);
+  vec2 blend = offset * offset * (3.0 - 2.0 * offset);
+
+  return mix(
+    mix(clothHash(cell), clothHash(cell + vec2(1.0, 0.0)), blend.x),
+    mix(
+      clothHash(cell + vec2(0.0, 1.0)),
+      clothHash(cell + vec2(1.0, 1.0)),
+      blend.x
+    ),
+    blend.y
+  );
+}
+`;
+
+const CLOTH_FRAGMENT_COLOR = /* glsl */ `
+#include <map_fragment>
+vec2 clothPoint = vClothPosition.xy;
+float clothWarp = sin(clothPoint.x * 34.0) * 0.5 + 0.5;
+float clothWeft = sin(clothPoint.y * 39.0 + 0.72) * 0.5 + 0.5;
+float clothNap = clothNoise(clothPoint * 7.0);
+float clothFiber = (clothWarp * clothWeft - 0.25) * 0.034;
+float clothCloud = (clothNap - 0.5) * 0.024;
+diffuseColor.rgb *= 1.0 + clothFiber + clothCloud;
+`;
+
+const CLOTH_FRAGMENT_ROUGHNESS = /* glsl */ `
+#include <roughnessmap_fragment>
+roughnessFactor = clamp(
+  roughnessFactor + (clothNap - 0.5) * 0.055,
+  0.88,
+  1.0
+);
+`;
+
+export const TableClothMaterial = memo(function TableClothMaterial({
+  color,
+  emissive,
+}: {
+  color: ColorRepresentation;
+  emissive: ColorRepresentation;
+}) {
+  const material = useMemo(() => {
+    const nextMaterial = new MeshStandardMaterial({
+      color,
+      emissive: new Color(emissive),
+      emissiveIntensity: 0.16,
+      metalness: 0,
+      roughness: 0.965,
+    });
+
+    nextMaterial.name = "tarot-table-cloth";
+    nextMaterial.onBeforeCompile = (shader) => {
+      shader.vertexShader = shader.vertexShader
+        .replace("#include <common>", CLOTH_VERTEX_DECLARATION)
+        .replace("#include <begin_vertex>", CLOTH_VERTEX_POSITION);
+      shader.fragmentShader = shader.fragmentShader
+        .replace("#include <common>", CLOTH_FRAGMENT_DECLARATION)
+        .replace("#include <map_fragment>", CLOTH_FRAGMENT_COLOR)
+        .replace(
+          "#include <roughnessmap_fragment>",
+          CLOTH_FRAGMENT_ROUGHNESS
+        );
+    };
+    nextMaterial.customProgramCacheKey = () => "tarot-table-cloth-v1";
+    return nextMaterial;
+  }, [color, emissive]);
+
+  useEffect(() => () => material.dispose(), [material]);
+
+  return <primitive object={material} attach="material" />;
+});

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -54,6 +54,7 @@ import {
 } from "./CardMesh";
 import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
 import { TableClothMaterial } from "./TableClothMaterial";
+import { ConstellationReading } from "./ConstellationReading";
 import { getTableCardRestingHeights } from "./card-stacking";
 import {
   createSceneTableLayout,
@@ -1809,6 +1810,16 @@ function TarotTable({
         dragBounds={layout.dragBounds}
         reducedMotion={reducedMotion}
         onSelect={handleTableSelect}
+      />
+      <ConstellationReading
+        activeSpread={session.activeSpread}
+        cards={tableCards}
+        isMobileViewport={isMobileViewport}
+        layout={layout}
+        palette={palette}
+        reducedMotion={reducedMotion}
+        selectedCardId={session.selectedCardId}
+        surfaceZ={TABLE_SURFACE_Z + 0.006}
       />
       <Suspense fallback={null}>
         <PhysicalDeck

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -53,6 +53,7 @@ import {
   type ExternalCardDrag,
 } from "./CardMesh";
 import { CardPaperMaterial, getPaperSeed } from "./CardPaperMaterial";
+import { TableClothMaterial } from "./TableClothMaterial";
 import { getTableCardRestingHeights } from "./card-stacking";
 import {
   createSceneTableLayout,
@@ -1324,9 +1325,21 @@ function PhysicalDeck({
         renderOrder={DECK_CARD_RENDER_ORDER}
       >
         <CardPaperMaterial
+          attach="material-0"
           color="#e8dcc5"
           roughness={0.94}
           paperSeed={getPaperSeed(`${backUrl}:deck`)}
+          cardSize={[width, height]}
+          edgePatina={0.12}
+          depthTest
+        />
+        <CardPaperMaterial
+          attach="material-1"
+          color="#c9b796"
+          roughness={0.88}
+          paperSeed={getPaperSeed(`${backUrl}:deck-edge`)}
+          cardSize={[width, height]}
+          edgePatina={0.34}
           depthTest
         />
       </instancedMesh>
@@ -1342,6 +1355,8 @@ function PhysicalDeck({
           color="#fffdf7"
           roughness={0.9}
           paperSeed={getPaperSeed(`${backUrl}:back`)}
+          cardSize={[Math.max(0.16, width - frameInset), Math.max(0.26, height - frameInset)]}
+          edgePatina={0.035}
           toneMapped={false}
           depthTest
         />
@@ -1439,12 +1454,9 @@ function TableSurface({
         onPointerDown={() => onSelect(null)}
       >
         <planeGeometry args={[visibleWidth, visibleHeight]} />
-        <meshStandardMaterial
+        <TableClothMaterial
           color={palette.table}
-          roughness={0.94}
-          metalness={0.012}
-          emissive={palette.table}
-          emissiveIntensity={0.46}
+          emissive={palette.tableEmissive}
         />
       </mesh>
       <group position={[0, 0, TABLE_SURFACE_Z + 0.002]} renderOrder={1}>

--- a/src/components/tarot-studio/TarotScene.tsx
+++ b/src/components/tarot-studio/TarotScene.tsx
@@ -46,6 +46,7 @@ import type {
 import { getCardStackOffset } from "@/lib/card-stack-layout";
 import { getDeckCards } from "@/lib/tarot-session";
 import type { CardSoundPlayer } from "@/lib/card-sounds";
+import type { SpreadRelationshipId } from "@/lib/tarot-spreads";
 import {
   CARD_THICKNESS,
   CardMesh,
@@ -521,6 +522,9 @@ type TarotSceneProps = {
    */
   viewPan?: TablePoint;
   deckMoveMode: boolean;
+  spreadRelationshipLabels: Readonly<
+    Record<SpreadRelationshipId, string>
+  >;
   onLayoutChange: (layout: SceneTableLayout) => void;
   onSelect: (cardId: string | null) => void;
   onDraw: (
@@ -1612,6 +1616,7 @@ function TarotTable({
   viewZoom,
   viewPan,
   deckMoveMode,
+  spreadRelationshipLabels,
   onSelect,
   onDraw,
   onMoveDeck,
@@ -1819,6 +1824,7 @@ function TarotTable({
         palette={palette}
         reducedMotion={reducedMotion}
         selectedCardId={session.selectedCardId}
+        relationshipLabels={spreadRelationshipLabels}
         surfaceZ={TABLE_SURFACE_Z + 0.006}
       />
       <Suspense fallback={null}>

--- a/src/components/tarot-studio/TarotStudio.tsx
+++ b/src/components/tarot-studio/TarotStudio.tsx
@@ -1639,6 +1639,7 @@ export function TarotStudio() {
           viewZoom={viewZoom}
           viewPan={viewPan}
           deckMoveMode={isDeckMoveMode}
+          spreadRelationshipLabels={messages.spreadRelationshipLabels}
           onLayoutChange={handleLayoutChange}
           onSelect={handleSelect}
           onDraw={handleDraw}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,5 +1,5 @@
 import type { AppLocale } from "./locale";
-import type { CardSpreadId } from "@/lib/tarot-spreads";
+import type { CardSpreadId } from "@/types";
 
 type CardCategory = "lenormand" | "major" | "minor";
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,5 +1,6 @@
 import type { AppLocale } from "./locale";
 import type { CardSpreadId } from "@/types";
+import type { SpreadRelationshipId } from "@/lib/tarot-spreads";
 
 type CardCategory = "lenormand" | "major" | "minor";
 
@@ -94,6 +95,9 @@ type Messages = {
   emptyDeck: string;
   liveStatus: (deck: Count, table: Count) => string;
   spreadLabels: Readonly<Record<CardSpreadId, [string, string]>>;
+  spreadRelationshipLabels: Readonly<
+    Record<SpreadRelationshipId, string>
+  >;
 };
 
 const cardNoun = (count: number) => (count === 1 ? "card" : "cards");
@@ -218,6 +222,31 @@ const messages: Record<AppLocale, Messages> = {
       "lenormand-portrait": ["Portrait", "9 cards"],
       "lenormand-grand-tableau": ["Grand Tableau", "36 cards"],
     },
+    spreadRelationshipLabels: {
+      "shapes-present": "shapes the present",
+      "guides-future": "guides the future",
+      "arrives-now": "arrives in the now",
+      "reveals-hidden": "reveals the hidden",
+      "meets-obstacle": "meets the obstacle",
+      "draws-support": "draws on support",
+      "informs-counsel": "informs the counsel",
+      "guides-outcome": "guides the outcome",
+      "crowns-present": "crowns the present",
+      "roots-present": "roots the present",
+      "releases-past": "releases the past",
+      "opens-future": "opens the future",
+      "future-meets-context": "future meets context",
+      "self-meets-context": "self meets context",
+      "context-shapes-hopes": "context shapes hopes",
+      "hopes-guide-outcome": "hopes guide outcome",
+      "sets-scene": "sets the scene",
+      "centers-matter": "centers the matter",
+      "shows-turn": "shows the turn",
+      "shows-outcome": "shows the outcome",
+      "guides-view": "guides the view",
+      "frames-past": "frames the past",
+      "grounds-reading": "grounds the reading",
+    },
   },
   "pt-BR": {
     localeLabel: "Português (Brasil)",
@@ -334,6 +363,31 @@ const messages: Record<AppLocale, Messages> = {
       "lenormand-five-card": ["Linha de cinco cartas", "5 cartas"],
       "lenormand-portrait": ["Retrato", "9 cartas"],
       "lenormand-grand-tableau": ["Grande Tableau", "36 cartas"],
+    },
+    spreadRelationshipLabels: {
+      "shapes-present": "molda o presente",
+      "guides-future": "guia o futuro",
+      "arrives-now": "chega ao agora",
+      "reveals-hidden": "revela o oculto",
+      "meets-obstacle": "encontra o obstáculo",
+      "draws-support": "busca apoio",
+      "informs-counsel": "orienta o conselho",
+      "guides-outcome": "guia o desfecho",
+      "crowns-present": "coroa o presente",
+      "roots-present": "enraíza o presente",
+      "releases-past": "libera o passado",
+      "opens-future": "abre o futuro",
+      "future-meets-context": "futuro encontra contexto",
+      "self-meets-context": "você no contexto",
+      "context-shapes-hopes": "contexto molda esperanças",
+      "hopes-guide-outcome": "esperanças guiam desfecho",
+      "sets-scene": "prepara o cenário",
+      "centers-matter": "centra o tema",
+      "shows-turn": "mostra a virada",
+      "shows-outcome": "mostra o desfecho",
+      "guides-view": "guia a visão",
+      "frames-past": "enquadra o passado",
+      "grounds-reading": "firma a leitura",
     },
   },
 };

--- a/src/lib/tarot-session.ts
+++ b/src/lib/tarot-session.ts
@@ -1,4 +1,5 @@
 import type {
+  ActiveSpreadReading,
   CardLayerDirection,
   CardSetDefinition,
   TableCard,
@@ -39,12 +40,21 @@ function cloneCards(cards: TableCard[]): TableCard[] {
   }));
 }
 
+function cloneActiveSpread(
+  activeSpread: ActiveSpreadReading | null
+): ActiveSpreadReading | null {
+  return activeSpread
+    ? { ...activeSpread, cardIds: [...activeSpread.cardIds] }
+    : null;
+}
+
 function cloneDeckPosition(position: TablePoint | null): TablePoint | null {
   return position ? ([...position] as TablePoint) : null;
 }
 
 function cloneSnapshots(snapshots: TableSnapshot[]): TableSnapshot[] {
   return snapshots.map((entry) => ({
+    activeSpread: cloneActiveSpread(entry.activeSpread),
     cards: cloneCards(entry.cards),
     deckPosition: cloneDeckPosition(entry.deckPosition),
     selectedCardId: entry.selectedCardId,
@@ -53,6 +63,7 @@ function cloneSnapshots(snapshots: TableSnapshot[]): TableSnapshot[] {
 
 function snapshot(session: TarotSession): TableSnapshot {
   return {
+    activeSpread: cloneActiveSpread(session.activeSpread),
     cards: cloneCards(session.cards),
     deckPosition: cloneDeckPosition(session.deckPosition),
     selectedCardId: session.selectedCardId,
@@ -63,10 +74,12 @@ function commit(
   session: TarotSession,
   cards: TableCard[],
   selectedCardId = session.selectedCardId,
-  deckPosition = session.deckPosition
+  deckPosition = session.deckPosition,
+  activeSpread = session.activeSpread
 ): TarotSession {
   return {
     ...session,
+    activeSpread: cloneActiveSpread(activeSpread),
     cards,
     deckPosition: cloneDeckPosition(deckPosition),
     selectedCardId,
@@ -96,6 +109,7 @@ export function createTarotSession(cardSet: CardSetDefinition): TarotSession {
   }));
 
   return {
+    activeSpread: null,
     cardSetId: cardSet.id,
     cards,
     deckPosition: null,
@@ -270,6 +284,7 @@ export function tarotSessionReducer(
   if (action.type === "restore") {
     return {
       ...action.session,
+      activeSpread: cloneActiveSpread(action.session.activeSpread),
       cards: cloneCards(action.session.cards),
       deckPosition: cloneDeckPosition(action.session.deckPosition),
       history: cloneSnapshots(action.session.history),
@@ -294,6 +309,7 @@ export function tarotSessionReducer(
 
     return {
       ...session,
+      activeSpread: cloneActiveSpread(previous.activeSpread),
       cards: cloneCards(previous.cards),
       deckPosition: cloneDeckPosition(previous.deckPosition),
       selectedCardId: previous.selectedCardId,
@@ -311,6 +327,7 @@ export function tarotSessionReducer(
 
     return {
       ...session,
+      activeSpread: cloneActiveSpread(next.activeSpread),
       cards: cloneCards(next.cards),
       deckPosition: cloneDeckPosition(next.deckPosition),
       selectedCardId: next.selectedCardId,
@@ -385,7 +402,8 @@ export function tarotSessionReducer(
       session,
       cards,
       session.selectedCardId,
-      action.deckPosition ?? session.deckPosition
+      action.deckPosition ?? session.deckPosition,
+      null
     );
   }
 
@@ -430,7 +448,11 @@ export function tarotSessionReducer(
       session,
       cards,
       null,
-      action.deckPosition ?? session.deckPosition
+      action.deckPosition ?? session.deckPosition,
+      {
+        id: action.spread.id,
+        cardIds: deckCards.map((card) => card.id),
+      }
     );
   }
 
@@ -500,7 +522,8 @@ export function tarotSessionReducer(
       session,
       cards,
       null,
-      action.deckPosition ?? session.deckPosition
+      action.deckPosition ?? session.deckPosition,
+      null
     );
   }
 

--- a/src/lib/tarot-spreads.ts
+++ b/src/lib/tarot-spreads.ts
@@ -1,4 +1,10 @@
-import type { CardSetKind, TablePoint } from "@/types";
+import type {
+  CardSetKind,
+  CardSpreadId,
+  LenormandSpreadId,
+  TablePoint,
+  TarotSpreadId,
+} from "@/types";
 import type { SceneTableLayout } from "@/components/tarot-studio/table-layout";
 import {
   getArrangementPresentation,
@@ -10,25 +16,13 @@ export type TarotSpreadSlot = {
   rotation: number;
 };
 
-export type TarotSpreadId =
-  | "one-card"
-  | "three-card"
-  | "horseshoe"
-  | "celtic-cross";
-
-export type LenormandSpreadId =
-  | "lenormand-three-card"
-  | "lenormand-five-card"
-  | "lenormand-portrait"
-  | "lenormand-grand-tableau";
-
-export type CardSpreadId = TarotSpreadId | LenormandSpreadId;
-
 export type CardSpread = {
   id: CardSpreadId;
   label: string;
   shortLabel: string;
   slots: TarotSpreadSlot[];
+  /** Sparse semantic relationships between zero-based spread slots. */
+  connections: Array<readonly [from: number, to: number]>;
 };
 
 /** A spread whose positions suit the taller tarot card format. */
@@ -57,12 +51,22 @@ export function getSpreadPresentation(
   return getArrangementPresentation(spread.slots, layout, options);
 }
 
+function createPathConnections(
+  length: number
+): Array<readonly [number, number]> {
+  return Array.from({ length: Math.max(0, length - 1) }, (_, index) => [
+    index,
+    index + 1,
+  ]);
+}
+
 export const popularTarotSpreads: TarotSpread[] = [
   {
     id: "one-card",
     label: "One card",
     shortLabel: "1 card",
     slots: [{ position: [0, 0], rotation: 0 }],
+    connections: [],
   },
   {
     id: "three-card",
@@ -73,6 +77,7 @@ export const popularTarotSpreads: TarotSpread[] = [
       { position: [0, 0.03], rotation: 0 },
       { position: [0.52, -0.04], rotation: 5 },
     ],
+    connections: createPathConnections(3),
   },
   {
     id: "horseshoe",
@@ -87,6 +92,7 @@ export const popularTarotSpreads: TarotSpread[] = [
       { position: [0.98, 0.32], rotation: 10 },
       { position: [1.08, -0.85], rotation: 14 },
     ],
+    connections: createPathConnections(7),
   },
   {
     id: "celtic-cross",
@@ -104,6 +110,16 @@ export const popularTarotSpreads: TarotSpread[] = [
       { position: [0.98, 0.61], rotation: 0 },
       { position: [0.98, 1.84], rotation: 0 },
     ],
+    connections: [
+      [0, 2],
+      [0, 3],
+      [0, 4],
+      [0, 5],
+      [5, 7],
+      [6, 7],
+      [7, 8],
+      [8, 9],
+    ],
   },
 ];
 
@@ -117,6 +133,7 @@ export const popularLenormandSpreads: LenormandSpread[] = [
       { position: [0, 0], rotation: 0 },
       { position: [0.5, 0], rotation: 0 },
     ],
+    connections: createPathConnections(3),
   },
   {
     id: "lenormand-five-card",
@@ -129,6 +146,7 @@ export const popularLenormandSpreads: LenormandSpread[] = [
       { position: [0.5, 0], rotation: 0 },
       { position: [1, 0], rotation: 0 },
     ],
+    connections: createPathConnections(5),
   },
   {
     id: "lenormand-portrait",
@@ -145,6 +163,20 @@ export const popularLenormandSpreads: LenormandSpread[] = [
       { position: [0, -0.94], rotation: 0 },
       { position: [0.55, -0.94], rotation: 0 },
     ],
+    connections: [
+      [0, 1],
+      [1, 2],
+      [2, 5],
+      [5, 8],
+      [8, 7],
+      [7, 6],
+      [6, 3],
+      [3, 0],
+      [4, 1],
+      [4, 3],
+      [4, 5],
+      [4, 7],
+    ],
   },
   {
     id: "lenormand-grand-tableau",
@@ -156,6 +188,7 @@ export const popularLenormandSpreads: LenormandSpread[] = [
         rotation: 0,
       }))
     ),
+    connections: [],
   },
 ];
 
@@ -168,4 +201,12 @@ export function getPopularSpreads(cardSetKind: CardSetKind): CardSpread[] {
   return cardSetKind === "lenormand"
     ? popularLenormandSpreads
     : popularTarotSpreads;
+}
+
+export function getSpreadById(
+  spreadId: CardSpreadId
+): CardSpread | undefined {
+  return [...popularTarotSpreads, ...popularLenormandSpreads].find(
+    (spread) => spread.id === spreadId
+  );
 }

--- a/src/lib/tarot-spreads.ts
+++ b/src/lib/tarot-spreads.ts
@@ -16,13 +16,46 @@ export type TarotSpreadSlot = {
   rotation: number;
 };
 
+export type SpreadRelationshipId =
+  | "shapes-present"
+  | "guides-future"
+  | "arrives-now"
+  | "reveals-hidden"
+  | "meets-obstacle"
+  | "draws-support"
+  | "informs-counsel"
+  | "guides-outcome"
+  | "crowns-present"
+  | "roots-present"
+  | "releases-past"
+  | "opens-future"
+  | "future-meets-context"
+  | "self-meets-context"
+  | "context-shapes-hopes"
+  | "hopes-guide-outcome"
+  | "sets-scene"
+  | "centers-matter"
+  | "shows-turn"
+  | "shows-outcome"
+  | "guides-view"
+  | "frames-past"
+  | "grounds-reading";
+
+export type SpreadConnection = {
+  from: number;
+  to: number;
+  relationship?: SpreadRelationshipId;
+  /** Selects which side of a crowded relationship line carries its label. */
+  labelSide?: -1 | 1;
+};
+
 export type CardSpread = {
   id: CardSpreadId;
   label: string;
   shortLabel: string;
   slots: TarotSpreadSlot[];
   /** Sparse semantic relationships between zero-based spread slots. */
-  connections: Array<readonly [from: number, to: number]>;
+  connections: SpreadConnection[];
 };
 
 /** A spread whose positions suit the taller tarot card format. */
@@ -52,12 +85,14 @@ export function getSpreadPresentation(
 }
 
 function createPathConnections(
-  length: number
-): Array<readonly [number, number]> {
-  return Array.from({ length: Math.max(0, length - 1) }, (_, index) => [
-    index,
-    index + 1,
-  ]);
+  relationships: SpreadRelationshipId[]
+): SpreadConnection[] {
+  return relationships.map((relationship, index) => ({
+    from: index,
+    to: index + 1,
+    relationship,
+    labelSide: index % 2 === 0 ? 1 : -1,
+  }));
 }
 
 export const popularTarotSpreads: TarotSpread[] = [
@@ -77,7 +112,10 @@ export const popularTarotSpreads: TarotSpread[] = [
       { position: [0, 0.03], rotation: 0 },
       { position: [0.52, -0.04], rotation: 5 },
     ],
-    connections: createPathConnections(3),
+    connections: createPathConnections([
+      "shapes-present",
+      "guides-future",
+    ]),
   },
   {
     id: "horseshoe",
@@ -92,7 +130,14 @@ export const popularTarotSpreads: TarotSpread[] = [
       { position: [0.98, 0.32], rotation: 10 },
       { position: [1.08, -0.85], rotation: 14 },
     ],
-    connections: createPathConnections(7),
+    connections: createPathConnections([
+      "arrives-now",
+      "reveals-hidden",
+      "meets-obstacle",
+      "draws-support",
+      "informs-counsel",
+      "guides-outcome",
+    ]),
   },
   {
     id: "celtic-cross",
@@ -111,14 +156,14 @@ export const popularTarotSpreads: TarotSpread[] = [
       { position: [0.98, 1.84], rotation: 0 },
     ],
     connections: [
-      [0, 2],
-      [0, 3],
-      [0, 4],
-      [0, 5],
-      [5, 7],
-      [6, 7],
-      [7, 8],
-      [8, 9],
+      { from: 0, to: 2, relationship: "crowns-present", labelSide: 1 },
+      { from: 0, to: 3, relationship: "roots-present", labelSide: -1 },
+      { from: 0, to: 4, relationship: "releases-past", labelSide: 1 },
+      { from: 0, to: 5, relationship: "opens-future", labelSide: -1 },
+      { from: 5, to: 7, relationship: "future-meets-context", labelSide: 1 },
+      { from: 6, to: 7, relationship: "self-meets-context", labelSide: -1 },
+      { from: 7, to: 8, relationship: "context-shapes-hopes", labelSide: 1 },
+      { from: 8, to: 9, relationship: "hopes-guide-outcome", labelSide: -1 },
     ],
   },
 ];
@@ -133,7 +178,10 @@ export const popularLenormandSpreads: LenormandSpread[] = [
       { position: [0, 0], rotation: 0 },
       { position: [0.5, 0], rotation: 0 },
     ],
-    connections: createPathConnections(3),
+    connections: createPathConnections([
+      "sets-scene",
+      "shows-outcome",
+    ]),
   },
   {
     id: "lenormand-five-card",
@@ -146,7 +194,12 @@ export const popularLenormandSpreads: LenormandSpread[] = [
       { position: [0.5, 0], rotation: 0 },
       { position: [1, 0], rotation: 0 },
     ],
-    connections: createPathConnections(5),
+    connections: createPathConnections([
+      "sets-scene",
+      "centers-matter",
+      "shows-turn",
+      "shows-outcome",
+    ]),
   },
   {
     id: "lenormand-portrait",
@@ -164,18 +217,18 @@ export const popularLenormandSpreads: LenormandSpread[] = [
       { position: [0.55, -0.94], rotation: 0 },
     ],
     connections: [
-      [0, 1],
-      [1, 2],
-      [2, 5],
-      [5, 8],
-      [8, 7],
-      [7, 6],
-      [6, 3],
-      [3, 0],
-      [4, 1],
-      [4, 3],
-      [4, 5],
-      [4, 7],
+      { from: 0, to: 1 },
+      { from: 1, to: 2 },
+      { from: 2, to: 5 },
+      { from: 5, to: 8 },
+      { from: 8, to: 7 },
+      { from: 7, to: 6 },
+      { from: 6, to: 3 },
+      { from: 3, to: 0 },
+      { from: 4, to: 1, relationship: "guides-view", labelSide: 1 },
+      { from: 4, to: 3, relationship: "frames-past", labelSide: -1 },
+      { from: 4, to: 5, relationship: "opens-future", labelSide: 1 },
+      { from: 4, to: 7, relationship: "grounds-reading", labelSide: -1 },
     ],
   },
   {

--- a/src/lib/tarot-workspace.ts
+++ b/src/lib/tarot-workspace.ts
@@ -9,6 +9,7 @@ import {
   resolveSceneSettings,
   type SceneSettings,
 } from "@/components/tarot-studio/theme";
+import { getPopularSpreads } from "@/lib/tarot-spreads";
 
 export const TAROT_WORKSPACE_STORAGE_KEY = "tarot-table:workspace:v1";
 
@@ -74,6 +75,42 @@ function isTableCard(value: unknown, cardSet: CardSetDefinition): value is Table
   );
 }
 
+function restoreActiveSpread(
+  value: unknown,
+  cardSet: CardSetDefinition,
+  cardIds: Set<string>
+): TarotSession["activeSpread"] {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const activeSpread = value as {
+    id?: unknown;
+    cardIds?: unknown;
+  };
+  const spread = getPopularSpreads(cardSet.kind).find(
+    (candidate) => candidate.id === activeSpread.id
+  );
+
+  if (
+    !spread ||
+    !Array.isArray(activeSpread.cardIds) ||
+    activeSpread.cardIds.length !== spread.slots.length ||
+    !activeSpread.cardIds.every(
+      (cardId): cardId is string =>
+        typeof cardId === "string" && cardIds.has(cardId)
+    ) ||
+    new Set(activeSpread.cardIds).size !== activeSpread.cardIds.length
+  ) {
+    return null;
+  }
+
+  return {
+    id: spread.id,
+    cardIds: [...activeSpread.cardIds],
+  };
+}
+
 function restoreSession(
   value: unknown,
   cardSet: CardSetDefinition
@@ -114,6 +151,7 @@ function restoreSession(
   }
 
   return {
+    activeSpread: restoreActiveSpread(session.activeSpread, cardSet, cardIds),
     cardSetId: cardSet.id,
     cards,
     deckPosition: session.deckPosition

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,26 @@ export const DECK_POINT_LIMIT = 6.4;
 
 export type CardLayerDirection = "forward" | "backward";
 
+export type TarotSpreadId =
+  | "one-card"
+  | "three-card"
+  | "horseshoe"
+  | "celtic-cross";
+
+export type LenormandSpreadId =
+  | "lenormand-three-card"
+  | "lenormand-five-card"
+  | "lenormand-portrait"
+  | "lenormand-grand-tableau";
+
+export type CardSpreadId = TarotSpreadId | LenormandSpreadId;
+
+/** Stable card-to-slot assignment for a dealt spread. */
+export type ActiveSpreadReading = {
+  id: CardSpreadId;
+  cardIds: string[];
+};
+
 export type TableCard = {
   id: string;
   cardId: string;
@@ -71,12 +91,14 @@ export type TableCard = {
 };
 
 export type TableSnapshot = {
+  activeSpread: ActiveSpreadReading | null;
   cards: TableCard[];
   deckPosition: TablePoint | null;
   selectedCardId: string | null;
 };
 
 export type TarotSession = {
+  activeSpread: ActiveSpreadReading | null;
   cardSetId: string;
   cards: TableCard[];
   deckPosition: TablePoint | null;


### PR DESCRIPTION
## Why

The table should feel materially convincing when cards overlap, while a dealt spread should reveal its structure without turning the reading into a diagram.

## What changed

- Adds woven cloth response, layered paper edges, restrained patina, and subtle drag flex.
- Persists the exact cards dealt into spread positions through movement, undo/redo, and reload.
- Reveals sparse, spread-specific constellation threads as related cards turn face-up.
- Names each revealed relationship in a few words, localized in English and Brazilian Portuguese, with mobile-aware label culling.
