### PR TITLE
Let poorly balanced cards settle and tumble

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:marseille-assets": "node scripts/build-marseille-assets.mjs",
     "validate:marseille-assets": "node scripts/validate-marseille-assets.mjs",
     "validate:locales": "node scripts/validate-locales.mjs",
-    "validate:card-readings": "node scripts/validate-card-readings.mjs"
+    "validate:card-readings": "node scripts/validate-card-readings.mjs",
+    "validate:card-balance": "node scripts/validate-card-balance.mjs"
   },
   "dependencies": {
     "@react-three/drei": "^9.122.0",

--- a/scripts/validate-card-balance.mjs
+++ b/scripts/validate-card-balance.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+
+const source = await readFile(
+  new URL("../src/lib/card-balance.ts", import.meta.url),
+  "utf8"
+);
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2020,
+  },
+  fileName: "card-balance.ts",
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+const {
+  evaluateCardSupport,
+  getCardStackLevels,
+  resolvePrimaryCardDrop,
+  shouldFlipAfterFall,
+} = await import(moduleUrl);
+
+const layout = {
+  cardHeight: 4,
+  cardWidth: 2.4,
+  dragBounds: { bottom: -8, left: -8, right: 8, top: 8 },
+  toPoint: (x, y) => [x, y],
+  toWorld: (point) => [point[0], point[1]],
+};
+
+function card(id, position, zIndex, rotation = 0) {
+  return {
+    cardId: id,
+    cardSetId: "test",
+    faceUp: false,
+    id,
+    position,
+    rotation,
+    zIndex,
+    zone: "table",
+  };
+}
+
+function assess(cards, cardId) {
+  const levels = getCardStackLevels({
+    baseHeight: 0,
+    cards,
+    layerStep: 1,
+    layout,
+  });
+
+  return evaluateCardSupport({ cardId, layout, levels });
+}
+
+const tableCard = card("table", [0, 0], 0);
+assert.equal(assess([tableCard], "table")?.kind, "table");
+assert.equal(assess([tableCard], "table")?.stable, true);
+
+const centeredSupport = card("lower", [0, 0], 0);
+const centeredCard = card("upper", [0, 0], 1);
+assert.equal(
+  assess([centeredSupport, centeredCard], "upper")?.stable,
+  true,
+  "centred card should be stable on a matching support"
+);
+
+const rotatedSupport = card("rotated-lower", [0, 0], 0, 35);
+const rotatedCard = card("rotated-upper", [0, 0], 1, 35);
+assert.equal(
+  assess([rotatedSupport, rotatedCard], "rotated-upper")?.stable,
+  true,
+  "matching rotated cards should keep a stable support polygon"
+);
+
+const edgeCards = [
+  card("edge-lower", [0, 0], 0),
+  card("edge-upper", [1.9, 0], 1),
+];
+const edgeResolution = resolvePrimaryCardDrop({
+  baseHeight: 0,
+  cards: edgeCards,
+  layerStep: 1,
+  layout,
+  primaryCardId: "edge-upper",
+});
+assert.equal(edgeResolution?.outcome, "fell");
+assert.ok(
+  (edgeResolution?.direction?.[0] ?? 0) > 0,
+  "edge card should fall away from its exposed right-side centre of mass"
+);
+
+const nearEdgeCards = [
+  card("near-edge-lower", [0, 0], 0),
+  card("near-edge-upper", [1.1, 0], 1),
+];
+const nearEdgeResolution = resolvePrimaryCardDrop({
+  baseHeight: 0,
+  cards: nearEdgeCards,
+  layerStep: 1,
+  layout,
+  primaryCardId: "near-edge-upper",
+  supportMargin: 0.12,
+});
+assert.ok(
+  (nearEdgeResolution?.direction?.[0] ?? 0) > 0,
+  "a marginally supported card should tip toward its nearest exposed edge"
+);
+
+const bridgeCards = [
+  card("bridge-left", [-2.25, 0], 0),
+  card("bridge-right", [2.25, 0], 1),
+  card("bridge-upper", [0, 0], 2),
+];
+assert.equal(
+  assess(bridgeCards, "bridge-upper")?.stable,
+  true,
+  "two contact patches should form a valid bridge support polygon"
+);
+
+assert.equal(
+  shouldFlipAfterFall({ cardHeight: 4, cardWidth: 2.4, overhang: 0.1 }),
+  false
+);
+assert.equal(
+  shouldFlipAfterFall({ cardHeight: 4, cardWidth: 2.4, overhang: 0.8 }),
+  true
+);
+
+const repeatedResolution = resolvePrimaryCardDrop({
+  baseHeight: 0,
+  cards: edgeCards,
+  layerStep: 1,
+  layout,
+  primaryCardId: "edge-upper",
+});
+assert.deepEqual(
+  repeatedResolution,
+  edgeResolution,
+  "same input should resolve to the same landing"
+);
+
+const patch = edgeResolution?.patch;
+assert.ok(patch, "falling card should produce a final placement");
+assert.ok(
+  patch.position[0] >= -6.8 &&
+    patch.position[0] <= 6.8 &&
+    patch.position[1] >= -6 &&
+    patch.position[1] <= 6,
+  "resolved landing must keep the whole card inside drag bounds"
+);
+
+console.log(
+  "Validated support-aware card balance geometry and primary-drop resolution."
+);

--- a/src/components/tarot-studio/CardMesh.tsx
+++ b/src/components/tarot-studio/CardMesh.tsx
@@ -56,8 +56,9 @@ const RELEASE_GLIDE_SECONDS = 0.06;
 const MAX_RELEASE_GLIDE = 0.32;
 const MIN_THROW_SPEED = 0.7;
 const MAX_THROW_ROTATION = 11;
-const FLIP_DURATION_SECONDS = 0.52;
+const FLIP_DURATION_SECONDS = 0.46;
 const FLIP_SURFACE_CLEARANCE = 0.0005;
+const FLIP_MIN_WIDTH_SCALE = 0.12;
 const DRAG_SCALE = 1.035;
 
 export const CARD_THICKNESS = 0.018;
@@ -700,6 +701,7 @@ export const CardMesh = memo(function CardMesh({
       1,
       card.zone === "deck" ? deckDepthScale : 1
     );
+    flippingCard.position.set(0, 0, 0);
     flippingCard.rotation.set(0, card.faceUp ? 0 : Math.PI, 0);
     flipAnimationRef.current = null;
     hasPositionedRef.current = true;
@@ -722,10 +724,28 @@ export const CardMesh = memo(function CardMesh({
     }
 
     const target = card.faceUp ? 0 : Math.PI;
+    const activeFlip = flipAnimationRef.current;
 
     if (reducedMotion) {
+      flippingCard.position.set(0, 0, 0);
       flippingCard.rotation.set(0, target, 0);
       flipAnimationRef.current = null;
+      invalidate();
+      return;
+    }
+
+    if (
+      activeFlip &&
+      Math.abs(activeFlip.from - target) <= 0.0008
+    ) {
+      flipAnimationRef.current = {
+        from: activeFlip.to,
+        to: activeFlip.from,
+        elapsed: Math.max(
+          0,
+          FLIP_DURATION_SECONDS - activeFlip.elapsed
+        ),
+      };
       invalidate();
       return;
     }
@@ -1053,9 +1073,9 @@ export const CardMesh = memo(function CardMesh({
     let flipIsActive = false;
     let flipScaleX = 1;
     let flipScaleY = 1;
-    let flipSqueeze = 0;
 
     if (reducedMotion) {
+      flippingCard.position.set(0, 0, 0);
       flippingCard.rotation.set(0, card.faceUp ? 0 : Math.PI, 0);
       flipAnimationRef.current = null;
     } else if (flipAnimation) {
@@ -1069,20 +1089,20 @@ export const CardMesh = memo(function CardMesh({
           ? 4 * progress * progress * progress
           : 1 - Math.pow(-2 * progress + 2, 3) / 2;
 
-      const squeeze = Math.sin(Math.PI * easedProgress);
-      flipSqueeze = squeeze;
+      const turnEnvelope = Math.sin(Math.PI * easedProgress);
 
       flipScaleX = Math.max(
-        0.018,
+        FLIP_MIN_WIDTH_SCALE,
         Math.abs(Math.cos(Math.PI * easedProgress))
       );
-      flipScaleY = 1 - squeeze * 0.012;
+      flipScaleY = 1 - turnEnvelope * 0.006;
       flippingCard.rotation.y =
         easedProgress < 0.5 ? flipAnimation.from : flipAnimation.to;
       flippingCard.rotation.x = 0;
       flipIsActive = progress < 1;
 
       if (!flipIsActive) {
+        flippingCard.position.set(0, 0, 0);
         flippingCard.rotation.set(0, flipAnimation.to, 0);
         flipAnimationRef.current = null;
         flipScaleX = 1;
@@ -1147,12 +1167,12 @@ export const CardMesh = memo(function CardMesh({
       ? 0
       : moving
         ? tiltYTarget * 0.036
-        : flipSqueeze * (card.faceUp ? 0.006 : -0.006);
+        : 0;
     const curlYTarget = reducedMotion
       ? 0
       : moving
         ? -tiltXTarget * 0.03
-        : -flipSqueeze * 0.0035;
+        : 0;
     const paperMotion = paperMotionRef.current;
     const nextCurlX = reducedMotion
       ? 0
@@ -1221,6 +1241,7 @@ export const CardMesh = memo(function CardMesh({
       group.position.y = positionYTarget;
       group.position.z = zTarget;
       group.scale.set(scaleTarget, scaleTarget, 1);
+      flippingCard.position.set(0, 0, 0);
       flippingCard.scale.set(flipScaleX, flipScaleY, depthScaleTarget);
       paperMotion.curlX = 0;
       paperMotion.curlY = 0;
@@ -1260,6 +1281,7 @@ export const CardMesh = memo(function CardMesh({
     group.position.y = nextY;
     group.position.z = nextZ;
     group.scale.set(nextScale, nextScale, 1);
+    flippingCard.position.set(0, 0, 0);
     flippingCard.scale.set(flipScaleX, flipScaleY, nextDepthScale);
     paperMotion.curlX = nextCurlX;
     paperMotion.curlY = nextCurlY;

--- a/src/components/tarot-studio/card-stacking.ts
+++ b/src/components/tarot-studio/card-stacking.ts
@@ -1,66 +1,6 @@
 import type { TableCard } from "@/types";
+import { getCardStackLevels } from "@/lib/card-balance";
 import type { SceneTableLayout } from "./table-layout";
-
-type Axis = [number, number];
-
-type RotatedCard = {
-  center: [number, number];
-  axes: [Axis, Axis];
-};
-
-function dot(first: Axis, second: Axis): number {
-  return first[0] * second[0] + first[1] * second[1];
-}
-
-function createRotatedCard(
-  card: TableCard,
-  layout: SceneTableLayout
-): RotatedCard {
-  const radians = (card.rotation * Math.PI) / 180;
-  const cosine = Math.cos(radians);
-  const sine = Math.sin(radians);
-
-  return {
-    center: layout.toWorld(card.position),
-    axes: [
-      [cosine, sine],
-      [-sine, cosine],
-    ],
-  };
-}
-
-function projectionRadius(
-  card: RotatedCard,
-  axis: Axis,
-  halfWidth: number,
-  halfHeight: number
-): number {
-  return (
-    halfWidth * Math.abs(dot(card.axes[0], axis)) +
-    halfHeight * Math.abs(dot(card.axes[1], axis))
-  );
-}
-
-function cardsOverlap(
-  first: RotatedCard,
-  second: RotatedCard,
-  halfWidth: number,
-  halfHeight: number
-): boolean {
-  const centerDelta: Axis = [
-    second.center[0] - first.center[0],
-    second.center[1] - first.center[1],
-  ];
-
-  return [...first.axes, ...second.axes].every((axis) => {
-    const centerDistance = Math.abs(dot(centerDelta, axis));
-    const combinedRadius =
-      projectionRadius(first, axis, halfWidth, halfHeight) +
-      projectionRadius(second, axis, halfWidth, halfHeight);
-
-    return centerDistance < combinedRadius - 0.001;
-  });
-}
 
 export function getTableCardRestingHeights({
   cards,
@@ -73,33 +13,9 @@ export function getTableCardRestingHeights({
   baseHeight: number;
   layerStep: number;
 }): Map<string, number> {
-  const restingHeights = new Map<string, number>();
-  const footprints = cards.map((card) => createRotatedCard(card, layout));
-  const halfWidth = layout.cardWidth / 2;
-  const halfHeight = layout.cardHeight / 2;
-
-  cards.forEach((card, index) => {
-    let restingHeight = baseHeight;
-
-    for (let lowerIndex = 0; lowerIndex < index; lowerIndex += 1) {
-      if (
-        cardsOverlap(
-          footprints[index],
-          footprints[lowerIndex],
-          halfWidth,
-          halfHeight
-        )
-      ) {
-        restingHeight = Math.max(
-          restingHeight,
-          (restingHeights.get(cards[lowerIndex].id) ?? baseHeight) +
-            layerStep
-        );
-      }
-    }
-
-    restingHeights.set(card.id, restingHeight);
-  });
-
-  return restingHeights;
+  return new Map(
+    Array.from(
+      getCardStackLevels({ cards, layout, baseHeight, layerStep }).entries()
+    ).map(([cardId, level]) => [cardId, level.height])
+  );
 }

--- a/src/lib/card-balance.ts
+++ b/src/lib/card-balance.ts
@@ -1,0 +1,714 @@
+import type { TableCard, TablePoint } from "@/types";
+
+export type BalancePoint = readonly [number, number];
+
+export type BalanceBounds = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+/** The small layout contract needed by pure table-physics helpers. */
+export type CardBalanceLayout = {
+  cardWidth: number;
+  cardHeight: number;
+  dragBounds?: BalanceBounds;
+  toPoint?: (x: number, y: number) => TablePoint;
+  toWorld: (point: TablePoint) => [number, number];
+};
+
+export type CardFootprint = {
+  cardId: string;
+  center: [number, number];
+  corners: Array<[number, number]>;
+  rotation: number;
+};
+
+export type CardStackLevel = {
+  card: TableCard;
+  footprint: CardFootprint;
+  height: number;
+  /** Cards immediately touching this card's underside at its highest plane. */
+  supportCardIds: string[];
+};
+
+export type CardSupportContact = {
+  cardId: string;
+  area: number;
+  polygon: Array<[number, number]>;
+};
+
+export type CardSupportEvaluation = {
+  cardId: string;
+  contacts: CardSupportContact[];
+  kind: "cards" | "table";
+  margin: number;
+  nearestPoint: [number, number] | null;
+  overhang: number;
+  stable: boolean;
+  supportPolygon: Array<[number, number]>;
+};
+
+export type CardFallResolution = {
+  assessment: CardSupportEvaluation;
+  direction: [number, number] | null;
+  outcome: "fell" | "stable" | "unresolved";
+  patch?: Pick<TableCard, "faceUp" | "position" | "rotation">;
+  willFlipFace: boolean;
+};
+
+export type ResolvePrimaryCardDropOptions = {
+  baseHeight?: number;
+  /** World-space velocity at release, in units per second. */
+  releaseVelocity?: BalancePoint;
+  layerStep: number;
+  /** A card must keep this much support polygon beneath its centre. */
+  supportMargin?: number;
+};
+
+const EPSILON = 0.000001;
+const OVERLAP_EPSILON = 0.001;
+const DEFAULT_SUPPORT_MARGIN_RATIO = 0.025;
+const FALL_DISTANCES = [0.32, 0.52, 0.78, 1.04] as const;
+const FALL_ANGLE_OFFSETS = [0, -24, 24, -48, 48] as const;
+const MAX_FALL_ROTATION = 24;
+const MIN_FALL_ROTATION = 8;
+const FLIP_SCORE_THRESHOLD = 0.28;
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+  Math.min(Math.max(value, minimum), maximum);
+
+const dot = (first: BalancePoint, second: BalancePoint) =>
+  first[0] * second[0] + first[1] * second[1];
+
+const cross = (origin: BalancePoint, first: BalancePoint, second: BalancePoint) =>
+  (first[0] - origin[0]) * (second[1] - origin[1]) -
+  (first[1] - origin[1]) * (second[0] - origin[0]);
+
+const distance = (first: BalancePoint, second: BalancePoint) =>
+  Math.hypot(first[0] - second[0], first[1] - second[1]);
+
+function normalise(vector: BalancePoint): [number, number] | null {
+  const length = Math.hypot(vector[0], vector[1]);
+
+  return length > EPSILON ? [vector[0] / length, vector[1] / length] : null;
+}
+
+function rotate(vector: BalancePoint, degrees: number): [number, number] {
+  const radians = (degrees * Math.PI) / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+
+  return [
+    vector[0] * cosine - vector[1] * sine,
+    vector[0] * sine + vector[1] * cosine,
+  ];
+}
+
+function stableHash(value: string): number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0) / 4294967296;
+}
+
+function getFallbackDirection(cardId: string): [number, number] {
+  const angle = stableHash(cardId) * Math.PI * 2;
+
+  return [Math.cos(angle), Math.sin(angle)];
+}
+
+function getCorners(
+  center: BalancePoint,
+  rotation: number,
+  cardWidth: number,
+  cardHeight: number
+): Array<[number, number]> {
+  const halfWidth = cardWidth / 2;
+  const halfHeight = cardHeight / 2;
+  const radians = (rotation * Math.PI) / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+  const points: Array<[number, number]> = [
+    [-halfWidth, -halfHeight],
+    [halfWidth, -halfHeight],
+    [halfWidth, halfHeight],
+    [-halfWidth, halfHeight],
+  ];
+
+  return points.map(([x, y]) => [
+    center[0] + x * cosine - y * sine,
+    center[1] + x * sine + y * cosine,
+  ]);
+}
+
+export function createCardFootprint(
+  card: Pick<TableCard, "id" | "position" | "rotation">,
+  layout: CardBalanceLayout
+): CardFootprint {
+  const center = layout.toWorld(card.position);
+
+  return {
+    cardId: card.id,
+    center,
+    corners: getCorners(
+      center,
+      card.rotation,
+      layout.cardWidth,
+      layout.cardHeight
+    ),
+    rotation: card.rotation,
+  };
+}
+
+function axesFor(footprint: CardFootprint): Array<[number, number]> {
+  const first = footprint.corners[0];
+  const second = footprint.corners[1];
+  const third = footprint.corners[2];
+  const firstAxis = normalise([second[0] - first[0], second[1] - first[1]]);
+  const secondAxis = normalise([third[0] - second[0], third[1] - second[1]]);
+
+  return firstAxis && secondAxis ? [firstAxis, secondAxis] : [];
+}
+
+function boundsAlong(points: readonly BalancePoint[], axis: BalancePoint) {
+  let minimum = Number.POSITIVE_INFINITY;
+  let maximum = Number.NEGATIVE_INFINITY;
+
+  points.forEach((point) => {
+    const projection = dot(point, axis);
+    minimum = Math.min(minimum, projection);
+    maximum = Math.max(maximum, projection);
+  });
+
+  return { maximum, minimum };
+}
+
+/** Separating-axis overlap for two oriented card rectangles. */
+export function footprintsOverlap(
+  first: CardFootprint,
+  second: CardFootprint,
+  epsilon = OVERLAP_EPSILON
+): boolean {
+  return [...axesFor(first), ...axesFor(second)].every((axis) => {
+    const firstBounds = boundsAlong(first.corners, axis);
+    const secondBounds = boundsAlong(second.corners, axis);
+
+    return (
+      Math.min(firstBounds.maximum, secondBounds.maximum) -
+        Math.max(firstBounds.minimum, secondBounds.minimum) >
+      epsilon
+    );
+  });
+}
+
+function polygonArea(points: readonly BalancePoint[]): number {
+  if (points.length < 3) {
+    return 0;
+  }
+
+  let twiceArea = 0;
+
+  for (let index = 0; index < points.length; index += 1) {
+    const next = points[(index + 1) % points.length];
+    twiceArea += points[index][0] * next[1] - points[index][1] * next[0];
+  }
+
+  return Math.abs(twiceArea) / 2;
+}
+
+function lineIntersection(
+  start: BalancePoint,
+  end: BalancePoint,
+  clipStart: BalancePoint,
+  clipEnd: BalancePoint
+): [number, number] {
+  const edge: [number, number] = [end[0] - start[0], end[1] - start[1]];
+  const clipEdge: [number, number] = [
+    clipEnd[0] - clipStart[0],
+    clipEnd[1] - clipStart[1],
+  ];
+  const denominator = edge[0] * clipEdge[1] - edge[1] * clipEdge[0];
+
+  if (Math.abs(denominator) <= EPSILON) {
+    return [end[0], end[1]];
+  }
+
+  const between: [number, number] = [
+    clipStart[0] - start[0],
+    clipStart[1] - start[1],
+  ];
+  const t =
+    (between[0] * clipEdge[1] - between[1] * clipEdge[0]) / denominator;
+
+  return [start[0] + edge[0] * t, start[1] + edge[1] * t];
+}
+
+/** Clips one convex polygon against another, retaining the overlap patch. */
+export function clipConvexPolygon(
+  subject: readonly BalancePoint[],
+  clip: readonly BalancePoint[]
+): Array<[number, number]> {
+  let output = subject.map(([x, y]) => [x, y] as [number, number]);
+
+  for (let clipIndex = 0; clipIndex < clip.length; clipIndex += 1) {
+    const clipStart = clip[clipIndex];
+    const clipEnd = clip[(clipIndex + 1) % clip.length];
+    const input = output;
+    output = [];
+
+    if (input.length === 0) {
+      break;
+    }
+
+    let previous = input[input.length - 1];
+    let previousInside = cross(clipStart, clipEnd, previous) >= -EPSILON;
+
+    input.forEach((current) => {
+      const currentInside = cross(clipStart, clipEnd, current) >= -EPSILON;
+
+      if (currentInside !== previousInside) {
+        output.push(lineIntersection(previous, current, clipStart, clipEnd));
+      }
+
+      if (currentInside) {
+        output.push(current);
+      }
+
+      previous = current;
+      previousInside = currentInside;
+    });
+  }
+
+  return output;
+}
+
+export function getConvexHull(
+  points: readonly BalancePoint[]
+): Array<[number, number]> {
+  const uniquePoints = Array.from(
+    new Map(
+      points.map((point) => [
+        `${point[0].toFixed(8)}:${point[1].toFixed(8)}`,
+        [point[0], point[1]] as [number, number],
+      ])
+    ).values()
+  ).sort((first, second) => first[0] - second[0] || first[1] - second[1]);
+
+  if (uniquePoints.length <= 2) {
+    return uniquePoints;
+  }
+
+  const lower: Array<[number, number]> = [];
+  uniquePoints.forEach((point) => {
+    while (
+      lower.length >= 2 &&
+      cross(lower[lower.length - 2], lower[lower.length - 1], point) <= EPSILON
+    ) {
+      lower.pop();
+    }
+    lower.push(point);
+  });
+
+  const upper: Array<[number, number]> = [];
+  [...uniquePoints].reverse().forEach((point) => {
+    while (
+      upper.length >= 2 &&
+      cross(upper[upper.length - 2], upper[upper.length - 1], point) <= EPSILON
+    ) {
+      upper.pop();
+    }
+    upper.push(point);
+  });
+
+  upper.pop();
+  lower.pop();
+  return [...lower, ...upper];
+}
+
+function closestPointOnSegment(
+  point: BalancePoint,
+  start: BalancePoint,
+  end: BalancePoint
+): [number, number] {
+  const segment: [number, number] = [end[0] - start[0], end[1] - start[1]];
+  const lengthSquared = dot(segment, segment);
+
+  if (lengthSquared <= EPSILON) {
+    return [start[0], start[1]];
+  }
+
+  const progress = clamp(
+    dot([point[0] - start[0], point[1] - start[1]], segment) /
+      lengthSquared,
+    0,
+    1
+  );
+
+  return [start[0] + segment[0] * progress, start[1] + segment[1] * progress];
+}
+
+function getPointMargin(
+  point: BalancePoint,
+  polygon: readonly BalancePoint[]
+): { inside: boolean; margin: number; nearestPoint: [number, number] | null } {
+  if (polygon.length < 3 || polygonArea(polygon) <= EPSILON) {
+    return { inside: false, margin: Number.NEGATIVE_INFINITY, nearestPoint: null };
+  }
+
+  let inside = true;
+  let nearestPoint: [number, number] | null = null;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index < polygon.length; index += 1) {
+    const start = polygon[index];
+    const end = polygon[(index + 1) % polygon.length];
+    if (cross(start, end, point) < -EPSILON) {
+      inside = false;
+    }
+
+    const candidate = closestPointOnSegment(point, start, end);
+    const candidateDistance = distance(point, candidate);
+    if (candidateDistance < nearestDistance) {
+      nearestDistance = candidateDistance;
+      nearestPoint = candidate;
+    }
+  }
+
+  return {
+    inside,
+    margin: inside ? nearestDistance : -nearestDistance,
+    nearestPoint,
+  };
+}
+
+function sortCards(cards: readonly TableCard[]) {
+  return [...cards].sort(
+    (first, second) => first.zIndex - second.zIndex || first.id.localeCompare(second.id)
+  );
+}
+
+/**
+ * Computes visual contact planes from the same z-order used to render table
+ * cards. A card with no lower overlap rests directly on the table.
+ */
+export function getCardStackLevels({
+  cards,
+  layout,
+  baseHeight,
+  layerStep,
+}: {
+  cards: readonly TableCard[];
+  layout: CardBalanceLayout;
+  baseHeight: number;
+  layerStep: number;
+}): Map<string, CardStackLevel> {
+  const levels = new Map<string, CardStackLevel>();
+  const sortedCards = sortCards(cards);
+
+  sortedCards.forEach((card, index) => {
+    const footprint = createCardFootprint(card, layout);
+    const lowerLevels = sortedCards.slice(0, index).flatMap((lowerCard) => {
+      const lowerLevel = levels.get(lowerCard.id);
+      return lowerLevel && footprintsOverlap(footprint, lowerLevel.footprint)
+        ? [lowerLevel]
+        : [];
+    });
+    const height = lowerLevels.reduce(
+      (maximum, lowerLevel) => Math.max(maximum, lowerLevel.height + layerStep),
+      baseHeight
+    );
+    const supportCardIds = lowerLevels
+      .filter((lowerLevel) => Math.abs(lowerLevel.height + layerStep - height) <= EPSILON)
+      .map((lowerLevel) => lowerLevel.card.id);
+
+    levels.set(card.id, { card, footprint, height, supportCardIds });
+  });
+
+  return levels;
+}
+
+/**
+ * Evaluates whether the card's centre of mass is safely inside the convex
+ * support polygon made by the contact patches beneath it.
+ */
+export function evaluateCardSupport({
+  cardId,
+  levels,
+  layout,
+  supportMargin = Math.min(layout.cardWidth, layout.cardHeight) * DEFAULT_SUPPORT_MARGIN_RATIO,
+}: {
+  cardId: string;
+  levels: ReadonlyMap<string, CardStackLevel>;
+  layout: CardBalanceLayout;
+  supportMargin?: number;
+}): CardSupportEvaluation | null {
+  const level = levels.get(cardId);
+
+  if (!level) {
+    return null;
+  }
+
+  if (level.supportCardIds.length === 0) {
+    return {
+      cardId,
+      contacts: [],
+      kind: "table",
+      margin: Number.POSITIVE_INFINITY,
+      nearestPoint: null,
+      overhang: 0,
+      stable: true,
+      supportPolygon: [],
+    };
+  }
+
+  const contacts = level.supportCardIds.flatMap((supportCardId) => {
+    const supportLevel = levels.get(supportCardId);
+    if (!supportLevel) {
+      return [];
+    }
+
+    const polygon = clipConvexPolygon(
+      level.footprint.corners,
+      supportLevel.footprint.corners
+    );
+    const area = polygonArea(polygon);
+    return area > EPSILON ? [{ area, cardId: supportCardId, polygon }] : [];
+  });
+  const supportPolygon = getConvexHull(contacts.flatMap((contact) => contact.polygon));
+  const pointMargin = getPointMargin(level.footprint.center, supportPolygon);
+  const stable = pointMargin.inside && pointMargin.margin >= supportMargin;
+
+  return {
+    cardId,
+    contacts,
+    kind: "cards",
+    margin: pointMargin.margin,
+    nearestPoint: pointMargin.nearestPoint,
+    overhang: Math.max(0, -pointMargin.margin),
+    stable,
+    supportPolygon,
+  };
+}
+
+export function shouldFlipAfterFall({
+  cardHeight,
+  cardWidth,
+  overhang,
+  releaseVelocity = [0, 0],
+}: {
+  cardHeight: number;
+  cardWidth: number;
+  overhang: number;
+  releaseVelocity?: BalancePoint;
+}): boolean {
+  const shortEdge = Math.max(EPSILON, Math.min(cardWidth, cardHeight));
+  const speed = Math.hypot(releaseVelocity[0], releaseVelocity[1]);
+  const score = overhang / shortEdge + Math.min(0.32, (speed / shortEdge) * 0.12);
+
+  return score >= FLIP_SCORE_THRESHOLD;
+}
+
+function clampCardCenter(
+  center: BalancePoint,
+  rotation: number,
+  layout: CardBalanceLayout
+): [number, number] {
+  if (!layout.dragBounds) {
+    return [center[0], center[1]];
+  }
+
+  const radians = (rotation * Math.PI) / 180;
+  const halfWidth =
+    (Math.abs(Math.cos(radians)) * layout.cardWidth +
+      Math.abs(Math.sin(radians)) * layout.cardHeight) /
+    2;
+  const halfHeight =
+    (Math.abs(Math.sin(radians)) * layout.cardWidth +
+      Math.abs(Math.cos(radians)) * layout.cardHeight) /
+    2;
+  const { bottom, left, right, top } = layout.dragBounds;
+
+  return [
+    clamp(center[0], left + halfWidth, right - halfWidth),
+    clamp(center[1], bottom + halfHeight, top - halfHeight),
+  ];
+}
+
+function toTablePoint(
+  point: BalancePoint,
+  layout: CardBalanceLayout
+): TablePoint {
+  return layout.toPoint ? layout.toPoint(point[0], point[1]) : [point[0], point[1]];
+}
+
+function createCandidateCard(
+  card: TableCard,
+  center: BalancePoint,
+  rotation: number,
+  layout: CardBalanceLayout
+): TableCard {
+  return {
+    ...card,
+    position: toTablePoint(center, layout),
+    rotation,
+  };
+}
+
+function overlapsHigherLayer(
+  candidate: TableCard,
+  cards: readonly TableCard[],
+  layout: CardBalanceLayout
+): boolean {
+  const footprint = createCardFootprint(candidate, layout);
+
+  return cards.some(
+    (card) =>
+      card.id !== candidate.id &&
+      card.zIndex > candidate.zIndex &&
+      footprintsOverlap(footprint, createCardFootprint(card, layout))
+  );
+}
+
+/**
+ * Resolves one released card. This intentionally does not mutate cards or
+ * cascade; the reducer layer can call it repeatedly for a bounded settle pass.
+ */
+export function resolvePrimaryCardDrop({
+  cards,
+  primaryCardId,
+  layout,
+  baseHeight = 0,
+  layerStep,
+  releaseVelocity = [0, 0],
+  supportMargin,
+}: {
+  cards: readonly TableCard[];
+  primaryCardId: string;
+  layout: CardBalanceLayout;
+} & ResolvePrimaryCardDropOptions): CardFallResolution | null {
+  const primaryCard = cards.find((card) => card.id === primaryCardId);
+
+  if (!primaryCard) {
+    return null;
+  }
+
+  const levels = getCardStackLevels({ cards, layout, baseHeight, layerStep });
+  const assessment = evaluateCardSupport({
+    cardId: primaryCardId,
+    layout,
+    levels,
+    supportMargin,
+  });
+
+  if (!assessment || assessment.stable) {
+    return assessment
+      ? {
+          assessment,
+          direction: null,
+          outcome: "stable",
+          willFlipFace: false,
+        }
+      : null;
+  }
+
+  const primaryLevel = levels.get(primaryCardId);
+  const centre = primaryLevel?.footprint.center ?? layout.toWorld(primaryCard.position);
+  const nearestDirection = assessment.nearestPoint
+    ? assessment.margin >= 0
+      ? [
+          assessment.nearestPoint[0] - centre[0],
+          assessment.nearestPoint[1] - centre[1],
+        ] satisfies BalancePoint
+      : [
+          centre[0] - assessment.nearestPoint[0],
+          centre[1] - assessment.nearestPoint[1],
+        ] satisfies BalancePoint
+    : releaseVelocity;
+  const escapeDirection = normalise(
+    nearestDirection
+  ) ?? getFallbackDirection(primaryCard.id);
+  const driftSign = stableHash(`${primaryCard.id}:${primaryCard.rotation}`) < 0.5 ? -1 : 1;
+  const shortEdge = Math.min(layout.cardWidth, layout.cardHeight);
+  const velocityMagnitude = Math.hypot(releaseVelocity[0], releaseVelocity[1]);
+  const rotationDrift =
+    driftSign *
+    clamp(
+      MIN_FALL_ROTATION + (velocityMagnitude / Math.max(shortEdge, EPSILON)) * 4,
+      MIN_FALL_ROTATION,
+      MAX_FALL_ROTATION
+    );
+  const nextRotation = primaryCard.rotation + rotationDrift;
+
+  for (const distanceScale of FALL_DISTANCES) {
+    for (const angleOffset of FALL_ANGLE_OFFSETS) {
+      const direction = rotate(escapeDirection, angleOffset);
+      const rawCandidate: [number, number] = [
+        centre[0] + direction[0] * shortEdge * distanceScale,
+        centre[1] + direction[1] * shortEdge * distanceScale,
+      ];
+      const candidateCenter = clampCardCenter(rawCandidate, nextRotation, layout);
+      const candidateCard = createCandidateCard(
+        primaryCard,
+        candidateCenter,
+        nextRotation,
+        layout
+      );
+
+      if (overlapsHigherLayer(candidateCard, cards, layout)) {
+        continue;
+      }
+
+      const candidateCards = cards.map((card) =>
+        card.id === primaryCardId ? candidateCard : card
+      );
+      const candidateLevels = getCardStackLevels({
+        cards: candidateCards,
+        layout,
+        baseHeight,
+        layerStep,
+      });
+      const candidateAssessment = evaluateCardSupport({
+        cardId: primaryCardId,
+        layout,
+        levels: candidateLevels,
+        supportMargin,
+      });
+
+      if (!candidateAssessment?.stable) {
+        continue;
+      }
+
+      const willFlipFace = shouldFlipAfterFall({
+        cardHeight: layout.cardHeight,
+        cardWidth: layout.cardWidth,
+        overhang: assessment.overhang,
+        releaseVelocity,
+      });
+
+      return {
+        assessment,
+        direction,
+        outcome: "fell",
+        patch: {
+          faceUp: willFlipFace ? !primaryCard.faceUp : primaryCard.faceUp,
+          position: candidateCard.position,
+          rotation: candidateCard.rotation,
+        },
+        willFlipFace,
+      };
+    }
+  }
+
+  return {
+    assessment,
+    direction: escapeDirection,
+    outcome: "unresolved",
+    willFlipFace: false,
+  };
+}


### PR DESCRIPTION
## Why

Every overlap currently counts as fully supported, so a card can balance on one corner without reacting. The table needs physical surprise without sacrificing deterministic undo, reload, deliberate spreads, or mobile performance.

## What changed

- Models each card's oriented contact patches and evaluates its centre of mass against the resulting support polygon.
- Resolves unstable edge landings into deterministic, bounded fall positions with an energy threshold for turning over.
- Reuses the same overlap geometry for visual stack heights and adds a focused physics validator.

Depends on #16.
